### PR TITLE
Simplify lt propagator

### DIFF
--- a/src/propagators/lt.coffee
+++ b/src/propagators/lt.coffee
@@ -10,7 +10,6 @@ module.exports = (FD) ->
     fdvar_lower_bound
     fdvar_remove_gte_inline
     fdvar_remove_lte_inline
-    fdvar_set_domain
     fdvar_upper_bound
   } = FD.Var
 
@@ -40,6 +39,5 @@ module.exports = (FD) ->
 
     current_upid = fdvar1.vupid + fdvar2.vupid
     return current_upid - begin_upid
-
 
   FD.propagators.lt_step_bare = lt_step_bare

--- a/src/propagators/lt.coffee
+++ b/src/propagators/lt.coffee
@@ -12,6 +12,7 @@ module.exports = (FD) ->
   } = FD.Domain
 
   {
+    fdvar_is_rejected
     fdvar_lower_bound
     fdvar_set_domain
     fdvar_upper_bound
@@ -20,7 +21,7 @@ module.exports = (FD) ->
   lt_step_bare = (fdvar1, fdvar2) ->
     begin_upid = fdvar1.vupid + fdvar2.vupid
 
-    unless fdvar1.dom.length and fdvar2.dom.length
+    if fdvar_is_rejected(fdvar1) or fdvar_is_rejected(fdvar2)
       return REJECTED
 
     lo_1 = fdvar_lower_bound fdvar1

--- a/src/propagators/lt.coffee
+++ b/src/propagators/lt.coffee
@@ -1,7 +1,6 @@
 module.exports = (FD) ->
   {
     REJECTED
-    ZERO_CHANGES
 
     ASSERT_DOMAIN
   } = FD.helpers
@@ -21,17 +20,10 @@ module.exports = (FD) ->
   lt_step_bare = (fdvar1, fdvar2) ->
     begin_upid = fdvar1.vupid + fdvar2.vupid
 
-    if fdvar_is_rejected(fdvar1) or fdvar_is_rejected(fdvar2)
-      return REJECTED
-
     lo_1 = fdvar_lower_bound fdvar1
     hi_1 = fdvar_upper_bound fdvar1
     lo_2 = fdvar_lower_bound fdvar2
     hi_2 = fdvar_upper_bound fdvar2
-
-    if lo_2 > hi_1 # :'(
-      # Condition already satisfied. No changes necessary.
-      return ZERO_CHANGES
 
     ASSERT_DOMAIN fdvar1.dom, 'v1 needs to be csis for this trick to work'
     ASSERT_DOMAIN fdvar2.dom, 'v2 needs to be csis for this trick to work'
@@ -39,22 +31,23 @@ module.exports = (FD) ->
     # every number in v1 can only be smaller than or equal to the biggest
     # value in v2. bigger values will never satisfy lt so prune them.
     if hi_1 >= hi_2
-      # TODO: make this an inline operation to fdvar, once that's possible
       new_dom = fdvar1.dom.slice 0
       domain_remove_gte_inline new_dom, hi_2
-      if new_dom.length is 0
-        return REJECTED
       fdvar_set_domain fdvar1, new_dom
+      # TOFIX: change to inline:
+      #domain_remove_gte_inline fdvar1.dom, hi_2
 
     # likewise; numbers in v2 that are smaller than or equal to the
     # smallest value of v1 can never satisfy lt so prune them as well
     if lo_1 >= lo_2
-      # TODO: make this an inline operation to fdvar, once that's possible
       new_dom = fdvar2.dom.slice 0
       domain_remove_lte_inline new_dom, lo_1
-      if new_dom.length is 0
-        return REJECTED
       fdvar_set_domain fdvar2, new_dom
+      # TOFIX: change to inline:
+      #domain_remove_lte_inline fdvar2.dom, lo_1
+
+    if fdvar_is_rejected(fdvar1) or fdvar_is_rejected(fdvar2)
+      return REJECTED
 
     current_upid = fdvar1.vupid + fdvar2.vupid
     return current_upid - begin_upid

--- a/src/propagators/lt.coffee
+++ b/src/propagators/lt.coffee
@@ -6,13 +6,10 @@ module.exports = (FD) ->
   } = FD.helpers
 
   {
-    domain_remove_gte_inline
-    domain_remove_lte_inline
-  } = FD.Domain
-
-  {
     fdvar_is_rejected
     fdvar_lower_bound
+    fdvar_remove_gte_inline
+    fdvar_remove_lte_inline
     fdvar_set_domain
     fdvar_upper_bound
   } = FD.Var
@@ -31,20 +28,12 @@ module.exports = (FD) ->
     # every number in v1 can only be smaller than or equal to the biggest
     # value in v2. bigger values will never satisfy lt so prune them.
     if hi_1 >= hi_2
-      new_dom = fdvar1.dom.slice 0
-      domain_remove_gte_inline new_dom, hi_2
-      fdvar_set_domain fdvar1, new_dom
-      # TOFIX: change to inline:
-      #domain_remove_gte_inline fdvar1.dom, hi_2
+      fdvar_remove_gte_inline fdvar1, hi_2
 
     # likewise; numbers in v2 that are smaller than or equal to the
     # smallest value of v1 can never satisfy lt so prune them as well
     if lo_1 >= lo_2
-      new_dom = fdvar2.dom.slice 0
-      domain_remove_lte_inline new_dom, lo_1
-      fdvar_set_domain fdvar2, new_dom
-      # TOFIX: change to inline:
-      #domain_remove_lte_inline fdvar2.dom, lo_1
+      fdvar_remove_lte_inline fdvar2, lo_1
 
     if fdvar_is_rejected(fdvar1) or fdvar_is_rejected(fdvar2)
       return REJECTED

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -61,6 +61,10 @@ module.exports = (FD) ->
     # overridden from distribution/distribute... for now. and copied from parent space
     @get_value_distributor = get_value_distributor
 
+    # used from Search
+    @next_distribution_choice = 0
+    @current_value_distributor = undefined
+
     return
 
   Space::clone = () ->

--- a/src/var.coffee
+++ b/src/var.coffee
@@ -19,6 +19,8 @@ module.exports = (FD) ->
     domain_max
     domain_middle_element
     domain_min
+    domain_remove_gte_inline
+    domain_remove_lte_inline
     domain_set_to_range_inline
     domain_size
   } = FD.Domain
@@ -115,6 +117,16 @@ module.exports = (FD) ->
   fdvar_middle_element = (fdvar) ->
     return domain_middle_element fdvar.dom
 
+  fdvar_remove_gte_inline = (fdvar, value) ->
+    if domain_remove_gte_inline fdvar.dom, value
+      ++fdvar.vupid
+    return
+
+  fdvar_remove_lte_inline = (fdvar, value) ->
+    if domain_remove_lte_inline fdvar.dom, value
+      ++fdvar.vupid
+    return
+
   FD.Var = {
     fdvar_clone
     fdvar_constrain
@@ -129,6 +141,8 @@ module.exports = (FD) ->
     fdvar_upper_bound
     fdvar_middle_element
     fdvar_lower_bound
+    fdvar_remove_gte_inline
+    fdvar_remove_lte_inline
     fdvar_set_domain
     fdvar_set_range_inline
     fdvar_set_value_inline

--- a/src/var.coffee
+++ b/src/var.coffee
@@ -3,6 +3,7 @@ module.exports = (FD) ->
   {
     REJECTED
 
+    ASSERT
     ASSERT_UNUSED_DOMAIN
   } = FD.helpers
 
@@ -29,6 +30,8 @@ module.exports = (FD) ->
     return fdvar_new id, domain_create_all(), 0
 
   fdvar_new = (id, dom, vupid) ->
+    ASSERT !!dom, 'should init to a domain', [id, dom, vupid]
+    ASSERT vupid >= 0, 'should init var update id (vupid) to >=0', vupid
     ASSERT_UNUSED_DOMAIN dom
     return {
       _class: 'fdvar'

--- a/tests/fixtures/domain.spec.coffee
+++ b/tests/fixtures/domain.spec.coffee
@@ -1,25 +1,27 @@
 SUP = 100000
 
 spec_d_create_range = (lo, hi) ->
-  return [lo, hi]
+  return spec_d_create_ranges [lo, hi]
 spec_d_create_ranges = (ranges...) ->
   arr = []
   ranges.forEach (range) -> arr.push range[0], range[1]
+
+  # hack. makes sure the DOMAIN_CHECK test doesnt trigger a fail for adding that property...
   return arr
 spec_d_create_value = (value) ->
-  return [value, value]
+  return spec_d_create_ranges [value, value]
 spec_d_create_list = (list) ->
   arr = []
   list.forEach (value) -> arr.push value, value
   return arr
 spec_d_create_zero = ->
-  return [0, 0]
+  return spec_d_create_ranges [0, 0]
 spec_d_create_one = ->
-  return [1, 1]
+  return spec_d_create_ranges [1, 1]
 spec_d_create_full = ->
-  return [0, SUP]
+  return spec_d_create_ranges [0, SUP]
 spec_d_create_bool = ->
-  return [0, 1]
+  return spec_d_create_ranges [0, 1]
 
 module.exports = {
   spec_d_create_range

--- a/tests/spec/propagators/lt.spec.coffee
+++ b/tests/spec/propagators/lt.spec.coffee
@@ -1,0 +1,169 @@
+if typeof require is 'function'
+  finitedomain = require '../../../src/index'
+  chai = require 'chai'
+  {
+  spec_d_create_bool
+  spec_d_create_range
+  spec_d_create_ranges
+  spec_d_create_value
+  } = require '../../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe "FD - propagators - lt", ->
+  # in general after call, max(v1) should be < max(v2) and min(v2) should be > min(v1)
+  # it makes sure v1 and v2 have no values that can't possibly result in fulfilling <
+
+  {
+    REJECTED
+    ZERO_CHANGES
+  } = FD.helpers
+
+  {
+    fdvar_create
+    fdvar_create_wide
+  } = FD.Var
+
+  {
+    lt_step_bare
+  } = FD.propagators
+
+  it 'should exist', ->
+
+    expect(lt_step_bare?).to.be.true
+
+  it 'should require two vars', ->
+
+    expect(-> lt_step_bare()).to.throw
+    v = fdvar_create_wide 'x'
+    expect(-> lt_step_bare v).to.throw
+    expect(-> lt_step_bare undefined, v).to.throw
+
+  it 'should reject for empty domains', ->
+
+    v1 = fdvar_create 'x', []
+    v2 = fdvar_create 'y', []
+    expect(lt_step_bare v1, v2).to.eql REJECTED
+
+  it 'should reject for empty left domain', ->
+
+    v1 = fdvar_create 'x', []
+    v2 = fdvar_create_wide 'y'
+    expect(lt_step_bare v1, v2).to.eql REJECTED
+
+  it 'should reject for empty right domain', ->
+
+    v1 = fdvar_create_wide 'x'
+    v2 = fdvar_create 'y', []
+    expect(lt_step_bare v1, v2).to.eql REJECTED
+
+  it 'should not change if v1 already < v2', ->
+
+    v1 = fdvar_create 'x', spec_d_create_range 0, 10
+    v2 = fdvar_create 'y', spec_d_create_range 20, 30
+    expect(lt_step_bare v1, v2).to.eql ZERO_CHANGES
+
+    v1 = fdvar_create 'x', spec_d_create_range 0, 10
+    v2 = fdvar_create 'y', spec_d_create_range 11, 30
+    expect(lt_step_bare v1, v2).to.eql ZERO_CHANGES
+
+    v1 = fdvar_create 'x', spec_d_create_range 0, 0
+    v2 = fdvar_create 'y', spec_d_create_range 1, 1
+    expect(lt_step_bare v1, v2).to.eql ZERO_CHANGES
+
+    v1 = fdvar_create 'x', spec_d_create_range 0, 0
+    v2 = fdvar_create 'y', spec_d_create_range 1, 1
+    expect(lt_step_bare v1, v2).to.eql ZERO_CHANGES
+
+  describe 'when max(v1) >= max(v2)', ->
+
+    test = (lo1, hi1, lo2, hi2, result_lo, result_hi, result) ->
+      it 'should (only) trunc values from v1 ['+[lo1,hi1,lo2,hi2,result_lo,result_hi]+']', ->
+        v1 = fdvar_create 'x', spec_d_create_range lo1, hi1
+        v2 = fdvar_create 'y', spec_d_create_range lo2, hi2
+        r = lt_step_bare v1, v2
+        expect(v1.dom, 'v1 after').to.eql spec_d_create_range result_lo, result_hi
+        expect(v2.dom, 'v2 after').to.eql spec_d_create_range lo2, hi2
+        result? and expect(r).to.eql result
+
+    test 0,20, 5,15, 0,14
+    test 0,10, 5,15, 0,10, ZERO_CHANGES
+    test 10,10, 5,5, 10,10, REJECTED
+
+  describe 'when min(v1) >= min(v2)', ->
+
+    test = (lo1, hi1, lo2, hi2, result_lo, result_hi, result) ->
+      it 'should (only) trunc values from v2 ['+[lo1,hi1,lo2,hi2,result_lo,result_hi]+']', ->
+        v1 = fdvar_create 'x', spec_d_create_range lo1, hi1
+        v2 = fdvar_create 'y', spec_d_create_range lo2, hi2
+        r = lt_step_bare v1, v2
+        expect(v1.dom, 'v1 after').to.eql spec_d_create_range lo1, hi1
+        expect(v2.dom, 'v2 after').to.eql spec_d_create_range result_lo, result_hi
+        result? and expect(r).to.eql result
+
+    test 5,14, 0,15, 6,15
+    test 5,10, 7,15, 7,15, ZERO_CHANGES
+    test 10,10, 5,5, 5,5, REJECTED
+
+  describe 'when both min/max v1 >= min/max v2', ->
+
+    test = (lo1, hi1, lo2, hi2, result_lo1, result_hi1, result_lo2, result_hi2, result) ->
+      it 'should (only) trunc values from v2 ['+[lo1, hi1, lo2, hi2, result_lo1, result_hi1, result_lo2, result_hi2, result]+']', ->
+        v1 = fdvar_create 'x', spec_d_create_range lo1, hi1
+        v2 = fdvar_create 'y', spec_d_create_range lo2, hi2
+        r = lt_step_bare v1, v2
+        expect(v1.dom, 'v1 after').to.eql spec_d_create_range result_lo1, result_hi1
+        expect(v2.dom, 'v2 after').to.eql spec_d_create_range result_lo2, result_hi2
+        result? and expect(r).to.eql result
+
+    test 5,20, 0,10, 5,9, 6,10
+    test 5,20, 5,20, 5,19, 6,20
+
+  it 'should handle multiple ranges too', ->
+
+    v1 = fdvar_create 'x', spec_d_create_ranges [10, 20], [30, 40], [50, 60], [70, 150]
+    v2 = fdvar_create 'y', spec_d_create_range 0, 100
+    lt_step_bare v1, v2
+    expect(v1.dom, 'v1 after').to.eql spec_d_create_ranges [10, 20], [30, 40], [50, 60], [70, 99]
+    expect(v2.dom, 'v2 after').to.eql spec_d_create_range 11, 100
+
+  it 'should be able to drop last range in v1', ->
+
+    v1 = fdvar_create 'x', spec_d_create_ranges [10, 20], [30, 40], [50, 60], [70, 98], [120, 150]
+    v2 = fdvar_create 'y', spec_d_create_range 0, 100
+    lt_step_bare v1, v2
+    expect(v1.dom, 'v1 after').to.eql spec_d_create_ranges [10, 20], [30, 40], [50, 60], [70, 98]
+    expect(v2.dom, 'v2 after').to.eql spec_d_create_range 11, 100
+
+    v1 = fdvar_create 'x', spec_d_create_ranges [10, 20], [30, 40], [50, 60], [70, 98], [100, 150]
+    v2 = fdvar_create 'y', spec_d_create_range 0, 100
+    lt_step_bare v1, v2
+    expect(v1.dom, 'v1 after').to.eql spec_d_create_ranges [10, 20], [30, 40], [50, 60], [70, 98]
+    expect(v2.dom, 'v2 after').to.eql spec_d_create_range 11, 100
+
+    v1 = fdvar_create 'x', spec_d_create_ranges [10, 20], [30, 40], [50, 60], [70, 98], [100, 100] # last is single value
+    v2 = fdvar_create 'y', spec_d_create_range 0, 100
+    lt_step_bare v1, v2
+    expect(v1.dom, 'v1 after').to.eql spec_d_create_ranges [10, 20], [30, 40], [50, 60], [70, 98]
+    expect(v2.dom, 'v2 after').to.eql spec_d_create_range 11, 100
+
+  it 'should be able to drop first range in v1', ->
+
+    v1 = fdvar_create 'x', spec_d_create_ranges [10, 20], [30, 40], [50, 60]
+    v2 = fdvar_create 'y', spec_d_create_ranges [0, 10], [20, 100]
+    lt_step_bare v1, v2
+    expect(v1.dom, 'v1 after').to.eql spec_d_create_ranges [10, 20], [30, 40], [50, 60]
+    expect(v2.dom, 'v2 after').to.eql spec_d_create_ranges [20, 100]
+
+    v1 = fdvar_create 'x', spec_d_create_ranges [10, 20], [30, 40], [50, 60]
+    v2 = fdvar_create 'y', spec_d_create_ranges [0, 5], [20, 100]
+    lt_step_bare v1, v2
+    expect(v1.dom, 'v1 after').to.eql spec_d_create_ranges [10, 20], [30, 40], [50, 60]
+    expect(v2.dom, 'v2 after').to.eql spec_d_create_ranges [20, 100]
+
+    v1 = fdvar_create 'x', spec_d_create_ranges [10, 20], [30, 40], [50, 60]
+    v2 = fdvar_create 'y', spec_d_create_ranges [10, 10], [20, 100]  # first is single value
+    lt_step_bare v1, v2
+    expect(v1.dom, 'v1 after').to.eql spec_d_create_ranges [10, 20], [30, 40], [50, 60]
+    expect(v2.dom, 'v2 after').to.eql spec_d_create_ranges [20, 100]

--- a/tests/spec/propagators/lt.spec.coffee
+++ b/tests/spec/propagators/lt.spec.coffee
@@ -83,13 +83,22 @@ describe "FD - propagators - lt", ->
         v1 = fdvar_create 'x', spec_d_create_range lo1, hi1
         v2 = fdvar_create 'y', spec_d_create_range lo2, hi2
         r = lt_step_bare v1, v2
-        expect(v1.dom, 'v1 after').to.eql spec_d_create_range result_lo, result_hi
+        expect(v1.dom, 'v1 after').to.eql (result is REJECTED and []) or spec_d_create_range result_lo, result_hi
         expect(v2.dom, 'v2 after').to.eql spec_d_create_range lo2, hi2
         result? and expect(r).to.eql result
 
     test 0,20, 5,15, 0,14
     test 0,10, 5,15, 0,10, ZERO_CHANGES
-    test 10,10, 5,5, 10,10, REJECTED
+
+  it 'should reject when v1 and v2 are solved and v1>v2', ->
+
+    v1 = fdvar_create 'x', spec_d_create_range 10, 10
+    v2 = fdvar_create 'y', spec_d_create_range 5, 5
+    r = lt_step_bare v1, v2
+    # depending on implementation v1 and v2 may be cleared, one of them cleared, or not changed. but must reject regardless...
+    #expect(v1.dom, 'v1 after').to.eql []
+    #expect(v2.dom, 'v2 after').to.eql []
+    expect(r).to.eql REJECTED
 
   describe 'when min(v1) >= min(v2)', ->
 
@@ -99,12 +108,12 @@ describe "FD - propagators - lt", ->
         v2 = fdvar_create 'y', spec_d_create_range lo2, hi2
         r = lt_step_bare v1, v2
         expect(v1.dom, 'v1 after').to.eql spec_d_create_range lo1, hi1
-        expect(v2.dom, 'v2 after').to.eql spec_d_create_range result_lo, result_hi
+        expect(v2.dom, 'v2 after').to.eql (result is REJECTED and []) or spec_d_create_range result_lo, result_hi
         result? and expect(r).to.eql result
 
     test 5,14, 0,15, 6,15
     test 5,10, 7,15, 7,15, ZERO_CHANGES
-    test 10,10, 5,5, 5,5, REJECTED
+    #test 10,10, 5,5, 5,5, REJECTED # note: this is the same test as in v1>=v2 because v1 is checked first. so not possible here.
 
   describe 'when both min/max v1 >= min/max v2', ->
 

--- a/tests/spec/solver.spec.coffee
+++ b/tests/spec/solver.spec.coffee
@@ -322,6 +322,6 @@ describe "FD", ->
 
       solutions = S.solve()
 
-      expect(solutions.length).to.equal(1)
-      expect(solutions[0].item1).to.equal(1)
-      expect(solutions[0].item2).to.equal(2)
+      expect(solutions.length, 'solution count').to.equal(1)
+      expect(solutions[0].item1, 'item1').to.equal(1)
+      expect(solutions[0].item2, 'item2').to.equal(2)


### PR DESCRIPTION
lets step away from accessing dom.length directly   06d735c
add more assertions b029672
add propagators lt tests    72d75c8
add desc to each expect e28c529
ultimately make one function generate the domains so we can trap that… …    82d03e0
postpone rejected checks to reduce logic branches   0318682
add fdvar_remove_gte_inline and ..lte_inline which also increments vupid    083349e
make pruning operation inline   6348f41
add properties in constructor for improved object profiling 3ff3c8d
remove unused dep    06b64a4
