### PR TITLE
Magic vars

### DIFF
--- a/src/distribution/markov.coffee
+++ b/src/distribution/markov.coffee
@@ -45,6 +45,10 @@ module.exports = (FD) ->
   RANDOM = Math.random #new Multiverse.random "sjf20ru"
 
   {
+    ASSERT
+  } = FD.helpers
+
+  {
     domain_contains_value
   } = FD.Domain
 
@@ -70,7 +74,8 @@ module.exports = (FD) ->
         value = val_legend?[index]
         value ?= index # default legend is the indic
         if value and domain_contains_value domain, value
-          total += prob
+          ASSERT prob >= 0, 'addition below assumes values are positive or zero'
+          total += prob # TODO: confirm this keeps working when SUB becomes negative... probably have to normalize
           vector.push prob
           legend.push value
 

--- a/src/domain.coffee
+++ b/src/domain.coffee
@@ -43,20 +43,20 @@ module.exports = (FD) ->
 
   domain_range_index_of = (domain, value) ->
     ASSERT_DOMAIN domain
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       if value >= lo and value <= domain[index+1]
         return index
     return NOT_FOUND
 
   domain_is_value = (domain, value) ->
     ASSERT_DOMAIN domain
-    if domain.length isnt 2
+    if domain.length isnt PAIR_SIZE
       return false
     return domain[LO_BOUND] is value and domain[HI_BOUND] is value
 
   domain_get_value = (domain) ->
     ASSERT_DOMAIN domain
-    if domain.length isnt 2
+    if domain.length isnt PAIR_SIZE
       return NOT_FOUND
     [lo, hi] = domain
     if domain[LO_BOUND] is domain[HI_BOUND]
@@ -93,7 +93,7 @@ module.exports = (FD) ->
   domain_to_list = (domain) ->
     ASSERT_DOMAIN domain
     list = []
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       # note: the translation for `list.push.apply list, [0..domain[index+1]]` would do double the work
       for val in [lo..domain[index+1]]
         list.push val
@@ -144,7 +144,7 @@ module.exports = (FD) ->
     else
       result = []
 
-    for index in [range_index...domain.length] by 2
+    for index in [range_index...domain.length] by PAIR_SIZE
       lo = domain[index]
       hi = domain[index+1]
       if index isnt range_index
@@ -187,7 +187,7 @@ module.exports = (FD) ->
 
     end = SUB
     result = []
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       ASSERT !end or end < lo, 'domain is supposed to be csis, so ranges dont overlap nor touch'
       if lo > SUB # prevent [SUB,SUB] if first range starts at SUB; that'd be bad
         result.push end, lo - 1
@@ -234,14 +234,14 @@ module.exports = (FD) ->
   domain_sort_by_range = (domain) ->
     len = domain.length
     if len >= 4
-      quick_sort_inline domain, 0, domain.length-2
+      quick_sort_inline domain, 0, domain.length-PAIR_SIZE
     return
 
   quick_sort_inline = (domain, first, last) ->
     if first < last
       pivot = partition domain, first, last
-      quick_sort_inline domain, first, pivot-2
-      quick_sort_inline domain, pivot+2, last
+      quick_sort_inline domain, first, pivot-PAIR_SIZE
+      quick_sort_inline domain, pivot+PAIR_SIZE, last
     return
 
   partition = (domain, first, last) ->
@@ -250,11 +250,11 @@ module.exports = (FD) ->
     pivot_r = domain[pivot_index+1]
 
     index = first
-    for i in [first...last] by 2
+    for i in [first...last] by PAIR_SIZE
       L = domain[i]
       if L < pivot or (L is pivot and domain[i+1] < pivot_r)
         swap_range_inline domain, index, i
-        index += 2
+        index += PAIR_SIZE
     swap_range_inline domain, index, last
     return index
 
@@ -271,13 +271,13 @@ module.exports = (FD) ->
   # Check if given domain is in simplified, CSIS form
 
   is_simplified = (domain) ->
-    if domain.length <= 2
-      if domain.length is 2
+    if domain.length <= PAIR_SIZE
+      if domain.length is PAIR_SIZE
         ASSERT domain[FIRST_RANGE_LO] >= SUB, 'domains should not be sparse [0]'
         ASSERT domain[FIRST_RANGE_HI] >= SUB, 'domains should not be sparse [1]'
       return true
     phi = SUB
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       hi = domain[index+1]
       ASSERT lo >= SUB, 'domains should not be sparse [lo]'
       ASSERT hi >= SUB, 'domains should not be sparse [hi]'
@@ -295,7 +295,7 @@ module.exports = (FD) ->
     # assumes all ranges are "sound" (lo<=hi)
     prev_hi = SUB
     write_index = 0
-    for lo, read_index in domain by 2
+    for lo, read_index in domain by PAIR_SIZE
       hi = domain[read_index+1]
       ASSERT lo <= hi, 'ranges should be ascending'
 
@@ -311,7 +311,7 @@ module.exports = (FD) ->
         domain[write_index] = lo
         domain[write_index+1] = hi
         prev_hi_index = write_index + 1
-        write_index += 2
+        write_index += PAIR_SIZE
         prev_hi = hi
     domain.length = write_index # if `domain` was a larger at the start this ensures extra elements are dropped from it
     for test in domain
@@ -341,27 +341,27 @@ module.exports = (FD) ->
     len1 = dom1.length
     len2 = dom2.length
 
-    ASSERT len1 % 2 is 0, 'domains should have an even len'
-    ASSERT len2 % 2 is 0, 'domains should have an even len'
+    ASSERT len1 % PAIR_SIZE is 0, 'domains should have an even len'
+    ASSERT len2 % PAIR_SIZE is 0, 'domains should have an even len'
 
     if len1 is 0 or len2 is 0
       return
 
-    if len1 is 2
-      if len2 is 2
+    if len1 is PAIR_SIZE
+      if len2 is PAIR_SIZE
         intersect_range_bound dom1[LO_BOUND], dom1[HI_BOUND], dom2[LO_BOUND], dom2[HI_BOUND], result
       else
         _domain_intersection dom2, dom1, result
-    else if len2 == 2
+    else if len2 == PAIR_SIZE
       domain_intersect_bounds_into dom1, dom2[LO_BOUND], dom2[HI_BOUND], result
     else
       # Worst case. Both lengths are > 1. Divide and conquer.
       # Note: since the array contains pairs, make sure i and j are even.
       # but since they can only contain pairs, they must be even
-      i = ((len1/2) >> 1) *2
-      j = ((len2/2) >> 1) *2
-      ASSERT i%2 is 0, 'i should be even '+i
-      ASSERT j%2 is 0, 'j should be even '+j
+      i = ((len1/PAIR_SIZE) >> 1) *PAIR_SIZE
+      j = ((len2/PAIR_SIZE) >> 1) *PAIR_SIZE
+      ASSERT i%PAIR_SIZE is 0, 'i should be even '+i
+      ASSERT j%PAIR_SIZE is 0, 'j should be even '+j
       # TODO: get rid of this slicing, use index ranges instead
       d1 = dom1.slice(0, i)
       d2 = dom1.slice(i)
@@ -381,7 +381,7 @@ module.exports = (FD) ->
     return result
 
   domain_intersect_bounds_into = (domain, lo, hi, result) ->
-    for lo2, index in domain by 2
+    for lo2, index in domain by PAIR_SIZE
       hi2 = domain[index+1]
       if lo2 <= hi and hi2 >= lo
         result.push MAX(lo, lo2), MIN(hi, hi2)
@@ -417,7 +417,7 @@ module.exports = (FD) ->
       return domain
 
     result = []
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       hi = domain[index+1]
       if index is 0
         result.push lo, hi
@@ -433,7 +433,7 @@ module.exports = (FD) ->
 
   dom_smallest_interval_width = (domain) ->
     min_width = SUP
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       hi = domain[index+1]
       width = 1 + hi - lo
       if width < min_width
@@ -442,7 +442,7 @@ module.exports = (FD) ->
 
   dom_largest_interval_width = (domain) ->
     max_width = SUP
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       hi = domain[index+1]
       width = 1 + hi - lo
       if width > max_width
@@ -494,10 +494,10 @@ module.exports = (FD) ->
     [domain1, domain2] = dom_close_gaps2 domain1, domain2
 
     result = []
-    for loi, index in domain1 by 2
+    for loi, index in domain1 by PAIR_SIZE
       hii = domain1[index+1]
 
-      for loj, index2 in domain2 by 2
+      for loj, index2 in domain2 by PAIR_SIZE
         hij = domain2[index2 + 1]
 
         result.push MIN(SUP, loi + loj), MIN(SUP, hii + hij)
@@ -511,10 +511,10 @@ module.exports = (FD) ->
     ASSERT_DOMAIN domain2
 
     result = []
-    for loi, index in domain1 by 2
+    for loi, index in domain1 by PAIR_SIZE
       hii = domain1[index+1]
 
-      for loj, index2 in domain2 by 2
+      for loj, index2 in domain2 by PAIR_SIZE
         hij = domain2[index2 + 1]
 
         result.push MIN(SUP, loi * loj), MIN(SUP, hii * hij)
@@ -531,10 +531,10 @@ module.exports = (FD) ->
     [domain1, domain2] = dom_close_gaps2 domain1, domain2
 
     result = []
-    for loi, index in domain1 by 2
+    for loi, index in domain1 by PAIR_SIZE
       hii = domain1[index+1]
 
-      for loj, index2 in domain2 by 2
+      for loj, index2 in domain2 by PAIR_SIZE
         hij = domain2[index2 + 1]
 
         lo = loi - hij
@@ -551,10 +551,10 @@ module.exports = (FD) ->
     ASSERT_DOMAIN domain2
 
     result = []
-    for loi, index in domain1 by 2
+    for loi, index in domain1 by PAIR_SIZE
       hii = domain1[index+1]
 
-      for loj, index2 in domain2 by 2
+      for loj, index2 in domain2 by PAIR_SIZE
         hij = domain2[index2 + 1]
 
         ASSERT hij > SUB, 'expecting no empty or inverted ranges'
@@ -570,7 +570,7 @@ module.exports = (FD) ->
   domain_size = (domain) ->
     ASSERT_DOMAIN domain
     count = 0
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       count += 1 + domain[index+1] - lo # TODO: add test to confirm this still works fine if SUB is negative
     return count
 
@@ -581,7 +581,7 @@ module.exports = (FD) ->
     size = domain_size domain
     target_value = FLOOR size / 2
 
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       hi = domain[index+1]
 
       count =  1 + hi - lo
@@ -610,14 +610,14 @@ module.exports = (FD) ->
     ASSERT_DOMAIN domain, 'should be sound domain'
     domain[LO_BOUND] = lo
     domain[HI_BOUND] = hi
-    domain.length = 2
+    domain.length = PAIR_SIZE
     return
 
   # A domain is "solved" if it covers exactly one value. It is not solved if it is empty.
 
   domain_is_solved = (domain) ->
     ASSERT_DOMAIN domain
-    return domain.length is 2 and domain_first_range_is_determined domain
+    return domain.length is PAIR_SIZE and domain_first_range_is_determined domain
 
   # A domain is "determined" if it's either one value (solved) or none at all (rejected)
 
@@ -626,7 +626,7 @@ module.exports = (FD) ->
     len = domain.length
     if len is 0
       return true
-    return len is 2 and domain_first_range_is_determined domain
+    return len is PAIR_SIZE and domain_first_range_is_determined domain
 
   # A domain is "rejected" if it covers no values. This means every given
   # value would break at least one constraint so none could be used.
@@ -648,20 +648,20 @@ module.exports = (FD) ->
     ASSERT_DOMAIN domain, 'needs to be csis for this trick to work'
 
     len = domain.length
-    i = len - 2
+    i = len - PAIR_SIZE
     while i >= 0 and domain[i] >= value
-      i -= 2
+      i -= PAIR_SIZE
 
     if i < 0
       domain.length = 0
       return len isnt 0
 
-    domain.length = i+2
+    domain.length = i+PAIR_SIZE
     if domain[i+1] >= value
       domain[i+1] = value-1 # we already know domain[i] < value so value-1 >= SUB
       return true
 
-    return len isnt i+2
+    return len isnt i+PAIR_SIZE
 
   # Remove any value from domain that is lesser than or equal to given value.
   # Since domains are assumed to be in CSIS form, we can start from the front and
@@ -675,7 +675,7 @@ module.exports = (FD) ->
     len = domain.length
     i = 0
     while i < len and domain[i+1] <= value
-      i += 2
+      i += PAIR_SIZE
 
     if i >= len
       domain.length = 0

--- a/src/domain.coffee
+++ b/src/domain.coffee
@@ -3,6 +3,7 @@ module.exports = (FD) ->
   {
     SUP
     NO_SUCH_VALUE
+    ZERO_CHANGES
 
     ASSERT
     ASSERT_DOMAIN
@@ -461,7 +462,7 @@ module.exports = (FD) ->
     ASSERT_DOMAIN dom1
     ASSERT_DOMAIN dom2
     loop
-      change = 0
+      change = ZERO_CHANGES
 
       domain = domain_close_gaps_fresh dom1, dom_smallest_interval_width dom2
       change += dom1.length - domain.length
@@ -471,7 +472,7 @@ module.exports = (FD) ->
       change += dom2.length - domain.length
       dom2 = domain
 
-      unless change > 0
+      if change is ZERO_CHANGES
         break
 
     return [

--- a/src/domain.coffee
+++ b/src/domain.coffee
@@ -19,8 +19,11 @@ module.exports = (FD) ->
   # ascending and no ranges overlap. We call this "simplified"
 
   FIRST_RANGE = 0
+  FIRST_RANGE_LO = 0
+  FIRST_RANGE_HI = 1
   LO_BOUND = 0
   HI_BOUND = 1
+  PAIR_SIZE = 2
 
   NOT_FOUND = -1
 
@@ -33,7 +36,7 @@ module.exports = (FD) ->
 
   domain_contains_value = (domain, value) ->
     ASSERT_DOMAIN domain
-    return (domain_range_index_of domain, value) >= 0
+    return (domain_range_index_of domain, value) isnt NOT_FOUND
 
   # return the range index in given domain that covers given
   # value, or if the domain does not cover it at all
@@ -270,8 +273,8 @@ module.exports = (FD) ->
   is_simplified = (domain) ->
     if domain.length <= 2
       if domain.length is 2
-        ASSERT domain[0] >= SUB, 'domains should not be sparse [0]'
-        ASSERT domain[1] >= SUB, 'domains should not be sparse [1]'
+        ASSERT domain[FIRST_RANGE_LO] >= SUB, 'domains should not be sparse [0]'
+        ASSERT domain[FIRST_RANGE_HI] >= SUB, 'domains should not be sparse [1]'
       return true
     phi = SUB
     for lo, index in domain by 2
@@ -686,8 +689,8 @@ module.exports = (FD) ->
     domain.length = n
 
     # note: first range should be lt or lte to value now since we moved everything
-    if domain[0] <= value
-      domain[0] = value+1
+    if domain[FIRST_RANGE_LO] <= value
+      domain[FIRST_RANGE_LO] = value+1
       return true
 
     return len isnt n

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -12,6 +12,7 @@ module.exports = (FD) ->
   NO_SUCH_VALUE = SUB-1 # make sure NO_SUCH_VALUE is not a value that may be valid in a domain
   DISABLED = true # slows down considerably when enabled, but ensures domains are proper only then
   DISABLE_DOMAIN_CHECK = true # also causes unrelated errors because mocha sees the expandos
+  PAIR_SIZE = 2
 
   # For unit tests
   # Should be removed in production. Obviously.
@@ -33,9 +34,9 @@ module.exports = (FD) ->
     if DISABLED
       return
     ASSERT !!domain, 'domains should be an array', domain
-    ASSERT domain.length % 2 is 0, 'domains should contain pairs so len should be even', domain
+    ASSERT domain.length % PAIR_SIZE is 0, 'domains should contain pairs so len should be even', domain
     phi = SUB-2 # this means that the lowest `lo` can be, is SUB, csis requires at least one value gap
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       hi = domain[index+1]
       ASSERT lo >= SUB, 'lo should be gte to SUB '+' ['+lo+']', domain
       ASSERT hi >= SUB, 'hi should be gte to SUB '+' ['+hi+']', domain

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -3,6 +3,7 @@
 module.exports = (FD) ->
 
   SUP = 100000000
+  ZERO_CHANGES = 0
   REJECTED = -1
   NOT_FOUND = -1
   # different from NOT_FOUND in that NOT_FOUND must be -1 because of the indexOf api
@@ -72,6 +73,7 @@ module.exports = (FD) ->
     SUP
     NOT_FOUND
     NO_SUCH_VALUE
+    ZERO_CHANGES
 
     ASSERT
     ASSERT_DOMAIN

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -2,6 +2,7 @@
 
 module.exports = (FD) ->
 
+  SUB = 0 # WARNING: adjusting SUB to something negative means adjusting all tests. probably required for any change actually.
   SUP = 100000000
   ZERO_CHANGES = 0
   REJECTED = -1
@@ -33,12 +34,12 @@ module.exports = (FD) ->
       return
     ASSERT !!domain, 'domains should be an array', domain
     ASSERT domain.length % 2 is 0, 'domains should contain pairs so len should be even', domain
-    phi = -2 # this means the lowest `lo` can be is 0, csis requires at least one value gap
+    phi = SUB-2 # this means that the lowest `lo` can be, is SUB, csis requires at least one value gap
     for lo, index in domain by 2
       hi = domain[index+1]
-      ASSERT lo >= 0, 'lo should be a positive number'+' ['+lo+']', domain
-      ASSERT hi >= 0, 'hi should be a positive number'+' ['+hi+']', domain
-      ASSERT hi <= SUP, 'hi should be max SUP'+' ['+hi+']', domain
+      ASSERT lo >= SUB, 'lo should be gte to SUB '+' ['+lo+']', domain
+      ASSERT hi >= SUB, 'hi should be gte to SUB '+' ['+hi+']', domain
+      ASSERT hi <= SUP, 'hi should be lte to SUP'+' ['+hi+']', domain
       ASSERT lo <= hi, 'pairs should be lo<=hi'+' '+lo+' <= '+hi, domain
       ASSERT lo > phi+1, 'domains should be in csis form internally, end point apis should normalize input to this'+domain, domain
       phi = hi
@@ -70,6 +71,7 @@ module.exports = (FD) ->
 
   FD.helpers = {
     REJECTED
+    SUB
     SUP
     NOT_FOUND
     NO_SUCH_VALUE

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -9,7 +9,7 @@ module.exports = (FD) ->
   NOT_FOUND = -1
   # different from NOT_FOUND in that NOT_FOUND must be -1 because of the indexOf api
   # while NO_SUCH_VALUE must be a value that cannot be a legal domain value (<SUB or >SUP)
-  NO_SUCH_VALUE = -1
+  NO_SUCH_VALUE = SUB-1 # make sure NO_SUCH_VALUE is not a value that may be valid in a domain
   DISABLED = true # slows down considerably when enabled, but ensures domains are proper only then
   DISABLE_DOMAIN_CHECK = true # also causes unrelated errors because mocha sees the expandos
 

--- a/src/path_solver.coffee
+++ b/src/path_solver.coffee
@@ -12,6 +12,7 @@
 {mergePathMeta} = require './merge'
 
 MAX = Math.max
+PAIR_SIZE = 2
 
 module.exports = (FD) ->
 
@@ -181,7 +182,7 @@ module.exports = (FD) ->
       for v in vars
         domain = v.domain
         if domain
-          for index in [0...domain.length] by 2
+          for index in [0...domain.length] by PAIR_SIZE
             hi = domain[index+1]
             maxDomain = MAX hi, maxDomain
       if maxDomain is -99

--- a/src/propagators/callback.coffee
+++ b/src/propagators/callback.coffee
@@ -1,6 +1,7 @@
 module.exports = (FD) ->
   {
     REJECTED
+    ZERO_CHANGES
   } = FD.helpers
 
   {
@@ -16,7 +17,7 @@ module.exports = (FD) ->
     # (slice at 1 because first element is from_space)
     vars = propagator.propdata.slice 1
     if func vars, propagator.from_space
-      return 0 # "no change but keep searching"
+      return ZERO_CHANGES
     return REJECTED
 
   propagator_create_callback = (space, var_names, callback) ->

--- a/src/propagators/eq.coffee
+++ b/src/propagators/eq.coffee
@@ -1,6 +1,7 @@
 module.exports = (FD) ->
   {
     REJECTED
+    ZERO_CHANGES
   } = FD.helpers
 
   {
@@ -30,12 +31,12 @@ module.exports = (FD) ->
 
     begin_upid = v1.vupid + v2.vupid
     if begin_upid <= @last_upid
-      return 0
+      return ZERO_CHANGES
 
     dom1 = v1.dom
     dom2 = v2.dom
     if domain_equal dom1, dom2
-      return 0
+      return ZERO_CHANGES
 
     new_domain = domain_intersection dom1, dom2
     unless new_domain.length

--- a/src/propagators/lt.coffee
+++ b/src/propagators/lt.coffee
@@ -1,6 +1,7 @@
 module.exports = (FD) ->
   {
     REJECTED
+    ZERO_CHANGES
 
     ASSERT_DOMAIN
   } = FD.helpers
@@ -27,7 +28,7 @@ module.exports = (FD) ->
     last_upid = @last_upid
     begin_upid = v1.vupid + v2.vupid
     if begin_upid <= last_upid # or @solved
-      return 0
+      return ZERO_CHANGES
 
     unless v1.dom.length and v2.dom.length
       return REJECTED
@@ -41,7 +42,7 @@ module.exports = (FD) ->
       # Condition already satisfied. No changes necessary.
       @last_upid = begin_upid
       @solved = true
-      return 0
+      return ZERO_CHANGES
 
     ASSERT_DOMAIN v1.dom, 'v1 needs to be csis for this trick to work'
     ASSERT_DOMAIN v2.dom, 'v2 needs to be csis for this trick to work'

--- a/src/propagators/lte.coffee
+++ b/src/propagators/lte.coffee
@@ -1,6 +1,7 @@
 module.exports = (FD) ->
   {
     REJECTED
+    ZERO_CHANGES
 
     ASSERT_DOMAIN
   } = FD.helpers
@@ -27,7 +28,7 @@ module.exports = (FD) ->
     last_upid = @last_upid
     begin_upid = v1.vupid + v2.vupid
     if begin_upid <= last_upid # or @solved
-      return 0
+      return ZERO_CHANGES
 
     unless v1.dom.length and v2.dom.length
       return REJECTED
@@ -41,7 +42,7 @@ module.exports = (FD) ->
       # Condition already satisfied. No changes necessary.
       @last_upid = begin_upid
       @solved = true
-      return 0
+      return ZERO_CHANGES
 
     ASSERT_DOMAIN v1.dom, 'v1 needs to be csis for this trick to work'
     ASSERT_DOMAIN v2.dom, 'v2 needs to be csis for this trick to work'

--- a/src/propagators/neq.coffee
+++ b/src/propagators/neq.coffee
@@ -1,6 +1,7 @@
 module.exports = (FD) ->
   {
     REJECTED
+    ZERO_CHANGES
 
     ASSERT
   } = FD.helpers
@@ -25,7 +26,7 @@ module.exports = (FD) ->
 
     begin_upid = v1.vupid + v2.vupid
     if begin_upid <= @last_upid # or @solved
-      return 0
+      return ZERO_CHANGES
 
     unless v1.dom.length and v2.dom.length
       return REJECTED

--- a/src/propagators/reified.coffee
+++ b/src/propagators/reified.coffee
@@ -1,6 +1,7 @@
 module.exports = (FD) ->
   {
     REJECTED
+    ZERO_CHANGES
   } = FD.helpers
 
   {
@@ -59,7 +60,7 @@ module.exports = (FD) ->
       current_upid = v1.vupid + v2.vupid + bool_var.vupid
       last_upid = @last_upid
       if current_upid <= last_upid
-        return 0
+        return ZERO_CHANGES
 
       unless @pos_propagator
         # S is only needed to get the S.vars... which I think are static throughout a Space, so perhaps we can just re-use the deps instead?

--- a/src/propagators/scale_div.coffee
+++ b/src/propagators/scale_div.coffee
@@ -1,6 +1,7 @@
 module.exports = (FD) ->
   {
     REJECTED
+    ZERO_CHANGES
   } = FD.helpers
 
   {
@@ -23,7 +24,7 @@ module.exports = (FD) ->
 
     begin_upid = fdvar.vupid + prod.vupid
     if begin_upid <= @last_upid # or @solved
-      return 0
+      return ZERO_CHANGES
 
     domain = prod.dom
     unless domain.length

--- a/src/propagators/scale_div.coffee
+++ b/src/propagators/scale_div.coffee
@@ -17,6 +17,7 @@ module.exports = (FD) ->
   } = FD.Var
 
   FLOOR = Math.floor
+  PAIR_SIZE = 2
 
   scale_div_stepper = ->
     fdvar = @propdata[1]
@@ -32,7 +33,7 @@ module.exports = (FD) ->
 
     # We div only the interval bounds.
     dbyk = []
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       hi = domain[index+1]
       dbyk.push FLOOR(lo / factor), FLOOR(hi / factor) # TODO: factor doesnt exist. this should throw an error. unused?
 

--- a/src/propagators/scale_mul.coffee
+++ b/src/propagators/scale_mul.coffee
@@ -2,6 +2,7 @@ module.exports = (FD) ->
   {
     REJECTED
     SUP
+    ZERO_CHANGES
   } = FD.helpers
 
   {
@@ -24,7 +25,7 @@ module.exports = (FD) ->
 
     begin_upid = fdvar.vupid + prod.vupid
     if begin_upid <= @last_upid # or @solved
-      return 0
+      return ZERO_CHANGES
 
     domain = fdvar.dom
     unless domain.length

--- a/src/propagators/scale_mul.coffee
+++ b/src/propagators/scale_mul.coffee
@@ -18,6 +18,7 @@ module.exports = (FD) ->
   } = FD.Var
 
   MIN = Math.min
+  PAIR_SIZE = 2
 
   scale_mul_stepper = ->
     fdvar = @propdata[1]
@@ -33,7 +34,7 @@ module.exports = (FD) ->
 
     # We multiply only the interval bounds.
     kd = []
-    for lo, index in domain by 2
+    for lo, index in domain by PAIR_SIZE
       hi = domain[index+1]
       # TODO: this is untested, so unused? (no error if SUP is not imported)
       # TODO: factor isnt defined so this should throw an error

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -4,6 +4,7 @@ module.exports = (FD) ->
 
   {
     REJECTED
+    SUB
     SUP
   } = FD.helpers
 
@@ -263,7 +264,7 @@ module.exports = (FD) ->
   # instead. I'll keep the old name 'const' for compatibility.
 
   Space::konst = (val) ->
-    if val >= 0 and val <= SUP # also catches NaN cases
+    if val >= SUB and val <= SUP # also catches NaN cases
       return @temp domain_create_value val
     throw new Error 'FD.space.konst: Value out of valid range'
 
@@ -291,7 +292,7 @@ module.exports = (FD) ->
   # start with a lower case letter, a clash can certainly
   # be avoided if you stick to that rule.
   #
-  # If the domain is not specified, it is taken to be [0, SUP].
+  # If the domain is not specified, it is taken to be [SUB, SUP].
   #
   # Returns the space. All methods, unless otherwise noted,
   # will return the current space so that other methods


### PR DESCRIPTION
Replace some magic numbers with constants. They should be replaced by tooling when compiling a dist, but help legibility for dev.
