### PR TITLE
Perf matters

### DIFF
--- a/gruntfile.coffee
+++ b/gruntfile.coffee
@@ -120,6 +120,10 @@ module.exports = ->
               pattern: /^.*_class.*$/mg, # should only remove initializations so remove the whole line...
               replacement: ''
             }
+            { # turn function expressions into function declarations (coffee by default compiles to expr, perf is better for decl)
+              pattern: /([;}])[\s\n]*(\w+)\s*=\s*function([^\d])/mg, # tricky with regex... kitten sacrificed.
+              replacement: '$1 function $2 $3'
+            }
           ]
 
 

--- a/gruntfile.coffee
+++ b/gruntfile.coffee
@@ -116,6 +116,10 @@ module.exports = ->
               pattern: /^\s*ASSERT.*$/mg,
               replacement: '1'
             }
+            { # remove _class references. they should be for debugging only but increase the object footprints
+              pattern: /^.*_class.*$/mg, # should only remove initializations so remove the whole line...
+              replacement: ''
+            }
           ]
 
 

--- a/src/distribution/distribute.coffee
+++ b/src/distribution/distribute.coffee
@@ -66,7 +66,8 @@ module.exports = (FD) ->
     return distribution_create_distributor_on_space
 
   create_custom_distributor = (space, var_names, options) ->
-    return create_fixed_distributor(options) space, var_names
+    options = create_distributor_options options
+    return create_distributor_on_space space, var_names, options
 
   get_distributor_value_func = (name) ->
     switch name

--- a/src/distribution/distribute.coffee
+++ b/src/distribution/distribute.coffee
@@ -130,6 +130,9 @@ module.exports = (FD) ->
     # TODO: we may want to move this function to Space directly? I'm not sure we use any others, regardless of intent
 
     root_space.get_value_distributor = (current_space) ->
+
+      ASSERT current_space.root_space is root_space or current_space is root_space
+
       var_names = root_space.get_targeted_var_names current_space, root_space.initial_targeted_var_names
       if var_names.length > 0
 

--- a/src/distribution/distribute.coffee
+++ b/src/distribution/distribute.coffee
@@ -156,7 +156,6 @@ module.exports = (FD) ->
 
   # TOFIX: to improve later
   distribution = FD.distribution
-  distribution.create_fixed_distributor = create_fixed_distributor
   # for fd.js API compat:
   distribution.naive = create_fixed_distributor('naive')
   distribution.fail_first = create_fixed_distributor('fail_first')

--- a/src/distribution/distribute.coffee
+++ b/src/distribution/distribute.coffee
@@ -144,12 +144,23 @@ module.exports = (FD) ->
 
     return
 
+  distribution_naive = (space, var_names) ->
+    return create_custom_distributor space, var_names, 'naive'
+
+  distribution_fail_first = (space, var_names) ->
+    return create_custom_distributor space, var_names, 'fail_first'
+
+  distribution_split = (space, var_names) ->
+    return create_custom_distributor space, var_names, 'split'
+
   # TOFIX: to improve later
   distribution = FD.distribution
   distribution.create_custom_distributor = create_custom_distributor
-  # for fd.js API compat:
-  distribution.naive = (space, var_names) -> return create_custom_distributor space, var_names, 'naive'
-  distribution.fail_first = (space, var_names) -> return create_custom_distributor space, var_names, 'fail_first'
-  distribution.split = (space, var_names) -> return create_custom_distributor space, var_names, 'split'
+
+  # for fd.js API compat (should change this dynamic behavior
+  # to something we can trace and control more easily)
+  distribution.naive = distribution_naive
+  distribution.fail_first = distribution_fail_first
+  distribution.split = distribution_split
 
   return

--- a/src/distribution/distribute.coffee
+++ b/src/distribution/distribute.coffee
@@ -163,6 +163,6 @@ module.exports = (FD) ->
   distribution.split = create_fixed_distributor('split')
 
   # for testing only
-  distribution._create_custom_distributor = create_custom_distributor
+  distribution.create_custom_distributor = create_custom_distributor
 
   return

--- a/src/distribution/distribute.coffee
+++ b/src/distribution/distribute.coffee
@@ -37,10 +37,13 @@ module.exports = (FD) ->
   } = FD.Var
 
   distribution_get_undetermined_var_names = (S, var_names) ->
+    svars = S.vars
     undetermined_names = []
     for var_name in var_names
-      ASSERT !fdvar_is_rejected(S.vars[var_name]), 'fdvar should not be rejected at this point, but may be solved'
-      unless fdvar_is_solved S.vars[var_name] # if we do the lookup anyways, why not just return fdvars instead?
+      fdvar = svars[var_name]
+      ASSERT !fdvar_is_rejected(fdvar), 'fdvar should not be rejected at this point, but may be solved'
+      # TOFIX: we can drop the fdvar_is_solved check if we make sure `was_solved` is properly set all the time... meh
+      unless fdvar.was_solved or fdvar_is_solved fdvar # if we do the lookup anyways, why not just return fdvars instead?
         undetermined_names.push var_name
     return undetermined_names
 

--- a/src/distribution/distribute.coffee
+++ b/src/distribution/distribute.coffee
@@ -56,18 +56,8 @@ module.exports = (FD) ->
 
     return options
 
-  create_fixed_distributor = (options) ->
-    options = create_distributor_options options
-
-    # partial application by proxy (-> closure)
-    distribution_create_distributor_on_space = (S, varnames) ->
-      return create_distributor_on_space S, varnames, options
-
-    return distribution_create_distributor_on_space
-
   create_custom_distributor = (space, var_names, options) ->
-    options = create_distributor_options options
-    return create_distributor_on_space space, var_names, options
+    return create_distributor_on_space space, var_names, create_distributor_options options
 
   get_distributor_value_func = (name) ->
     switch name
@@ -156,12 +146,10 @@ module.exports = (FD) ->
 
   # TOFIX: to improve later
   distribution = FD.distribution
-  # for fd.js API compat:
-  distribution.naive = create_fixed_distributor('naive')
-  distribution.fail_first = create_fixed_distributor('fail_first')
-  distribution.split = create_fixed_distributor('split')
-
-  # for testing only
   distribution.create_custom_distributor = create_custom_distributor
+  # for fd.js API compat:
+  distribution.naive = (space, var_names) -> return create_custom_distributor space, var_names, 'naive'
+  distribution.fail_first = (space, var_names) -> return create_custom_distributor space, var_names, 'fail_first'
+  distribution.split = (space, var_names) -> return create_custom_distributor space, var_names, 'split'
 
   return

--- a/src/domain.coffee
+++ b/src/domain.coffee
@@ -861,6 +861,8 @@ module.exports = (FD) ->
       if value >= lo and value <= hi
         _domain_remove_value_at domain, value, index, lo, hi
         ASSERT_DOMAIN domain
+        if domain_is_rejected domain
+          return REJECTED
         return SOMETHING_CHANGED
     return ZERO_CHANGES
 

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -84,6 +84,13 @@ module.exports = (FD) ->
     ASSERT_VARS space.vars
     return
 
+  ASSERT_SNODE = (snode) ->
+    if DISABLED
+      return
+    # TBD: expand with other assertions...
+    ASSERT_VARS snode.changed_var_names
+    return
+
   ASSERT_PROPAGATORS = (propagators) ->
     ASSERT !!propagators, 'propagators should exist', propagators
     for p in propagators
@@ -120,6 +127,7 @@ module.exports = (FD) ->
     ASSERT_DOMAIN
     ASSERT_PROPAGATOR
     ASSERT_PROPAGATORS
+    ASSERT_SNODE
     ASSERT_SPACE
     ASSERT_UNUSED_DOMAIN
     ASSERT_VARS

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -21,12 +21,12 @@ require('./propagators/scale_div')(FD)
 require('./propagators/scale_mul')(FD)
 require('./propagators/ring')(FD)
 require('./propagators/stepper_any')(FD) # should be last of the props
-require('./space')(FD)
 require('./distribution/markov')(FD)
 require('./distribution/presets')(FD)
 require('./distribution/value')(FD)
 require('./distribution/var')(FD)
 require('./distribution/distribute')(FD)
+require('./space')(FD)
 require('./search')(FD)
 # high level API
 require('./solver')(FD)

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -26,6 +26,7 @@ require('./distribution/presets')(FD)
 require('./distribution/value')(FD)
 require('./distribution/var')(FD)
 require('./distribution/distribute')(FD)
+require('./snode')(FD)
 require('./space')(FD)
 require('./search')(FD)
 # high level API

--- a/src/propagators/eq.coffee
+++ b/src/propagators/eq.coffee
@@ -1,6 +1,8 @@
 module.exports = (FD) ->
   {
     REJECTED
+
+    ASSERT
   } = FD.helpers
 
   {
@@ -33,8 +35,10 @@ module.exports = (FD) ->
     dom1 = fdvar1.dom
     dom2 = fdvar2.dom
 
-    if domain_is_rejected dom1 or domain_is_rejected dom2
-      return true
+    ASSERT !domain_is_rejected dom1, 'empty domains should reject at time of becoming empty'
+    ASSERT !domain_is_rejected dom2, 'empty domains should reject at time of becoming empty'
+#    if domain_is_rejected dom1 or domain_is_rejected dom2
+#      return true
 
     return domain_shares_no_elements dom1, dom2
 

--- a/src/propagators/lt.coffee
+++ b/src/propagators/lt.coffee
@@ -3,6 +3,7 @@ module.exports = (FD) ->
     REJECTED
     ZERO_CHANGES
 
+    ASSERT
     ASSERT_DOMAIN
   } = FD.helpers
 
@@ -53,8 +54,10 @@ module.exports = (FD) ->
     dom1 = fdvar1.dom
     dom2 = fdvar2.dom
 
-    if domain_is_rejected dom1 or domain_is_rejected dom2
-      return true
+    ASSERT !domain_is_rejected dom1, 'empty domains should reject at time of becoming empty'
+    ASSERT !domain_is_rejected dom2, 'empty domains should reject at time of becoming empty'
+#    if domain_is_rejected dom1 or domain_is_rejected dom2
+#      return true
 
     return domain_min(dom1) >= domain_max(dom2)
 

--- a/src/propagators/lt.coffee
+++ b/src/propagators/lt.coffee
@@ -29,19 +29,22 @@ module.exports = (FD) ->
 
     ASSERT_DOMAIN fdvar1.dom, 'v1 needs to be csis for this trick to work'
     ASSERT_DOMAIN fdvar2.dom, 'v2 needs to be csis for this trick to work'
+    ASSERT !domain_is_rejected fdvar1.dom, 'empty domains should reject at time of becoming empty'
+    ASSERT !domain_is_rejected fdvar2.dom, 'empty domains should reject at time of becoming empty'
 
     # every number in v1 can only be smaller than or equal to the biggest
     # value in v2. bigger values will never satisfy lt so prune them.
     if hi_1 >= hi_2
       left_changed = fdvar_remove_gte_inline fdvar1, hi_2
+      if fdvar_is_rejected fdvar1
+        left_changed = REJECTED
 
     # likewise; numbers in v2 that are smaller than or equal to the
     # smallest value of v1 can never satisfy lt so prune them as well
     if lo_1 >= lo_2
       right_changed = fdvar_remove_lte_inline fdvar2, lo_1
-
-    if fdvar_is_rejected(fdvar1) or fdvar_is_rejected(fdvar2)
-      return REJECTED
+      if fdvar_is_rejected fdvar2
+        right_changed = REJECTED
 
     return left_changed or right_changed or ZERO_CHANGES
 

--- a/src/propagators/lte.coffee
+++ b/src/propagators/lte.coffee
@@ -29,19 +29,22 @@ module.exports = (FD) ->
 
     ASSERT_DOMAIN fdvar1.dom, 'v1 needs to be csis for this trick to work'
     ASSERT_DOMAIN fdvar2.dom, 'v2 needs to be csis for this trick to work'
+    ASSERT !domain_is_rejected fdvar1.dom, 'empty domains should reject at time of becoming empty'
+    ASSERT !domain_is_rejected fdvar2.dom, 'empty domains should reject at time of becoming empty'
 
     # every number in v1 can only be smaller than or equal to the biggest
     # value in v2. bigger values will never satisfy lt so prune them.
     if hi_1 > hi_2
       left_changed = fdvar_remove_gte_inline fdvar1, hi_2+1
+      if fdvar_is_rejected fdvar1
+        left_changed = REJECTED
 
     # likewise; numbers in v2 that are smaller than or equal to the
     # smallest value of v1 can never satisfy lt so prune them as well
     if lo_1 > lo_2
       right_changed = fdvar_remove_lte_inline fdvar2, lo_1-1
-
-    if fdvar_is_rejected(fdvar1) or fdvar_is_rejected(fdvar2)
-      return REJECTED
+      if fdvar_is_rejected fdvar2
+        right_changed = REJECTED
 
     return left_changed or right_changed or ZERO_CHANGES
 

--- a/src/propagators/lte.coffee
+++ b/src/propagators/lte.coffee
@@ -3,6 +3,7 @@ module.exports = (FD) ->
     REJECTED
     ZERO_CHANGES
 
+    ASSERT
     ASSERT_DOMAIN
   } = FD.helpers
 
@@ -53,8 +54,10 @@ module.exports = (FD) ->
     dom1 = fdvar1.dom
     dom2 = fdvar2.dom
 
-    if domain_is_rejected dom1 or domain_is_rejected dom2
-      return true
+    ASSERT !domain_is_rejected dom1, 'empty domains should reject at time of becoming empty'
+    ASSERT !domain_is_rejected dom2, 'empty domains should reject at time of becoming empty'
+#    if domain_is_rejected dom1 or domain_is_rejected dom2
+#      return true
 
     return domain_min(dom1) > domain_max(dom2)
 

--- a/src/propagators/neq.coffee
+++ b/src/propagators/neq.coffee
@@ -1,6 +1,5 @@
 module.exports = (FD) ->
   {
-    domain_is_rejected
     domain_max
     domain_min
   } = FD.Domain

--- a/src/snode.coffee
+++ b/src/snode.coffee
@@ -1,0 +1,51 @@
+# Snode represents a node in the search space (Space Node)
+# Previously this was part of Space but we'll use that
+# exclusively as an external API endpoint object now.
+
+
+module.exports = (FD) ->
+
+  {
+    REJECTED
+    SUB
+    SUP
+
+    ASSERT
+    ASSERT_DOMAIN
+    ASSERT_PROPAGATORS
+  } = FD.helpers
+
+  snode_create_root = (space) ->
+    snode_create [], {}, 0, null, space
+
+  snode_new = (vars, space) ->
+    snode_create Object.keys(vars), vars, 0, null, space
+
+  snode_clone = (snode) ->
+    # clone the vars for now. later we'll change this to deltas only
+    names = snode.changed_var_names
+    parent_vars = snode.changed_vars
+    child_vars = {}
+    for var_name in names
+      child_vars[var_name] = fdvar_clone parent_vars[var_name]
+
+    return snode_create names.slice(0), child_vars, snode.distribution_choice, snode.root_space, snode
+
+  snode_create = (changed_var_names, changed_vars, distribution_choice, root_space, parent_snode) ->
+    return {
+      _class: 'snode'
+
+      changed_var_names # array of names
+      changed_vars # by name
+
+      distribution_choice # tbd
+
+      parent_snode # parent snode
+      root_space # we need this?
+    }
+
+  FD.Snode = {
+    snode_clone
+    snode_create_root
+    snode_new
+  }

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -314,14 +314,12 @@ module.exports = (FD) ->
         state = searchMethod state
         break if state.status is 'end'
         count++
-        if squash
-          solutions.push true
-        else
+        unless squash
           solution = state.space.solution()
           solutions.push solution
-        if log >= 2
-          console.log "      - FD solution() ::::::::::::::::::::::::::::"
-          console.log JSON.stringify(solution)
+          if log >= 2
+            console.log "      - FD solution() ::::::::::::::::::::::::::::"
+            console.log JSON.stringify(solution)
 
       if log >= 1
         console.timeEnd '      - FD Solver Time'

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -21,6 +21,10 @@ module.exports = (FD) ->
     domain_create_bool
   } = FD.Domain
 
+  {
+    create_custom_distributor
+  } = FD.distribution
+
   class FD.Solver
 
     constructor: (o={}) ->
@@ -291,7 +295,7 @@ module.exports = (FD) ->
       vars ?= @vars.all
 
       distributor_options ?= @distribute
-      FD.distribution.create_custom_distributor @S, _.es(vars), distributor_options
+      create_custom_distributor @S, _.es(vars), distributor_options
 
       search ?= @search
       searchMethod = FD.search[search]

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -291,7 +291,7 @@ module.exports = (FD) ->
       vars ?= @vars.all
 
       distributor_options ?= @distribute
-      FD.distribution.create_fixed_distributor(distributor_options)(@S, _.es(vars))
+      FD.distribution.create_custom_distributor @S, _.es(vars), distributor_options
 
       search ?= @search
       searchMethod = FD.search[search]

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -66,6 +66,13 @@ module.exports = (FD) ->
     @current_value_distributor = undefined
     @solver = undefined # see clone
 
+    # stuff migrated from distribute. See create_distributor_on_space
+    @get_targeted_var_names = undefined
+    @get_var_fitness_function = undefined
+    @get_next_value = undefined
+    @initial_targeted_var_names = null # may be set from distributor
+    @markov_vars_by_id = null # cache for markov chains
+
     return
 
   Space::clone = () ->

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -78,7 +78,7 @@ module.exports = (FD) ->
 
   Space::clone = () ->
     root = @root_space or @
-    space = new FD.space root, @get_value_distributor, @_propagators
+    space = new Space root, @get_value_distributor, @_propagators
 
     parent_vars = @vars
     child_vars = space.vars

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -45,7 +45,7 @@ module.exports = (FD) ->
   # Duplicates the functionality of new Space(S) for readability.
   # Concept of a space that holds fdvars and propagators
 
-  Space = FD.space = (get_value_distributor = throw_unless_overridden, propagator_data = []) ->
+  Space = FD.space = (root_space = null, get_value_distributor = throw_unless_overridden, propagator_data = []) ->
     @_class = 'space'
 
     # The FDVARS are all named and accessed by name.
@@ -54,6 +54,7 @@ module.exports = (FD) ->
     # fdvars object. This gets us copy on modify semantics.
     @vars = {}
     @var_names = []
+    @root_space = root_space
 
     # shared with root! should not change after initialization
     @_propagators = propagator_data
@@ -76,7 +77,8 @@ module.exports = (FD) ->
     return
 
   Space::clone = () ->
-    space = new FD.space @get_value_distributor, @_propagators
+    root = @root_space or @
+    space = new FD.space root, @get_value_distributor, @_propagators
 
     parent_vars = @vars
     child_vars = space.vars

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -4,6 +4,7 @@ module.exports = (FD) ->
 
   {
     REJECTED
+    SOMETHING_CHANGED
     SUB
     SUP
 
@@ -165,7 +166,7 @@ module.exports = (FD) ->
       changed = false
       for prop_details in propagators
         n = step_any prop_details, @ # TODO: if we can get a "solved" state here we can prevent an "is_solved" check later...
-        if n > 0
+        if n is SOMETHING_CHANGED
           changed = true
         else if n is REJECTED
           return false # solution impossible
@@ -194,6 +195,7 @@ module.exports = (FD) ->
     j = 0
     for name, i in unsolved_names
       fdvar = vars[name]
+      ASSERT !fdvar.was_solved, 'should not be set yet at this stage' # we may change this though...
       if fdvar_is_solved fdvar
         ASSERT !fdvar.was_solved, 'should not have been marked as solved yet'
         fdvar.was_solved = true # makes Space#clone faster

--- a/src/var.coffee
+++ b/src/var.coffee
@@ -42,6 +42,7 @@ module.exports = (FD) ->
       _class: 'fdvar'
       id
       dom
+      was_solved: false # for Space#clone
     }
 
   # A var is undetermined when it is neither rejected nor solved.
@@ -63,6 +64,7 @@ module.exports = (FD) ->
     return domain_is_rejected fdvar.dom
 
   fdvar_clone = (fdvar) ->
+    ASSERT !fdvar.was_solved, 'should not clone vars that are already solved...'
     return fdvar_new fdvar.id, fdvar.dom.slice(0)
 
   fdvar_is_equal = (fdvar1, fdvar2) ->

--- a/src/var.coffee
+++ b/src/var.coffee
@@ -139,17 +139,20 @@ module.exports = (FD) ->
     r = ZERO_CHANGES
     dom1 = fdvar1.dom
     dom2 = fdvar2.dom
-    if fdvar_is_solved fdvar1
+
+    ASSERT !domain_is_rejected dom1, 'empty domains should reject at time of becoming empty'
+    ASSERT !domain_is_rejected dom2, 'empty domains should reject at time of becoming empty'
+
+    if fdvar1.was_solved or fdvar_is_solved fdvar1
       r = domain_remove_value_inline dom2, domain_min dom1
       ASSERT r < 2, 'should return SOMETHING_CHANGED and not the actual number of changes... test here just in case!'
-    else if fdvar_is_solved fdvar2
+    else if fdvar2.was_solved or fdvar_is_solved fdvar2
       r = domain_remove_value_inline dom1, domain_min dom2
       ASSERT r < 2, 'should return SOMETHING_CHANGED and not the actual number of changes... test here just in case!'
-    if domain_is_rejected(dom1) or domain_is_rejected dom2
-      dom1.length = 0
-      dom2.length = 0
-      r = REJECTED
+
     ASSERT r is REJECTED or r is ZERO_CHANGES or r is SOMETHING_CHANGED, 'turning stuff into enum, must be sure about values'
+    ASSERT (r is REJECTED) is (domain_is_rejected(dom1) or domain_is_rejected(dom2)), 'if either domain is rejected, r should reflect this already'
+
     return r
 
   FD.Var = {

--- a/tests/perf/perf.coffee
+++ b/tests/perf/perf.coffee
@@ -49,7 +49,7 @@ if PROFILE
   # for the browser
   if console.profile
     console.profile()
-    new finitedomain.PathSolver({rawtree: w.o5}).solve({log:1}, true)
+    new finitedomain.PathSolver({rawtree: w.o5}).solve({log:1, max: 10000}, true)
     console.profileEnd()
   else
     console.log 'browser does not support console.profile, you\'ll need to work around it ;)'

--- a/tests/spec/distribution/value.spec.coffee
+++ b/tests/spec/distribution/value.spec.coffee
@@ -35,7 +35,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_bool()
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_min` here
         get_next_value = space.get_value_distributor space
@@ -53,7 +53,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_ranges([10, 11], [13, 20])
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_min` here
         get_next_value = space.get_value_distributor space
@@ -71,7 +71,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_bool()
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_min` here
         get_next_value = space.get_value_distributor space
@@ -89,7 +89,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_ranges([10, 11], [13, 20])
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_min` here
         get_next_value = space.get_value_distributor space
@@ -108,7 +108,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_zero()
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_min` here
         get_next_value = space.get_value_distributor space
@@ -124,7 +124,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', [0, 1] # initially set to unsolved to circumvent early asserts
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'min'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_min` here
         get_next_value = space.get_value_distributor space
@@ -161,7 +161,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_bool()
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_max` here
         get_next_value = space.get_value_distributor space
@@ -179,7 +179,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_ranges([10, 11], [13, 20])
 
         # setup the space distributors such that all vars are used and value uses value_distribution_by_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_max` here
         get_next_value = space.get_value_distributor space
@@ -197,7 +197,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_bool()
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_max` here
         get_next_value = space.get_value_distributor space
@@ -215,7 +215,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_ranges([10, 11], [13, 20])
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_max` here
         get_next_value = space.get_value_distributor space
@@ -234,7 +234,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_zero()
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_max` here
         get_next_value = space.get_value_distributor space
@@ -250,7 +250,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', [0, 1] # initially set to unsolved to circumvent early asserts
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'max'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_max` here
         get_next_value = space.get_value_distributor space
@@ -287,7 +287,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_range(10, 20)
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_mid
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_mid` here
         get_next_value = space.get_value_distributor space
@@ -305,7 +305,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_ranges([10, 12], [18, 20])
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_mid
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_min` here
         get_next_value = space.get_value_distributor space
@@ -323,7 +323,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_range(10, 20)
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_mid
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_mid` here
         get_next_value = space.get_value_distributor space
@@ -341,7 +341,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_ranges([10, 12], [18, 20])
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_mid
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_mid` here
         get_next_value = space.get_value_distributor space
@@ -360,7 +360,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_zero()
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_mid
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_mid` here
         get_next_value = space.get_value_distributor space
@@ -376,7 +376,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_bool() # initially set to unsolved to circumvent early asserts
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_mid
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'mid'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_mid` here
         get_next_value = space.get_value_distributor space
@@ -413,7 +413,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_range(10, 20)
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_min` here
         get_next_value = space.get_value_distributor space
@@ -431,7 +431,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_ranges([10, 11], [13, 20])
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_min` here
         get_next_value = space.get_value_distributor space
@@ -449,7 +449,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_range(10, 20)
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_min` here
         get_next_value = space.get_value_distributor space
@@ -467,7 +467,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_ranges([10, 17], [19, 20])
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_min` here
         get_next_value = space.get_value_distributor space
@@ -486,7 +486,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_zero()
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_min` here
         get_next_value = space.get_value_distributor space
@@ -502,7 +502,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_bool() # initially set to unsolved to circumvent early asserts
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_min
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMin'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_min` here
         get_next_value = space.get_value_distributor space
@@ -539,7 +539,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_range(10, 20)
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_max` here
         get_next_value = space.get_value_distributor space
@@ -557,7 +557,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_ranges([10, 17], [19, 20])
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_max` here
         get_next_value = space.get_value_distributor space
@@ -575,7 +575,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_range(10, 20)
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_max` here
         get_next_value = space.get_value_distributor space
@@ -593,7 +593,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_ranges([10, 11], [13, 20])
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_max` here
         get_next_value = space.get_value_distributor space
@@ -612,7 +612,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_zero()
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_max` here
         get_next_value = space.get_value_distributor space
@@ -628,7 +628,7 @@ describe 'FD.distribution.Value', ->
         space.decl 'A', spec_d_create_bool() # initially set to unsolved to circumvent early asserts
 
         # setup the space distributors such that all vars are used and value uses distribution_value_by_split_max
-        FD.distribution._create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
+        FD.distribution.create_custom_distributor space, ['A'], {var: 'naive', val: 'splitMax'}
 
         # create a function that walks the space. note that we're calling a `distribution_value_by_split_max` here
         get_next_value = space.get_value_distributor space

--- a/tests/spec/propagators/eq.spec.coffee
+++ b/tests/spec/propagators/eq.spec.coffee
@@ -42,23 +42,23 @@ describe "FD - propagators - eq", ->
     expect(-> eq_step_bare v).to.throw
     expect(-> eq_step_bare undefined, v).to.throw
 
-  it 'should reject for empty domains', ->
-
-    v1 = fdvar_create 'x', []
-    v2 = fdvar_create 'y', []
-    expect(eq_step_bare v1, v2).to.eql REJECTED
-
-  it 'should reject for empty left domain', ->
-
-    v1 = fdvar_create 'x', []
-    v2 = fdvar_create_wide 'y'
-    expect(eq_step_bare v1, v2).to.eql REJECTED
-
-  it 'should reject for empty right domain', ->
-
-    v1 = fdvar_create_wide 'x'
-    v2 = fdvar_create 'y', []
-    expect(eq_step_bare v1, v2).to.eql REJECTED
+#  it 'should reject for empty domains', ->
+#
+#    v1 = fdvar_create 'x', []
+#    v2 = fdvar_create 'y', []
+#    expect(eq_step_bare v1, v2).to.eql REJECTED
+#
+#  it 'should reject for empty left domain', ->
+#
+#    v1 = fdvar_create 'x', []
+#    v2 = fdvar_create_wide 'y'
+#    expect(eq_step_bare v1, v2).to.eql REJECTED
+#
+#  it 'should reject for empty right domain', ->
+#
+#    v1 = fdvar_create_wide 'x'
+#    v2 = fdvar_create 'y', []
+#    expect(eq_step_bare v1, v2).to.eql REJECTED
 
   it 'should split a domain if it covers multiple ranges of other domain', ->
 

--- a/tests/spec/propagators/lt.spec.coffee
+++ b/tests/spec/propagators/lt.spec.coffee
@@ -40,23 +40,23 @@ describe "FD - propagators - lt", ->
     expect(-> lt_step_bare v).to.throw
     expect(-> lt_step_bare undefined, v).to.throw
 
-  it 'should reject for empty domains', ->
-
-    v1 = fdvar_create 'x', []
-    v2 = fdvar_create 'y', []
-    expect(lt_step_bare v1, v2).to.eql REJECTED
-
-  it 'should reject for empty left domain', ->
-
-    v1 = fdvar_create 'x', []
-    v2 = fdvar_create_wide 'y'
-    expect(lt_step_bare v1, v2).to.eql REJECTED
-
-  it 'should reject for empty right domain', ->
-
-    v1 = fdvar_create_wide 'x'
-    v2 = fdvar_create 'y', []
-    expect(lt_step_bare v1, v2).to.eql REJECTED
+#  it 'should reject for empty domains', ->
+#
+#    v1 = fdvar_create 'x', []
+#    v2 = fdvar_create 'y', []
+#    expect(lt_step_bare v1, v2).to.eql REJECTED
+#
+#  it 'should reject for empty left domain', ->
+#
+#    v1 = fdvar_create 'x', []
+#    v2 = fdvar_create_wide 'y'
+#    expect(lt_step_bare v1, v2).to.eql REJECTED
+#
+#  it 'should reject for empty right domain', ->
+#
+#    v1 = fdvar_create_wide 'x'
+#    v2 = fdvar_create 'y', []
+#    expect(lt_step_bare v1, v2).to.eql REJECTED
 
   it 'should not change if v1 already < v2', ->
 

--- a/tests/spec/propagators/lte.spec.coffee
+++ b/tests/spec/propagators/lte.spec.coffee
@@ -40,23 +40,23 @@ describe "FD - propagators - lte", ->
     expect(-> lte_step_bare v).to.throw
     expect(-> lte_step_bare undefined, v).to.throw
 
-  it 'should reject for empty domains', ->
-
-    v1 = fdvar_create 'x', []
-    v2 = fdvar_create 'y', []
-    expect(lte_step_bare v1, v2).to.eql REJECTED
-
-  it 'should reject for empty left domain', ->
-
-    v1 = fdvar_create 'x', []
-    v2 = fdvar_create_wide 'y'
-    expect(lte_step_bare v1, v2).to.eql REJECTED
-
-  it 'should reject for empty right domain', ->
-
-    v1 = fdvar_create_wide 'x'
-    v2 = fdvar_create 'y', []
-    expect(lte_step_bare v1, v2).to.eql REJECTED
+#  it 'should reject for empty domains', ->
+#
+#    v1 = fdvar_create 'x', []
+#    v2 = fdvar_create 'y', []
+#    expect(lte_step_bare v1, v2).to.eql REJECTED
+#
+#  it 'should reject for empty left domain', ->
+#
+#    v1 = fdvar_create 'x', []
+#    v2 = fdvar_create_wide 'y'
+#    expect(lte_step_bare v1, v2).to.eql REJECTED
+#
+#  it 'should reject for empty right domain', ->
+#
+#    v1 = fdvar_create_wide 'x'
+#    v2 = fdvar_create 'y', []
+#    expect(lte_step_bare v1, v2).to.eql REJECTED
 
   it 'should not change if v1 already <= v2', ->
 

--- a/tests/spec/propagators/neq.spec.coffee
+++ b/tests/spec/propagators/neq.spec.coffee
@@ -42,23 +42,23 @@ describe "FD - propagators - neq", ->
     expect(-> neq_step_bare v).to.throw
     expect(-> neq_step_bare undefined, v).to.throw
 
-  it 'should reject for empty domains', ->
-
-    v1 = fdvar_create 'x', []
-    v2 = fdvar_create 'y', []
-    expect(neq_step_bare v1, v2).to.eql REJECTED
-
-  it 'should reject for empty left domain', ->
-
-    v1 = fdvar_create 'x', []
-    v2 = fdvar_create_wide 'y'
-    expect(neq_step_bare v1, v2).to.eql REJECTED
-
-  it 'should reject for empty right domain', ->
-
-    v1 = fdvar_create_wide 'x'
-    v2 = fdvar_create 'y', []
-    expect(neq_step_bare v1, v2).to.eql REJECTED
+#  it 'should reject for empty domains', ->
+#
+#    v1 = fdvar_create 'x', []
+#    v2 = fdvar_create 'y', []
+#    expect(neq_step_bare v1, v2).to.eql REJECTED
+#
+#  it 'should reject for empty left domain', ->
+#
+#    v1 = fdvar_create 'x', []
+#    v2 = fdvar_create_wide 'y'
+#    expect(neq_step_bare v1, v2).to.eql REJECTED
+#
+#  it 'should reject for empty right domain', ->
+#
+#    v1 = fdvar_create_wide 'x'
+#    v2 = fdvar_create 'y', []
+#    expect(neq_step_bare v1, v2).to.eql REJECTED
 
   describe 'should not change anything as long as both domains are unsolved', ->
 
@@ -143,8 +143,8 @@ describe "FD - propagators - neq", ->
         v1 = fdvar_create 'x', domain1.slice 0
         v2 = fdvar_create 'y', domain1.slice 0
         expect(neq_step_bare v1, v2).to.eql REJECTED
-        expect(v1.dom, 'v1 dom').to.eql []
-        expect(v2.dom, 'v2 dom').to.eql []
+#        expect(v1.dom, 'v1 dom').to.eql []
+#        expect(v2.dom, 'v2 dom').to.eql []
 
     test 0, 1
     test 1, 2

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -31,15 +31,6 @@ describe "FD", ->
         # I dont want to test for instanceof... but i dont think we can change that due to ext. api.
         expect(new Space).to.be.a 'object'
 
-      it 'should set the value distributor to a thrower', ->
-
-        expect(-> new Space().get_value_distributor()).to.throw
-
-      it 'should set the value distributor to given function', ->
-
-        f = ->
-        expect(new Space(undefined, f).get_value_distributor).to.equal f
-
       it 'should init vars and var_names', ->
 
         expect(new Space().vars).to.be.an 'object'
@@ -91,18 +82,16 @@ describe "FD", ->
         expect(space.var_names.join()).to.equal clone.var_names.join()
         expect(space._propagators).to.equal clone._propagators
 
-      it 'should copy the get value distributor', ->
-
-        expect(space.get_value_distributor).to.equal clone.get_value_distributor
-        g = ->
-        expect(new Space(undefined, g).clone().get_value_distributor).to.equal g
-
       it 'should copy the solver', ->
 
         expect(clone.solver).to.equal space.solver
         s = new Space()
         s.solver = {}
         expect(s.clone().solver).to.equal s.solver
+
+    describe '#get_value_distributor()', ->
+
+      # TODO
 
     describe '#done()', ->
 

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -38,12 +38,21 @@ describe "FD", ->
       it 'should set the value distributor to given function', ->
 
         f = ->
-        expect(new Space(f).get_value_distributor).to.equal f
+        expect(new Space(undefined, f).get_value_distributor).to.equal f
 
       it 'should init vars and var_names', ->
 
         expect(new Space().vars).to.be.an 'object'
         expect(new Space().var_names).to.be.an 'array'
+
+      it 'should set root_space to null unless given', ->
+
+        expect(new Space().root_space).to.be.null
+
+      it 'should set root_space to given root_space', ->
+
+        root = {}
+        expect(new Space(root).root_space).to.equal root
 
     describe '#clone()', ->
 
@@ -54,9 +63,18 @@ describe "FD", ->
 
         expect(clone).to.not.equal space
 
-      it 'should deep clone the space', ->
+      it 'should deep clone the space and set root_space', ->
 
-        expect(clone).to.eql space
+        lclone = space.clone() # local!
+        expect(lclone.root_space).to.equal space
+        expect(space.root_space).to.equal null
+        lclone.root_space = null # exception to the rule
+        expect(lclone, 'clone should be space').to.eql space
+
+      it 'should set root_space to cloned space if not yet set there', ->
+
+        expect(clone.root_space, 'clone.root_space').to.equal space
+        expect(clone.clone().root_space, 'clone.clone().root_space').to.equal space
 
       it 'should clone vars', ->
 
@@ -77,7 +95,7 @@ describe "FD", ->
 
         expect(space.get_value_distributor).to.equal clone.get_value_distributor
         g = ->
-        expect(new Space(g).clone().get_value_distributor).to.equal g
+        expect(new Space(undefined, g).clone().get_value_distributor).to.equal g
 
       it 'should copy the solver', ->
 
@@ -96,6 +114,7 @@ describe "FD", ->
 
         space = new Space
         clone = space.clone()
+        clone.root_space = null # since space is the root, it does not have itself as a root_space prop.
         space.done()
         expect(space).to.eql clone # since clone is a deep clone, we can do a deep eq check here
 
@@ -222,6 +241,7 @@ describe "FD", ->
       it 'should not modify its space', ->
         space = new Space()
         clone = space.clone()
+        clone.root_space = null # since space is the root, it does not have itself as a root_space prop.
         space.inject ->
         expect(space).to.eql clone
 

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -34,7 +34,8 @@ describe "FD", ->
       it 'should init vars and var_names', ->
 
         expect(new Space().vars).to.be.an 'object'
-        expect(new Space().var_names).to.be.an 'array'
+        expect(new Space().unsolved_var_names).to.be.an 'array'
+        expect(new Space().all_var_names).to.be.an 'array'
 
       it 'should set root_space to null unless given', ->
 
@@ -73,13 +74,14 @@ describe "FD", ->
 
       it 'should deep clone the vars', ->
 
-        for var_name in space.var_names
+        for var_name in space.all_var_names
           expect(clone.vars[var_name]).to.not.equal space.vars[var_name]
           # note: the deep clone check is already done above, no need to repeat it
 
-      it 'should clone certain props', ->
-        expect(space.var_names).to.not.equal clone.var_names
-        expect(space.var_names.join()).to.equal clone.var_names.join()
+      it 'should clone certain props, copy others', ->
+        expect(space.unsolved_var_names).to.not.equal clone.unsolved_var_names
+        expect(space.unsolved_var_names.join()).to.equal clone.unsolved_var_names.join()
+        expect(space.all_var_names).to.equal clone.all_var_names
         expect(space._propagators).to.equal clone._propagators
 
       it 'should copy the solver', ->
@@ -239,15 +241,18 @@ describe "FD", ->
       it 'should create a new var', ->
 
         space = new Space()
-        expect(space.var_names.length, 'before decl').to.eql 0 # no vars... right? :)
+        expect(space.all_var_names.length, 'before decl').to.eql 0 # no vars... right? :)
+        expect(space.unsolved_var_names.length, 'before decl').to.eql 0 # no vars... right? :)
         space.decl_anon spec_d_create_value 22
-        expect(space.var_names.length, 'after decl').to.eql 1
+        expect(space.all_var_names.length, 'after decl').to.eql 1
+        expect(space.unsolved_var_names.length, 'after decl').to.eql 1
 
       it 'should return the name of a var', ->
 
         space = new Space()
         name = space.decl_anon spec_d_create_value 50
-        expect(space.var_names.indexOf(name) > -1).to.be.true
+        expect(space.all_var_names.indexOf(name) > -1).to.be.true
+        expect(space.unsolved_var_names.indexOf(name) > -1).to.be.true
 
       it 'should create a var with given domain', ->
 
@@ -266,16 +271,19 @@ describe "FD", ->
       it 'should create multiple vars', ->
 
         space = new Space()
-        expect(space.var_names.length, 'before decl').to.eql 0 # no vars... right? :)
+        expect(space.all_var_names.length, 'before decl').to.eql 0 # no vars... right? :)
+        expect(space.unsolved_var_names.length, 'before decl').to.eql 0 # no vars... right? :)
         space.decl_anons 22
-        expect(space.var_names.length, 'after decl').to.eql 22
+        expect(space.all_var_names.length, 'after decl').to.eql 22
+        expect(space.unsolved_var_names.length, 'after decl').to.eql 22
 
       it 'should return a list of names of the new vars', ->
 
         space = new Space()
         names = space.decl_anons 50
         for name in names
-          expect(space.var_names.indexOf(name) > -1).to.be.true
+          expect(space.all_var_names.indexOf(name) > -1).to.be.true
+          expect(space.unsolved_var_names.indexOf(name) > -1).to.be.true
 
       it 'should set the domain to full if no domain is given', ->
 
@@ -324,15 +332,18 @@ describe "FD", ->
       it 'should create a new var', ->
 
         space = new Space()
-        expect(space.var_names.length, 'before decl').to.eql 0 # no vars... right? :)
+        expect(space.all_var_names.length, 'before decl').to.eql 0 # no vars... right? :)
+        expect(space.unsolved_var_names.length, 'before decl').to.eql 0 # no vars... right? :)
         space.decl_value 22
-        expect(space.var_names.length, 'after decl').to.eql 1
+        expect(space.all_var_names.length, 'after decl').to.eql 1
+        expect(space.unsolved_var_names.length, 'after decl').to.eql 1
 
       it 'should return the name of a var', ->
 
         space = new Space()
         name = space.decl_value 50
-        expect(space.var_names.indexOf(name) > -1).to.be.true
+        expect(space.all_var_names.indexOf(name) > -1).to.be.true
+        expect(space.unsolved_var_names.indexOf(name) > -1).to.be.true
 
       it 'should create a "solved" var with given value', ->
 
@@ -351,7 +362,8 @@ describe "FD", ->
 
         space = new Space()
         space.decl 'foo', spec_d_create_value 100
-        expect(space.var_names).to.eql ['foo']
+        expect(space.all_var_names).to.eql ['foo']
+        expect(space.unsolved_var_names).to.eql ['foo']
         expect(space.vars.foo?).to.be.true
 
       it 'should return the space', ->
@@ -403,7 +415,8 @@ describe "FD", ->
         space = new Space()
         names = ['foo', 'bar', 'baz']
         space.decls names, spec_d_create_value 100
-        expect(space.var_names).to.eql names
+        expect(space.all_var_names).to.eql names
+        expect(space.unsolved_var_names).to.eql names
         for name in names
           expect(space.vars.foo?).to.be.true
 
@@ -413,7 +426,8 @@ describe "FD", ->
         names = ['foo', 'bar', 'baz']
         domain = spec_d_create_value 100
         space.decls names, domain
-        expect(space.var_names).to.eql names
+        expect(space.all_var_names).to.eql names
+        expect(space.unsolved_var_names).to.eql names
         for name in names
           expect(space.vars[name]?).to.be.true
           expect(space.vars[name].dom, 'domain should be cloned').not.to.equal domain
@@ -427,7 +441,8 @@ describe "FD", ->
         names = ['foo', 'bar', 'baz']
         domain = spec_d_create_range FD.helpers.SUB, FD.helpers.SUP
         space.decls names
-        expect(space.var_names).to.eql names
+        expect(space.all_var_names).to.eql names
+        expect(space.unsolved_var_names).to.eql names
         for name in names
           expect(space.vars[name]?).to.be.true
           expect(space.vars[name].dom).to.eql domain
@@ -440,7 +455,8 @@ describe "FD", ->
 
         space = new Space()
         space.num 'foo', 22
-        expect(space.var_names).to.eql ['foo']
+        expect(space.all_var_names).to.eql ['foo']
+        expect(space.unsolved_var_names).to.eql ['foo']
 
       it 'should return the space', ->
 


### PR DESCRIPTION
This is kind of a wip but it may take a while until I can proceed.

eliminate call step 07a5bc3
Cut out an extra call to simplify the code  90666a4
properly import dep (prepares for optim. later) c6e5fb9
remove export, no longer needed 19b20f6
untangling a mess   f89fa78
separate exports from logic b6343e2
Strip the _class property declarations, they are debug only 7a48640
Make Space#get_value_distributor not rely on closures …   012585e
Add a root_space to Space and propagate it  3b32790
Why not use the local value?    600d16a
Move the value distributor static stuff to Space    87fb6ec
improve squash and prolongue test   da32bf6
Space#var_names -> #unsolved_var_names and #all_var_names   987f439
~50% perf improvement; dont clone solved vars   f853b55
turn func expr in func decl in dist ee15b1b
Refactor distribution_value_by_min to smaller funcs 008eb44
Refactor Space cloning stuff    dd3348d
Remove dud reject checks    df4be8c
skip solved check if already known, refactor    eeb66d3
return REJECTED early   2551fd7
only test for rejected when something changed   037e371
eliminate unneccessary is_rejected checks, dont change dom if it rejects    329a0fd
disable some legacy tests concerning empty domains in arg   d979b6b
Explicitly check for SOMETHING_CHANGED rather than num of changes    64f4737
