### PR TITLE
Eliminate vupid, for now

### DIFF
--- a/src/domain.coffee
+++ b/src/domain.coffee
@@ -4,8 +4,8 @@ module.exports = (FD) ->
     SUB
     SUP
     NO_SUCH_VALUE
-    ONE_CHANGE
     REJECTED
+    SOMETHING_CHANGED
     ZERO_CHANGES
 
     ASSERT
@@ -27,7 +27,6 @@ module.exports = (FD) ->
   HI_BOUND = 1
   PAIR_SIZE = 2
   DOMAINS_NOT_CHANGED = 0
-  DOMAINS_UPDATED = 1
 
   NOT_FOUND = -1
 
@@ -767,7 +766,7 @@ module.exports = (FD) ->
     if index is 0
       return REJECTED
 
-    return DOMAINS_UPDATED
+    return SOMETHING_CHANGED
 
   domain_force_eq_inline = (domain1, domain2) ->
     ASSERT_DOMAIN domain1
@@ -862,7 +861,7 @@ module.exports = (FD) ->
       if value >= lo and value <= hi
         _domain_remove_value_at domain, value, index, lo, hi
         ASSERT_DOMAIN domain
-        return ONE_CHANGE
+        return SOMETHING_CHANGED
     return ZERO_CHANGES
 
   # Check if every element in one domain not
@@ -907,7 +906,7 @@ module.exports = (FD) ->
     INLINE
     NOT_INLINE
     PREV_CHANGED
-    DOMAINS_UPDATED
+    SOMETHING_CHANGED
 
     domain_shares_no_elements
     domain_complement

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -5,7 +5,7 @@ module.exports = (FD) ->
   SUB = 0 # WARNING: adjusting SUB to something negative means adjusting all tests. probably required for any change actually.
   SUP = 100000000
   ZERO_CHANGES = 0
-  ONE_CHANGE = 1
+  SOMETHING_CHANGED = 1
   REJECTED = -1
   NOT_FOUND = -1
   # different from NOT_FOUND in that NOT_FOUND must be -1 because of the indexOf api
@@ -97,7 +97,7 @@ module.exports = (FD) ->
     SUP
     NOT_FOUND
     NO_SUCH_VALUE
-    ONE_CHANGE
+    SOMETHING_CHANGED
     ZERO_CHANGES
 
     ASSERT

--- a/src/propagators/eq.coffee
+++ b/src/propagators/eq.coffee
@@ -21,13 +21,7 @@ module.exports = (FD) ->
   # can potentially skip a lot of values early.
 
   eq_step_bare = (fdvar1, fdvar2) ->
-    begin_upid = fdvar1.vupid + fdvar2.vupid
-
-    unless fdvar_force_eq_inline fdvar1, fdvar2
-      return REJECTED
-
-    new_vupid = fdvar1.vupid + fdvar2.vupid
-    return new_vupid - begin_upid
+    return fdvar_force_eq_inline fdvar1, fdvar2
 
   # The eq step would reject if there all elements in one domain
   # do not occur in the other domain. Because then there's no

--- a/src/propagators/lt.coffee
+++ b/src/propagators/lt.coffee
@@ -1,6 +1,7 @@
 module.exports = (FD) ->
   {
     REJECTED
+    ZERO_CHANGES
 
     ASSERT_DOMAIN
   } = FD.helpers
@@ -20,8 +21,6 @@ module.exports = (FD) ->
   } = FD.Var
 
   lt_step_bare = (fdvar1, fdvar2) ->
-    begin_upid = fdvar1.vupid + fdvar2.vupid
-
     lo_1 = fdvar_lower_bound fdvar1
     hi_1 = fdvar_upper_bound fdvar1
     lo_2 = fdvar_lower_bound fdvar2
@@ -33,18 +32,17 @@ module.exports = (FD) ->
     # every number in v1 can only be smaller than or equal to the biggest
     # value in v2. bigger values will never satisfy lt so prune them.
     if hi_1 >= hi_2
-      fdvar_remove_gte_inline fdvar1, hi_2
+      left_changed = fdvar_remove_gte_inline fdvar1, hi_2
 
     # likewise; numbers in v2 that are smaller than or equal to the
     # smallest value of v1 can never satisfy lt so prune them as well
     if lo_1 >= lo_2
-      fdvar_remove_lte_inline fdvar2, lo_1
+      right_changed = fdvar_remove_lte_inline fdvar2, lo_1
 
     if fdvar_is_rejected(fdvar1) or fdvar_is_rejected(fdvar2)
       return REJECTED
 
-    current_upid = fdvar1.vupid + fdvar2.vupid
-    return current_upid - begin_upid
+    return left_changed or right_changed or ZERO_CHANGES
 
   # lt would reject if all elements in the left var are bigger or equal to
   # the right var. And since everything is CSIS, we only have to check the

--- a/src/propagators/lte.coffee
+++ b/src/propagators/lte.coffee
@@ -1,6 +1,7 @@
 module.exports = (FD) ->
   {
     REJECTED
+    ZERO_CHANGES
 
     ASSERT_DOMAIN
   } = FD.helpers
@@ -20,8 +21,6 @@ module.exports = (FD) ->
   } = FD.Var
 
   lte_step_bare = (fdvar1, fdvar2) ->
-    begin_upid = fdvar1.vupid + fdvar2.vupid
-
     lo_1 = fdvar_lower_bound fdvar1
     hi_1 = fdvar_upper_bound fdvar1
     lo_2 = fdvar_lower_bound fdvar2
@@ -33,18 +32,17 @@ module.exports = (FD) ->
     # every number in v1 can only be smaller than or equal to the biggest
     # value in v2. bigger values will never satisfy lt so prune them.
     if hi_1 > hi_2
-      fdvar_remove_gte_inline fdvar1, hi_2+1
+      left_changed = fdvar_remove_gte_inline fdvar1, hi_2+1
 
     # likewise; numbers in v2 that are smaller than or equal to the
     # smallest value of v1 can never satisfy lt so prune them as well
     if lo_1 > lo_2
-      fdvar_remove_lte_inline fdvar2, lo_1-1
+      right_changed = fdvar_remove_lte_inline fdvar2, lo_1-1
 
     if fdvar_is_rejected(fdvar1) or fdvar_is_rejected(fdvar2)
       return REJECTED
 
-    current_upid = fdvar1.vupid + fdvar2.vupid
-    return current_upid - begin_upid
+    return left_changed or right_changed or ZERO_CHANGES
 
   # lte would reject if all elements in the left var are bigger than the
   # right var. And since everything is CSIS, we only have to check the

--- a/src/propagators/reified.coffee
+++ b/src/propagators/reified.coffee
@@ -1,5 +1,6 @@
 module.exports = (FD) ->
   {
+    SOMETHING_CHANGED
     ZERO_CHANGES
 
     ASSERT
@@ -15,7 +16,6 @@ module.exports = (FD) ->
   } = FD.Var
 
   PAIR_SIZE = 2
-  ONE_CHANGE = 1
 
   # A boolean variable that represents whether a comparison
   # condition between two variables currently holds or not.
@@ -39,11 +39,11 @@ module.exports = (FD) ->
     if lo < hi
       if step_would_reject op_name, fdvar1, fdvar2
         fdvar_set_value_inline bool_var, 0
-        return ONE_CHANGE
+        return SOMETHING_CHANGED
 
       if step_would_reject inv_op_name, fdvar1, fdvar2
         fdvar_set_value_inline bool_var, 1
-        return ONE_CHANGE
+        return SOMETHING_CHANGED
 
       return ZERO_CHANGES
 

--- a/src/propagators/ring.coffee
+++ b/src/propagators/ring.coffee
@@ -1,6 +1,7 @@
 module.exports = (FD) ->
   {
     REJECTED
+    SOMETHING_CHANGED
   } = FD.helpers
 
   {
@@ -15,14 +16,10 @@ module.exports = (FD) ->
     # Apply an operator func to fdvar1 and fdvar2
     # Updates fdvar_result to the intersection of the result and itself
 
-    begin_upid = fdvar1.vupid + fdvar2.vupid + fdvar_result.vupid
     domain = domain_intersection op_func(fdvar1.dom, fdvar2.dom), fdvar_result.dom
     unless domain.length
       return REJECTED
-    fdvar_set_domain fdvar_result, domain
 
-    new_upid = fdvar1.vupid + fdvar2.vupid + fdvar_result.vupid
-
-    return new_upid - begin_upid
+    return fdvar_set_domain fdvar_result, domain
 
   FD.propagators.ring_step_bare = ring_step_bare

--- a/src/propagators/scale_div.coffee
+++ b/src/propagators/scale_div.coffee
@@ -15,8 +15,6 @@ module.exports = (FD) ->
   PAIR_SIZE = 2
 
   div_step_bare = (fdvar_val, fdvar_prod) ->
-    begin_upid = fdvar_val.vupid + fdvar_prod.vupid
-
     domain = fdvar_prod.dom
     unless domain.length
       return REJECTED
@@ -30,9 +28,7 @@ module.exports = (FD) ->
     d = domain_intersection dbyk, domain
     unless d.length
       return REJECTED
-    fdvar_set_domain fdvar_val, d
 
-    current_upid = fdvar_val.vupid + fdvar_prod.vupid
-    return current_upid - begin_upid
+    return fdvar_set_domain fdvar_val, d
 
   FD.propagators.div_step_bare = div_step_bare

--- a/src/propagators/scale_mul.coffee
+++ b/src/propagators/scale_mul.coffee
@@ -18,8 +18,6 @@ module.exports = (FD) ->
   # TODO: write test that uses this. this is currently not tested at all.
 
   mul_step_bare = (fdvar, fdvar_prod) ->
-    begin_upid = fdvar.vupid + fdvar_prod.vupid
-
     domain = fdvar.dom
     unless domain.length
       return REJECTED
@@ -35,9 +33,7 @@ module.exports = (FD) ->
     d = domain_intersection kd, fdvar_prod.dom
     unless d.length
       return REJECTED
-    fdvar_set_domain fdvar_prod, d
 
-    current_upid = fdvar.vupid + fdvar_prod.vupid
-    return current_upid - begin_upid
+    return fdvar_set_domain fdvar_prod, d
 
   FD.propagators.mul_step_bare = mul_step_bare


### PR DESCRIPTION
The vupid (var update id) was a caching mechanism for propagators. But I've eliminated propagators as objects and so they only served to signal whether anything changed. I've slowly changes this to be determined by the called functions and now we're at a point where we don't need the vupid anymore to determine changes. And so we can eliminate it now. Perhaps it will return as a caching mechanism later. For now we aim for simplicity.

Farewell vupid, you've been kind!
