### PR TITLE
Spacing

### DIFF
--- a/src/distribution/value.coffee
+++ b/src/distribution/value.coffee
@@ -102,7 +102,12 @@ module.exports = (FD) ->
       legend
     } = options
 
-    root_space.memory.lastValueByVar ?= {}
+    # TOFIX: are we going to want to set/access lastValueByVar externally? otherwise drop the `memory` struct
+    unless root_space.memory
+      root_space.memory = {}
+    unless root_space.memory.lastValueByVar
+      root_space.memory.lastValueByVar = {}
+    lastValueByVar = root_space.memory.lastValueByVar
 
     # see Solver.addVar for setup...
 
@@ -120,12 +125,12 @@ module.exports = (FD) ->
           unless value?
             return # signifies end of search
           ASSERT domain_contains_value(fdvar.dom, value), 'markov picks the value from the existing domain' # the update below assumes this (skips constrain for this assumption)
-          space.memory.lastValueByVar[var_name] = value
+          lastValueByVar[var_name] = value
           # it is assumed that markov picks its value from the existing domain, so a direct update should be fine
           fdvar_set_value_inline fdvar, value
 
         when SECOND_CHOICE
-          new_domain = domain_remove_value fdvar.dom, space.memory.lastValueByVar[var_name]
+          new_domain = domain_remove_value fdvar.dom, lastValueByVar[var_name]
           unless new_domain and new_domain.length
             return # signifies end of search
           fdvar_set_domain fdvar, new_domain

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -164,28 +164,30 @@ module.exports = (FD) ->
 
     return result
 
-  Space::solutionFor = (ids, complete = false) -> # todo implement memorize flag
+  # @param {string[]} ids List of var names to query the solution for
+  # @param {boolean} [space=false] Return false if at least one var could not be solved?
 
+  Space::solutionFor = (ids, complete = false) -> # todo implement memorize flag
     result = {}
     for id in ids
 
       fdvar = @vars[id]
       value = undefined
       if fdvar?
-        d = fdvar.dom
-        if d.length is 0
+        domain = fdvar.dom
+        if domain.length is 0
           value = undefined
-        else if domain_is_solved d
-          value = domain_min d
+        else if domain_is_solved domain
+          value = domain_min domain
         else
-          value = d
+          value = domain
 
       if complete and !value?
         result = false
         break
+
       result[id] = value
     return result
-
 
   # Utility to easily print out the state of variables in the space.
 

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -217,7 +217,7 @@ module.exports = (FD) ->
   # to the full range (SUB-SUP).
 
   Space::decl_anon = (dom) ->
-    t = ++_temp_count
+    t = String(++_temp_count)
     @decl t, dom
     return t
 
@@ -235,7 +235,7 @@ module.exports = (FD) ->
   Space::decl_anons = (N, dom) ->
     result = []
     for [0...N]
-      result.push @decl_anon dom
+      result.push @decl_anon (dom and dom.slice 0)
     return result
 
   # Const/Konst is misleading because it serves no optimization.

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -202,29 +202,35 @@ module.exports = (FD) ->
     func @
     return @
 
-  # Returns a new unique name usable for a temporary fdvar
-  # for more complex calculations. Every call will yield
-  # a different name that is unique across all spaces.
-  #
-  # You can optionally specify a domain for the temporary
-  # if you already know something about it.
+  # @deprecated Use @anon instead
 
   Space::temp = (dom) ->
-    t = ++_temp_count
-    @decl t, dom
-    t
+    return @anon dom
 
-  # Create N temporary FD variables and return their names
-  # in an array.
+  # @deprecated Use @anons instead
 
   Space::temps = (N, dom) ->
-    i = undefined
+    return @anons N, dom
+
+  # Returns a new unique name usable for an anonymous fdvar.
+  # Returns the name of the new var, which will be a unique
+  # number. You can optionally specify a domain, defaults
+  # to the full range (SUB-SUP).
+
+  Space::decl_anon = (dom) ->
+    t = ++_temp_count
+    @decl t, dom
+    return t
+
+  # Create N anonymous FD variables and return their names
+  # in an array. Optionally set them to given dom for all
+  # of them, defaults to full range (SUB-SUP).
+
+  Space::anons = (N, dom) ->
     result = []
-    i = 0
-    while i < N
-      result.push @temp(dom)
-      ++i
-    result
+    for [0...N]
+      result.push @anon dom
+    return result
 
   # Create a "constant". We have no optimizing support for
   # constants at the moment and just treat it as a temp FDVar

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -148,47 +148,45 @@ module.exports = (FD) ->
     result = {}
     vars = @vars
     for var_name in @var_names
-      # Don't include the temporary variables in the "solution".
-      # Temporary variables take the form of a numeric property
-      # of the object, so we test for the var_name to be a number and
-      # don't include those variables in the result.
-
-      c = var_name[0]
-      if c < '0' or c > '9'
-        domain = vars[var_name].dom
-        if domain.length is 0
-          result[var_name] = false
-        else if domain_is_solved domain
-          result[var_name] = domain_min domain
-        else
-          result[var_name] = domain
-
+      getset_var_solve_state var_name, vars, result
     return result
 
-  # @param {string[]} ids List of var names to query the solution for
-  # @param {boolean} [space=false] Return false if at least one var could not be solved?
+  # @param {string[]} var_names List of var names to query the solution for
+  # @param {boolean} [complete=false] Return false if at least one var could not be solved?
 
-  Space::solutionFor = (ids, complete = false) -> # todo implement memorize flag
+  Space::solutionFor = (var_names, complete = false) -> # todo implement memorize flag
+    vars = @vars
     result = {}
-    for id in ids
+    for var_name in var_names
+      value = false
+      if vars[var_name]
+        value = getset_var_solve_state var_name, vars, result
 
-      fdvar = @vars[id]
-      value = undefined
-      if fdvar?
-        domain = fdvar.dom
-        if domain.length is 0
-          value = undefined
-        else if domain_is_solved domain
-          value = domain_min domain
-        else
-          value = domain
+      if complete and value is false
+        return false
 
-      if complete and !value?
-        result = false
-        break
+      result[var_name] = value
 
-      result[id] = value
     return result
+
+  getset_var_solve_state = (var_name, vars, result) ->
+    value = undefined
+    # Don't include the temporary variables in the "solution".
+    # Temporary variables take the form of a numeric property
+    # of the object, so we test for the var_name to be a number and
+    # don't include those variables in the result.
+    c = var_name[0]
+    if c < '0' or c > '9'
+      domain = vars[var_name].dom
+      if domain.length is 0
+        value = false
+      else if domain_is_solved domain
+        value = domain_min domain
+      else
+        value = domain
+      result[var_name] = value
+
+    return value
 
   # Utility to easily print out the state of variables in the space.
   # TOFIX: we should move this elsewhere so that we can more easily find usages of it. this is too implicit.

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -6,6 +6,8 @@ module.exports = (FD) ->
     REJECTED
     SUB
     SUP
+
+    ASSERT_DOMAIN
   } = FD.helpers
 
   {
@@ -309,6 +311,8 @@ module.exports = (FD) ->
   # Note: if you want to register multiple names call Space#decls instead
 
   Space::decl = (name_or_names, dom) ->
+    if dom
+      ASSERT_DOMAIN dom
     # lets try to deprecate this path
     if name_or_names instanceof Object or name_or_names instanceof Array
       return @decls name_or_names, dom

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -190,17 +190,17 @@ module.exports = (FD) ->
     return result
 
   # Utility to easily print out the state of variables in the space.
+  # TOFIX: we should move this elsewhere so that we can more easily find usages of it. this is too implicit.
 
   Space::toString = ->
-    JSON.stringify @solution()
+    return JSON.stringify @solution()
 
-  # Injects the given proc into this space by calling
-  # the proc with a single argument which is the current space.
+  # Call given function with `this` as argument
+  # @deprecated (Silly construct... we should refactor call sites to eliminate usages)
 
-  Space::inject = (proc) ->
-    proc this
-    # duh!
-    this
+  Space::inject = (func) ->
+    func @
+    return @
 
   # Returns a new unique name usable for a temporary fdvar
   # for more complex calculations. Every call will yield

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -145,24 +145,24 @@ module.exports = (FD) ->
   # be already in a solved state for this to work.
 
   Space::solution = ->
-    vars = @vars
     result = {}
-    for key of vars
+    for var_name, fdvar of @vars
       # Don't include the temporary variables in the "solution".
       # Temporary variables take the form of a numeric property
-      # of the object, so we test for the key to be a number and
+      # of the object, so we test for the var_name to be a number and
       # don't include those variables in the result.
 
-      c = key[0]
+      c = var_name[0]
       if c < '0' or c > '9'
-        d = vars[key].dom
-        if d.length is 0
-          result[key] = false
-        else if domain_is_solved d
-          result[key] = domain_min d
+        domain = fdvar.dom
+        if domain.length is 0
+          result[var_name] = false
+        else if domain_is_solved domain
+          result[var_name] = domain_min domain
         else
-          result[key] = d
-    result
+          result[var_name] = domain
+
+    return result
 
   Space::solutionFor = (ids, complete = false) -> # todo implement memorize flag
 

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -85,17 +85,7 @@ module.exports = (FD) ->
         unless propagator_is_solved p
           @_propagators.push propagator_create @, p.target_var_names, p.stepper, p._name
 
-      # TODO: Remove this reference. It might result in less
-      # memory being used during searches. If we keep around the
-      # parent space like this, then we have to maintain all
-      # spaces that we search in memory. For now, since I'm
-      # still debugging, this is all right.
-      @parent_space = parent_space
-
-    @succeeded_children = 0
-    @failed_children = 0
-    @stable_children = 0
-    this
+    return
 
   Space::clone = () ->
     space = new FD.space @
@@ -108,14 +98,6 @@ module.exports = (FD) ->
   # to the parent space from which it was cloned.
 
   Space::done = ->
-    if @parent_space
-      @parent_space.succeeded_children += @succeeded_children
-      @parent_space.failed_children += @failed_children
-      if @failed
-        @parent_space.failed_children++
-      if @succeeded_children == 0 and @failed_children > 0
-        @failed = true
-      @parent_space.stable_children += @stable_children
     return
 
   # A monotonically increasing class-global counter for unique temporary variable names.

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -315,27 +315,39 @@ module.exports = (FD) ->
 
     retval
 
+  # Register one or more variables with specific names
+  # Note: if you want to register multiple names call Space#decls instead
+
   Space::decl = (name_or_names, dom) ->
-    i = undefined
+    # lets try to deprecate this path
     if name_or_names instanceof Object or name_or_names instanceof Array
-      # Recursively declare all variables in the structure given.
-      for i of name_or_names
-        @decl name_or_names[i], dom.slice 0
-      return this
+      return @decls name_or_names, dom
+
     # A single variable is being declared.
-    name = name_or_names
-    fs = @vars
-    f = fs[name]
-    if f
+    var_name = name_or_names
+    vars = @vars
+
+    fdvar = vars[var_name]
+    if fdvar
       # If it already exists, change the domain if necessary.
       if dom
-        fdvar_set_domain f, dom
-      return this
+        fdvar_set_domain fdvar, dom
+      return @
+
     if dom
-      fs[name] = fdvar_create name, dom
+      vars[var_name] = fdvar_create var_name, dom
     else
-      fs[name] = fdvar_create_wide name
-    this
+      vars[var_name] = fdvar_create_wide var_name
+
+    return @
+
+  # Register multiple vars. If you supply a domain the domain will be cloned for each.
+
+  Space::decls = (names, dom) ->
+    # Recursively declare all variables in the structure given.
+    for key, value of names
+      @decl value, dom.slice 0
+    return @
 
   # Same function as var, but the domain is
   # that of a single number.

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -202,15 +202,15 @@ module.exports = (FD) ->
     func @
     return @
 
-  # @deprecated Use @anon instead
+  # @deprecated Use @decl_anon instead
 
   Space::temp = (dom) ->
-    return @anon dom
+    return @decl_anon dom
 
-  # @deprecated Use @anons instead
+  # @deprecated Use @decl_anons instead
 
   Space::temps = (N, dom) ->
-    return @anons N, dom
+    return @decl_anons N, dom
 
   # Returns a new unique name usable for an anonymous fdvar.
   # Returns the name of the new var, which will be a unique
@@ -222,11 +222,18 @@ module.exports = (FD) ->
     @decl t, dom
     return t
 
+  # Alias for @decl_anon [val, val]
+
+  Space::decl_value = (val) ->
+    if val >= SUB and val <= SUP # also catches NaN cases
+      return @decl_anon domain_create_value val
+    throw new Error 'FD.space.konst: Value out of valid range'
+
   # Create N anonymous FD variables and return their names
   # in an array. Optionally set them to given dom for all
   # of them, defaults to full range (SUB-SUP).
 
-  Space::anons = (N, dom) ->
+  Space::decl_anons = (N, dom) ->
     result = []
     for [0...N]
       result.push @anon dom
@@ -241,13 +248,17 @@ module.exports = (FD) ->
   # the closure compiler too. So I'm changing the name to 'konst'
   # instead. I'll keep the old name 'const' for compatibility.
 
+  # Const/Konst is misleading because it serves no optimization.
+  # @deprecated use @decl_value instead
+
   Space::konst = (val) ->
-    if val >= SUB and val <= SUP # also catches NaN cases
-      return @temp domain_create_value val
-    throw new Error 'FD.space.konst: Value out of valid range'
+    return @decl_value val
 
   # Keep old name for compatibility.
-  Space.prototype['const'] = Space::konst
+  # @deprecated use @decl_value instead
+
+  Space::const = (val) ->
+    return @decl_value val
 
   # Apply an operator func to var_left and var_right
   # Updates var_result to the intersection of the result and itself

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -56,7 +56,7 @@ module.exports = (FD) ->
   # Concept of a space that holds fdvars and propagators
 
   Space = FD.space = (get_value_distributor = throw_unless_overridden) ->
-    @_type = 'space'
+    @_class = 'space'
 
     # The FDVARS are all named and accessed by name.
     # When a space is cloned, the clone's fdvars objects

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -341,7 +341,7 @@ module.exports = (FD) ->
   Space::decls = (names, dom) ->
     # Recursively declare all variables in the structure given.
     for key, value of names
-      @decl value, dom.slice 0
+      @decl value, (dom and dom.slice 0)
     return @
 
   # Same function as @decl_value but with explicit name

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -224,6 +224,7 @@ module.exports = (FD) ->
     return t
 
   # Alias for @decl_anon [val, val]
+  # Note: use #num() to give it a name. TODO: combine these funcs to a single func with optional name arg...
 
   Space::decl_value = (val) ->
     if val >= SUB and val <= SUP # also catches NaN cases

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -349,11 +349,11 @@ module.exports = (FD) ->
       @decl value, dom.slice 0
     return @
 
-  # Same function as var, but the domain is
-  # that of a single number.
+  # Same function as @decl_value but with explicit name
 
   Space::num = (name, n) ->
-    @decl name, domain_create_value(n)
+    @decl name, domain_create_value n
+    return @
 
   # Adds propagators which reify the given operator application
   # to the given boolean variable.

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -135,9 +135,8 @@ module.exports = (FD) ->
   # that function.
 
   Space::is_solved = ->
-    vars = @vars
-    for i of vars # TODO: get rid of this "for-in" loop. it's slow.
-      unless fdvar_is_solved vars[i]
+    for var_name, fdvar of @vars # TODO: get rid of this "for-in" loop. it's slow.
+      unless fdvar_is_solved fdvar
         return false
     return true
 

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -417,21 +417,11 @@ module.exports = (FD) ->
     @_propagators.push propagator_create_callback @, var_names, callback
     return
 
-
   # Domain equality propagator. Creates the propagator
   # in this space. The specified variables need not
   # exist at the time the propagator is created and
   # added, since the fdvars are all referenced by name.
-  #
-  # A convention for propagators is that the return
-  # value of a propagator is number unless
-  # the propagator has failed, in which case it throws
-  # an exception 'fail'. The returned number indicates
-  # the number of domains that were changed by this propagation
-  # step.
-  #
-  # The second optional argument indicates what you want the
-  # propagator to do.
+  # TOFIX: deprecate the "functional" syntax for sake of simplicity. Was part of original lib. Silliness.
 
   Space::eq = (v1name, v2name) ->
     # If v2name is not specified, then we're operating in functional syntax

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -55,9 +55,6 @@ module.exports = (FD) ->
   # Duplicates the functionality of new Space(S) for readability.
   # Concept of a space that holds fdvars and propagators
 
-  # D4:
-  # - added memory object Spaces share, required for things like markov-style probabilistic value distribution
-
   Space = FD.space = (parent_space) ->
     @_type = 'space'
 
@@ -69,9 +66,6 @@ module.exports = (FD) ->
     @var_names = []
 
     @_propagators = []
-
-    # keep memory
-    @memory = parent_space and parent_space.memory or {}
 
     # copy the search strategy set from Distribution initially
     @get_value_distributor = parent_space and parent_space.get_value_distributor or throw_unless_overridden # overridden from distribution/distribute... for now.

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -94,11 +94,9 @@ module.exports = (FD) ->
     space.solver = @solver if @solver
     return space
 
-  # When done with the space, call this to send success results
-  # to the parent space from which it was cloned.
+  # @obsolete Keeping it for non-breaking-api sake
 
   Space::done = ->
-    return
 
   # A monotonically increasing class-global counter for unique temporary variable names.
   _temp_count = 1
@@ -111,9 +109,9 @@ module.exports = (FD) ->
     propagators = @_propagators
     while changed
       changed = false
-      for i in [0...propagators.length]
+      for propagator in propagators
         # step currently returns the nums of changes. but we will change that to 'change','nochange','fail' soon
-        n = propagators[i].stepper()
+        n = propagator.stepper()
         if n > 0
           changed = true
         else if n is REJECTED

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -84,3 +84,16 @@ describe "FD", ->
         s = new Space()
         s.solver = {}
         expect(s.clone().solver).to.equal s.solver
+
+    describe '#done()', ->
+
+      it 'should not do anything', ->
+
+        expect(new Space().done).not.to.throw
+
+      it 'should not modify the space', ->
+
+        space = new Space
+        clone = space.clone()
+        space.done()
+        expect(space).to.eql clone # since clone is a deep clone, we can do a deep eq check here

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -461,3 +461,21 @@ describe "FD", ->
         space = new Space()
         name = space.num 'foo', 100
         expect(space.vars.foo.dom).to.eql spec_d_create_value 100
+
+    # the propagator methods on Space are to be tested later, after I change them completely;
+    # reified
+    # callback
+    # eq
+    # lt
+    # gt
+    # lte
+    # gte
+    # neq
+    # distinct
+    # plus
+    # times
+    # scale
+    # times_plus
+    # sum
+    # product
+    # wsum

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -1,0 +1,86 @@
+if typeof require is 'function'
+  finitedomain = require '../../src/index'
+  chai = require 'chai'
+
+  {
+    spec_d_create_bool
+    spec_d_create_range
+    spec_d_create_ranges
+  } = require '../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe "FD", ->
+
+  it 'FD?', ->
+    expect(FD?).to.be.true
+
+  describe 'Space class', ->
+    {space:Space} = FD
+
+    it 'should exist', ->
+
+      expect(Space?).to.be.true
+
+    describe 'new Space', ->
+
+      it 'should create a new instance', ->
+
+        # I dont want to test for instanceof... but i dont think we can change that due to ext. api.
+        expect(new Space).to.be.a 'object'
+
+      it 'should set the value distributor to a thrower', ->
+
+        expect(-> new Space().get_value_distributor()).to.throw
+
+      it 'should set the value distributor to given function', ->
+
+        f = ->
+        expect(new Space(f).get_value_distributor).to.equal f
+
+      it 'should init vars and var_names', ->
+
+        expect(new Space().vars).to.be.an 'object'
+        expect(new Space().var_names).to.be.an 'array'
+
+    describe '#clone()', ->
+
+      space = new Space
+      clone = space.clone()
+
+      it 'should return a new space', ->
+
+        expect(clone).to.not.equal space
+
+      it 'should deep clone the space', ->
+
+        expect(clone).to.eql space
+
+      it 'should clone vars', ->
+
+        expect(space.vars).to.not.equal clone.vars
+
+      it 'should deep clone the vars', ->
+
+        for var_name in space.var_names
+          expect(clone.vars[var_name]).to.not.equal space.vars[var_name]
+          # note: the deep clone check is already done above, no need to repeat it
+
+      it 'should clone certain props', ->
+        expect(space.var_names).to.not.equal clone.var_names
+        expect(space.var_names.join()).to.equal clone.var_names.join()
+        expect(space._propagators).to.not.equal clone._propagators
+
+      it 'should copy the get value distributor', ->
+
+        expect(space.get_value_distributor).to.equal clone.get_value_distributor
+        g = ->
+        expect(new Space(g).clone().get_value_distributor).to.equal g
+
+      it 'should copy the solver', ->
+
+        expect(clone.solver).to.equal space.solver
+        s = new Space()
+        s.solver = {}
+        expect(s.clone().solver).to.equal s.solver

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -223,3 +223,22 @@ describe "FD", ->
         space.decl 'nope20', []
         space.decl 'yep30', spec_d_create_value 30
         expect(space.solutionFor ['yep10', 'yep30'], true).to.eql {yep10: 10, yep30: 30}
+
+    describe '#inject()', ->
+      # (this function is to be eliminated because it's super silly)
+
+      it 'should call its function with this', ->
+
+        x = false
+        new Space().inject -> x = true
+        expect(x).to.be.true
+
+      it 'should return its this', ->
+        space = new Space()
+        expect(space.inject ->).to.equal space
+
+      it 'should not modify its space', ->
+        space = new Space()
+        clone = space.clone()
+        space.inject ->
+        expect(space).to.eql clone

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -242,3 +242,114 @@ describe "FD", ->
         clone = space.clone()
         space.inject ->
         expect(space).to.eql clone
+
+    describe '#decl_anon()', ->
+
+      it 'should create a new var', ->
+
+        space = new Space()
+        expect(space.var_names.length, 'before decl').to.eql 0 # no vars... right? :)
+        space.decl_anon 22
+        expect(space.var_names.length, 'after decl').to.eql 1
+
+      it 'should return the name of a var', ->
+
+        space = new Space()
+        name = space.decl_anon 50
+        expect(space.var_names.indexOf(name) > -1).to.be.true
+
+      it 'should create a var with given domain', ->
+
+        space = new Space()
+        name = space.decl_anon spec_d_create_range 100, 200
+        expect(space.vars[name].dom).to.eql spec_d_create_range 100, 200
+
+      it 'should create a full range var if no domain is given', ->
+
+        space = new Space()
+        name = space.decl_anon()
+        expect(space.vars[name].dom).to.eql spec_d_create_range FD.helpers.SUB, FD.helpers.SUP
+
+    describe '#decl_anons()', ->
+
+      it 'should create multiple vars', ->
+
+        space = new Space()
+        expect(space.var_names.length, 'before decl').to.eql 0 # no vars... right? :)
+        space.decl_anons 22
+        expect(space.var_names.length, 'after decl').to.eql 22
+
+      it 'should return a list of names of the new vars', ->
+
+        space = new Space()
+        names = space.decl_anons 50
+        for name in names
+          expect(space.var_names.indexOf(name) > -1).to.be.true
+
+      it 'should set the domain to full if no domain is given', ->
+
+        full_range = spec_d_create_range FD.helpers.SUB, FD.helpers.SUP
+        space = new Space()
+        names = space.decl_anons 50
+        for name in names
+          expect(space.vars[name].dom).to.eql full_range
+
+      it 'should not use same reference for the new domains', ->
+
+        space = new Space()
+        names = space.decl_anons 5
+        for name1, i in names
+          for name2, j in names # yeah yeah you could start at `i`
+            if i isnt j
+              expect(space.vars[name1]).not.to.equal space.vars[name2]
+
+      it 'should set the domain to given domain', ->
+
+        domain = spec_d_create_range 10, 20
+        space = new Space()
+        names = space.decl_anons 5, domain
+        for name in names
+          expect(space.vars[name].dom).to.eql domain
+
+      it 'should init vars to a clone of the given domain', ->
+
+        domain = spec_d_create_range 10, 20
+        space = new Space()
+        names = space.decl_anons 5, domain
+        for name in names
+          expect(space.vars[name].dom).not.to.equal domain
+
+      it 'should not use same reference for the domains of new vars', ->
+
+        space = new Space()
+        names = space.decl_anons 5, spec_d_create_range 10, 20
+        for name1, i in names
+          for name2, j in names # yeah yeah you could start at `i`
+            if i isnt j
+              expect(space.vars[name1]).not.to.equal space.vars[name2]
+
+    describe '#decl_value()', ->
+
+      it 'should create a new var', ->
+
+        space = new Space()
+        expect(space.var_names.length, 'before decl').to.eql 0 # no vars... right? :)
+        space.decl_value 22
+        expect(space.var_names.length, 'after decl').to.eql 1
+
+      it 'should return the name of a var', ->
+
+        space = new Space()
+        name = space.decl_value 50
+        expect(space.var_names.indexOf(name) > -1).to.be.true
+
+      it 'should create a "solved" var with given value', ->
+
+        space = new Space()
+        name = space.decl_value 100
+        expect(space.vars[name].dom).to.eql spec_d_create_value 100
+
+      it 'should throw if value is OOB', ->
+
+        space = new Space()
+        expect(-> space.decl_value FD.helpers.SUB - 100).to.throw

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -97,3 +97,48 @@ describe "FD", ->
         clone = space.clone()
         space.done()
         expect(space).to.eql clone # since clone is a deep clone, we can do a deep eq check here
+
+    describe '#propagate()', ->
+
+      it 'should return true without any propagators', ->
+
+        expect(new Space().propagate()).to.be.true
+
+      it 'should return false if a prop rejects', ->
+
+        space = new Space
+        space._propagators.push { stepper: -> FD.helpers.REJECTED }
+        expect(space.propagate()).to.be.false
+
+      it 'should return true if no prop rejects', ->
+
+        space = new Space
+        space._propagators.push { stepper: -> FD.helpers.ZERO_CHANGES }, { stepper: -> FD.helpers.ZERO_CHANGES }
+        expect(space.propagate()).to.be.true
+
+    describe '#is_solved()', ->
+
+      it 'should return true if there are no vars', ->
+
+        expect(new Space().is_solved()).to.be.true
+
+      it 'should return true if all vars are solved', ->
+
+        space = new Space
+        space.decl_value 1
+        expect(space.is_solved(), 'only one solved var').to.be.true
+
+        space.decl_value 1
+        expect(space.is_solved(), 'two solved vars').to.be.true
+
+      it 'should return false if at least one var is not solved', ->
+
+        space = new Space
+        space.decl_anon spec_d_create_bool()
+        expect(space.is_solved(), 'only one unsolved var').to.be.false
+
+        space.decl_anon spec_d_create_bool()
+        expect(space.is_solved(), 'two unsolved vars').to.be.false
+
+        space.decl_value 1
+        expect(space.is_solved(), 'two unsolved vars and a solved var').to.be.false

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -172,17 +172,17 @@ describe "FD", ->
         space = new Space()
         space.decl 'single_range', spec_d_create_range 10, 20
         space.decl 'multi_range', spec_d_create_ranges [10, 20], [30, 40]
-        space.decl 'multi_range_with_solved', spec_d_create_ranges [10, 20], [15, 15], [30, 40]
+        space.decl 'multi_range_with_solved', spec_d_create_ranges [10, 20], [25, 25], [30, 40]
         expect(space.solution()).to.eql
           single_range: spec_d_create_range 10, 20
           multi_range: spec_d_create_ranges([10, 20], [30, 40])
-          multi_range_with_solved: spec_d_create_ranges([10, 20], [15, 15], [30, 40])
+          multi_range_with_solved: spec_d_create_ranges([10, 20], [25, 25], [30, 40])
 
       it 'should not add anonymous vars to the result', ->
 
         space = new Space()
         space.decl_value 15
-        space.decl 'addme', 20
+        space.decl 'addme', spec_d_create_value 20
         expect(space.solution()).to.eql {addme: 20}
 
     describe '#solutionFor()', ->
@@ -249,13 +249,13 @@ describe "FD", ->
 
         space = new Space()
         expect(space.var_names.length, 'before decl').to.eql 0 # no vars... right? :)
-        space.decl_anon 22
+        space.decl_anon spec_d_create_value 22
         expect(space.var_names.length, 'after decl').to.eql 1
 
       it 'should return the name of a var', ->
 
         space = new Space()
-        name = space.decl_anon 50
+        name = space.decl_anon spec_d_create_value 50
         expect(space.var_names.indexOf(name) > -1).to.be.true
 
       it 'should create a var with given domain', ->

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -353,3 +353,49 @@ describe "FD", ->
 
         space = new Space()
         expect(-> space.decl_value FD.helpers.SUB - 100).to.throw
+
+    describe '#decl()', ->
+
+      it 'should create a new var', ->
+
+        space = new Space()
+        space.decl 'foo', spec_d_create_value 100
+        expect(space.var_names).to.eql ['foo']
+        expect(space.vars.foo?).to.be.true
+
+      it 'should set var to domain', ->
+
+        space = new Space()
+        space.decl 'foo', spec_d_create_value 100
+        expect(space.vars.foo.dom).to.eql spec_d_create_value 100
+
+      it 'should set var to full domain if none given', ->
+
+        space = new Space()
+        space.decl 'foo'
+        expect(space.vars.foo.dom).to.eql spec_d_create_range FD.helpers.SUB, FD.helpers.SUP
+
+      it 'should just update domain if var already exists', ->
+        # this should throw an error instead. when would you _want_ to do this?
+
+        space = new Space()
+        space.decl 'foo', spec_d_create_value 100
+        expect(space.vars.foo.dom).to.eql spec_d_create_value 100
+        space.decl 'foo', spec_d_create_value 200
+        expect(space.vars.foo.dom).to.eql spec_d_create_value 200
+
+      it 'should ignore an update if no domain is given', ->
+        # this should throw an error instead. when would you _want_ to do this?
+
+        space = new Space()
+        space.decl 'foo', spec_d_create_value 100
+        expect(space.vars.foo.dom).to.eql spec_d_create_value 100
+        space.decl 'foo'
+        expect(space.vars.foo.dom).to.eql spec_d_create_value 100
+
+      it 'should return space', ->
+
+        space = new Space()
+        expect(space.decl 'foo', spec_d_create_value 100).to.equal space
+        # even if already exists
+        expect(space.decl 'foo', spec_d_create_value 200).to.equal space

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -399,3 +399,41 @@ describe "FD", ->
         expect(space.decl 'foo', spec_d_create_value 100).to.equal space
         # even if already exists
         expect(space.decl 'foo', spec_d_create_value 200).to.equal space
+
+    describe '#decls()', ->
+
+      it 'should create some new vars', ->
+
+        space = new Space()
+        names = ['foo', 'bar', 'baz']
+        space.decls names, spec_d_create_value 100
+        expect(space.var_names).to.eql names
+        for name in names
+          expect(space.vars.foo?).to.be.true
+
+      it 'should set to given domain', ->
+
+        space = new Space()
+        names = ['foo', 'bar', 'baz']
+        domain = spec_d_create_value 100
+        space.decls names, domain
+        expect(space.var_names).to.eql names
+        for name in names
+          expect(space.vars[name]?).to.be.true
+          expect(space.vars[name].dom, 'domain should be cloned').not.to.equal domain
+          expect(space.vars[name].dom).to.eql domain
+          for name2 in names
+            expect(space.vars[name].dom, 'domains should be cloned').not.to.equal space.vars[name2]
+
+      it 'should be set to full domain if none given', ->
+
+        space = new Space()
+        names = ['foo', 'bar', 'baz']
+        domain = spec_d_create_range FD.helpers.SUB, FD.helpers.SUP
+        space.decls names
+        expect(space.var_names).to.eql names
+        for name in names
+          expect(space.vars[name]?).to.be.true
+          expect(space.vars[name].dom).to.eql domain
+          for name2 in names
+            expect(space.vars[name].dom, 'domains should be cloned').not.to.equal space.vars[name2]

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -363,6 +363,11 @@ describe "FD", ->
         expect(space.var_names).to.eql ['foo']
         expect(space.vars.foo?).to.be.true
 
+      it 'should return the space', ->
+
+        space = new Space()
+        expect(space.decl 'foo', spec_d_create_value 100).to.eql space
+
       it 'should set var to domain', ->
 
         space = new Space()
@@ -437,3 +442,22 @@ describe "FD", ->
           expect(space.vars[name].dom).to.eql domain
           for name2 in names
             expect(space.vars[name].dom, 'domains should be cloned').not.to.equal space.vars[name2]
+
+    describe '#num()', ->
+
+      it 'should create a new var', ->
+
+        space = new Space()
+        space.num 'foo', 22
+        expect(space.var_names).to.eql ['foo']
+
+      it 'should return the space', ->
+
+        space = new Space()
+        expect(space.num 'foo', 100).to.eql space
+
+      it 'should create a "solved" var with given value', ->
+
+        space = new Space()
+        name = space.num 'foo', 100
+        expect(space.vars.foo.dom).to.eql spec_d_create_value 100


### PR DESCRIPTION
Refactor and test the Space class

refactor Space constructor  e480a09
remove the Space#parent_space link  d41ec97
Commits on Oct 16, 2015
slightly cleaner for form   fe5139f
get value in for-of cleaner 99f20e0
cleanup Space#solution  7c90a79
minor refactor of Space#solutionFor 1090797
small refactor, deprecate inject, move toString debug   3ccf740
deprecate @temp and @temps in favor of @anon and @anons, refactor them  d2517c8
move konst/const to decl_value, deprecated const/konst for sake of tr… …    0eadfac
Refactor Space#decl and add Space#decls for multi decls 7bef825
refactor Space#num a bit    c2e7584
whitespace changes  46f6c25
usages of @temp to @decl_anon, missing returns  3eaf225
get rid of `for-of`. Seems to cut search time in half. wowzah.   262abfa
Commits on Oct 19, 2015
tentatively remove `memory` from Space, except root to maintain api f… …    ba3da06
move cloning copy stuff to #clone   d4a1c7a
its class not type but whatever aa82e3a
Start upping test coverage for Space    75f3fed
add silly support for deprecated Space#done()   e7f7ccf
tests for #propagate and #is_solved 42eb572
Add tests for #solution and #solutionFor and refactor them  a4c4dd6
test #inject()  5b71e6d
make #decl_anons clone the domain, #decl to return a string, add test… …    0c9a3a1
Add tests for #decl()   a7c3e4d
oopsied some of the tests, thank you ASSERT_DOMAIN  5440b8b
minor bug in #decls(), add tests    c8d28cd
add tests for #num()    413aa1f
to be continued  4535b75
