### PR TITLE
Refactor solver

### DIFF
--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -87,9 +87,8 @@ module.exports = (FD) ->
 
     decl: (id, domain) ->
       domain ?= @defaultDomain.slice 0
-      v = @S.decl id, domain
-      v.id = id
-      v
+      @space.decl id, domain
+      return
 
     # Uses @defaultDomain if no domain was given
     # Distribution is optional

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -74,6 +74,9 @@ module.exports = (FD) ->
 
       @state = {@space, more: true}
 
+    # This wasn't a bad idea but the code debt is not worth it
+    # @deprecated
+
     constant: (num) ->
       return @space.decl_value num
 

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -1,16 +1,5 @@
 # Adds FD.Solver to FD.js
 
-_ =
-  e: (e) ->
-    return e.id if e.id?
-    return e
-
-  es: (es) ->
-    vnames = []
-    for v in es
-      vnames.push _.e(v)
-    vnames
-
 module.exports = (FD) ->
 
   {
@@ -25,6 +14,18 @@ module.exports = (FD) ->
   {
     create_custom_distributor
   } = FD.distribution
+
+  get_name = (e) ->
+    if e.id
+      return e.id
+    return e
+
+  get_names = (es) ->
+    var_names = []
+    for e in es
+      var_names.push get_name e
+
+    return var_names
 
   class FD.Solver
 
@@ -130,33 +131,33 @@ module.exports = (FD) ->
     '+': (e1, e2, resultVar) ->
       @plus e1, e2, resultVar
     plus: (e1, e2, resultVar) ->
-      return @S.plus _.e(e1), _.e(e2), _.e(resultVar) if resultVar
-      return @S.plus _.e(e1), _.e(e2)
+      return @S.plus get_name(e1), get_name(e2), get_name(resultVar) if resultVar
+      return @S.plus get_name(e1), get_name(e2)
 
     '*': (e1, e2, resultVar) ->
       @times e1, e2, resultVar
     times: (e1, e2, resultVar) ->
-      return @S.times _.e(e1), _.e(e2), _.e(resultVar) if resultVar
-      return @S.times _.e(e1), _.e(e2)
+      return @S.times get_name(e1), get_name(e2), get_name(resultVar) if resultVar
+      return @S.times get_name(e1), get_name(e2)
 
     '∑': (es, resultVar) ->
       @sum es, resultVar
     #_sumCache: null
     sum: (es, resultVar) ->
-      vnames = _.es es
+      vnames = get_names es
       #@_sumCache ?= {}
       #key = vnames.toString()
       #if @_sumCache[key]?
       #else
       #@_sumCache[key] = true
-      return @S.sum vnames, _.e(resultVar) if resultVar
+      return @S.sum vnames, get_name(resultVar) if resultVar
       return @S.sum vnames
 
     '∏': (es, resultVar) ->
       @product es, resultVar
     product: (es, resultVar) ->
-      vnames = _.es es
-      return @S.product vnames, _.e(resultVar) if resultVar
+      vnames = get_names es
+      return @S.product vnames, get_name(resultVar) if resultVar
       return @S.product vnames
 
     # TODO
@@ -170,7 +171,7 @@ module.exports = (FD) ->
     '{}≠': (es) ->
       @distinct es
     distinct: (es) ->
-      @S.distinct _.es(es)
+      @S.distinct get_names(es)
 
     '==': (e1, e2) ->
       @eq e1, e2
@@ -180,7 +181,7 @@ module.exports = (FD) ->
         @_eq e, e2
       @
     _eq: (e1, e2) ->
-      @S.eq _.e(e1), _.e(e2)
+      @S.eq get_name(e1), get_name(e2)
       @
 
     '!=': (e1, e2) ->
@@ -191,7 +192,7 @@ module.exports = (FD) ->
         @_neq e, e2
       @
     _neq: (e1, e2) ->
-      @S.neq _.e(e1), _.e(e2)
+      @S.neq get_name(e1), get_name(e2)
       @
 
     '>=': (e1, e2) ->
@@ -202,7 +203,7 @@ module.exports = (FD) ->
         @_gte e, e2
       @
     _gte: (e1, e2) ->
-      @S.gte _.e(e1), _.e(e2)
+      @S.gte get_name(e1), get_name(e2)
       @
 
     '<=': (e1, e2) ->
@@ -213,7 +214,7 @@ module.exports = (FD) ->
         @_lte e, e2
       @
     _lte: (e1, e2) ->
-      @S.lte _.e(e1), _.e(e2)
+      @S.lte get_name(e1), get_name(e2)
       @
 
     '>': (e1, e2) ->
@@ -224,7 +225,7 @@ module.exports = (FD) ->
         @_gt e, e2
       @
     _gt: (e1, e2) ->
-      @S.gt _.e(e1), _.e(e2)
+      @S.gt get_name(e1), get_name(e2)
       @
 
     '<': (e1, e2) ->
@@ -235,17 +236,17 @@ module.exports = (FD) ->
         @_lt e, e2
       @
     _lt: (e1, e2) ->
-      @S.lt _.e(e1), _.e(e2)
+      @S.lt get_name(e1), get_name(e2)
       @
 
 
     # Conditions, ie Reified (In)equality Propagators
     _cacheReified: (op, e1, e2, boolvar) ->
-      e1 = _.e(e1)
-      e2 = _.e(e2)
+      e1 = get_name(e1)
+      e2 = get_name(e2)
       key = "#{e1} #{op}? #{e2}"
       if boolvar
-        boolvar = _.e(boolvar)
+        boolvar = get_name(boolvar)
         if !@_cache[key]?
           @S.reified op, e1, e2, boolvar
           @_cache[key] = boolvar
@@ -308,7 +309,7 @@ module.exports = (FD) ->
       vars ?= @vars.all
 
       distributor_options ?= @distribute
-      create_custom_distributor @S, _.es(vars), distributor_options
+      create_custom_distributor @S, get_names(vars), distributor_options
 
       search ?= @search
       searchMethod = FD.search[search]

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -70,7 +70,6 @@ module.exports = (FD) ->
         all:[]
         byClass:{}
 
-      @_cache = {}
       @resetState()
 
     # Variables
@@ -258,20 +257,11 @@ module.exports = (FD) ->
     _cacheReified: (op, e1, e2, boolvar) ->
       e1 = get_name(e1)
       e2 = get_name(e2)
-      key = "#{e1} #{op}? #{e2}"
+
       if boolvar
-        boolvar = get_name(boolvar)
-        if !@_cache[key]?
-          @S.reified op, e1, e2, boolvar
-          @_cache[key] = boolvar
-        else
-          cache = @_cache[key]
-          return cache if cache is boolvar
-          return @S['=='](cache, boolvar)
-        return @
-      else
-        @_cache[key] ?= @S.reified op, e1, e2
-        @_cache[key]
+        return @S.reified op, e1, e2, get_name boolvar
+
+      return @S.reified op, e1, e2
 
     '!=?': (e1, e2, boolvar) ->
       @_cacheReified 'neq', e1, e2, boolvar

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -57,7 +57,7 @@ module.exports = (FD) ->
       @distribute ?= 'naive'
       @defaultDomain ?= domain_create_bool()
 
-      # TOFIX: get rid of this bi-directional dependency
+      # TOFIX: get rid of this bi-directional dependency Space <> Solver
       @space = new Space
       @space.solver = @
 
@@ -65,12 +65,14 @@ module.exports = (FD) ->
       @S = @space
 
       @vars =
-        byId:{}
-        byName:{}
-        all:[]
-        byClass:{}
+        byId: {}
+        byName: {}
+        all: []
+        byClass: {}
 
-      @resetState()
+      @solutions = []
+
+      @state = {@space, more: true}
 
     # Variables
 
@@ -294,15 +296,6 @@ module.exports = (FD) ->
       @_cacheReified 'lt', e1, e2, boolvar
     isLt: (e1, e2, boolvar) ->
       @_cacheReified 'lt', e1, e2, boolvar
-
-
-    # Solving
-
-    resetState: () ->
-      @solutions = []
-      space = @S #new FD.space @S # TODO???
-      @state = {space:space, more:true}
-      @
 
     # If squashed, dont get the actual solutions. They are irrelevant for perf tests.
 

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -3,17 +3,24 @@
 module.exports = (FD) ->
 
   {
+    distribution
+    Domain
+    helpers
+    space: Space
+  } = FD
+
+  {
     ASSERT
     ASSERT_SPACE
-  } = FD.helpers
+  } = helpers
 
   {
     domain_create_bool
-  } = FD.Domain
+  } = Domain
 
   {
     create_custom_distributor
-  } = FD.distribution
+  } = distribution
 
   get_name = (e) ->
     if e.id

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -69,11 +69,7 @@ module.exports = (FD) ->
         all:[]
         byClass:{}
 
-      # TODO
-      # - constants & resetState? eek
-      @_constants = {}
       @_cache = {}
-
       @resetState()
 
     # Variables
@@ -86,11 +82,7 @@ module.exports = (FD) ->
 
 
     constant: (num) ->
-      ASSERT (!isNaN num), 'Solver#constant: num is NaN', num, typeof num
-      num = Number(num)
-      return @_constants[num] if @_constants[num]?
-      @_constants[num] = @S.konst num
-      @_constants[num]
+      return @space.decl_value num
 
     addVars: (vs) ->
       vars = []

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -74,15 +74,6 @@ module.exports = (FD) ->
 
       @state = {@space, more: true}
 
-    # Variables
-
-    valueOf: (varr, solution) ->
-      return solution[varr.id]
-
-    varsByName: (name, context) ->
-      return @vars
-
-
     constant: (num) ->
       return @space.decl_value num
 

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -81,10 +81,9 @@ module.exports = (FD) ->
       return @space.decl_value num
 
     addVars: (vs) ->
-      vars = []
       for v in vs
-        vars.push @addVar v
-      vs
+        @addVar v
+      return
 
     decl: (id, domain) ->
       domain ?= @defaultDomain.slice 0

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -142,161 +142,178 @@ module.exports = (FD) ->
 
       return v
 
+
     # Arithmetic Propagators
 
-    '+': (e1, e2, resultVar) ->
-      @plus e1, e2, resultVar
-    plus: (e1, e2, resultVar) ->
-      return @S.plus get_name(e1), get_name(e2), get_name(resultVar) if resultVar
-      return @S.plus get_name(e1), get_name(e2)
+    '+': (e1, e2, result_var) ->
+      return @plus e1, e2, result_var
+    plus: (e1, e2, result_var) ->
+      if result_var
+        return @space.plus get_name(e1), get_name(e2), get_name(result_var)
+      return @space.plus get_name(e1), get_name(e2)
 
-    '*': (e1, e2, resultVar) ->
-      @times e1, e2, resultVar
-    times: (e1, e2, resultVar) ->
-      return @S.times get_name(e1), get_name(e2), get_name(resultVar) if resultVar
-      return @S.times get_name(e1), get_name(e2)
+    '*': (e1, e2, result_var) ->
+      return @times e1, e2, result_var
+    times: (e1, e2, result_var) ->
+      if result_var
+        return @space.times get_name(e1), get_name(e2), get_name(result_var)
+      return @space.times get_name(e1), get_name(e2)
 
-    '∑': (es, resultVar) ->
-      @sum es, resultVar
+    '∑': (es, result_var) ->
+      return @sum es, result_var
     #_sumCache: null
-    sum: (es, resultVar) ->
-      vnames = get_names es
-      #@_sumCache ?= {}
-      #key = vnames.toString()
-      #if @_sumCache[key]?
-      #else
-      #@_sumCache[key] = true
-      return @S.sum vnames, get_name(resultVar) if resultVar
-      return @S.sum vnames
+    sum: (es, result_var) ->
+      var_names = get_names es
+      if result_var
+        return @space.sum var_names, get_name(result_var)
+      return @space.sum var_names
 
-    '∏': (es, resultVar) ->
-      @product es, resultVar
-    product: (es, resultVar) ->
-      vnames = get_names es
-      return @S.product vnames, get_name(resultVar) if resultVar
-      return @S.product vnames
+    '∏': (es, result_var) ->
+      return @product es, result_var
+    product: (es, result_var) ->
+      var_names = get_names es
+      if result_var
+        return @space.product var_names, get_name(result_var)
+      return @space.product var_names
 
     # TODO
     # times_plus    k1*v1 + k2*v2
     # wsum          ∑ k*v
     # scale         k*v
 
+
     # (In)equality Propagators
     # only first expression can be array
 
     '{}≠': (es) ->
       @distinct es
+      return
     distinct: (es) ->
-      @S.distinct get_names(es)
+      @space.distinct get_names(es)
+      return
 
     '==': (e1, e2) ->
       @eq e1, e2
+      return
     eq: (e1, e2) ->
-      return @_eq(e1, e2) unless e1 instanceof Array
-      for e in e1
-        @_eq e, e2
-      @
+      if e1 instanceof Array
+        for e in e1
+          @_eq e, e2
+      else
+        @_eq e1, e2
+      return
     _eq: (e1, e2) ->
-      @S.eq get_name(e1), get_name(e2)
-      @
+      @space.eq get_name(e1), get_name(e2)
+      return
 
     '!=': (e1, e2) ->
       @neq e1, e2
+      return
     neq: (e1, e2) ->
-      return @_neq(e1, e2) unless e1 instanceof Array
-      for e in e1
-        @_neq e, e2
-      @
+      if e1 instanceof Array
+        for e in e1
+          @_neq e, e2
+      else
+        return @_neq e1, e2
+      return
     _neq: (e1, e2) ->
-      @S.neq get_name(e1), get_name(e2)
-      @
+      @space.neq get_name(e1), get_name(e2)
+      return
 
     '>=': (e1, e2) ->
       @gte e1, e2
+      return
     gte: (e1, e2) ->
-      return @_gte(e1, e2) unless e1 instanceof Array
-      for e in e1
-        @_gte e, e2
-      @
+      if e1 instanceof Array
+        for e in e1
+          @_gte e, e2
+      else
+        @_gte e1, e2
+      return
     _gte: (e1, e2) ->
-      @S.gte get_name(e1), get_name(e2)
-      @
+      @space.gte get_name(e1), get_name(e2)
+      return
 
     '<=': (e1, e2) ->
       @lte e1, e2
+      return
     lte: (e1, e2) ->
-      return @_lte(e1, e2) unless e1 instanceof Array
-      for e in e1
-        @_lte e, e2
-      @
+      if e1 instanceof Array
+        for e in e1
+          @_lte e, e2
+      else
+        @_lte e1, e2
+      return
     _lte: (e1, e2) ->
-      @S.lte get_name(e1), get_name(e2)
-      @
+      @space.lte get_name(e1), get_name(e2)
+      return
 
     '>': (e1, e2) ->
       @gt e1, e2
+      return
     gt: (e1, e2) ->
-      return @_gt(e1, e2) unless e1 instanceof Array
-      for e in e1
-        @_gt e, e2
-      @
+      if e1 instanceof Array
+        for e in e1
+          @_gt e, e2
+      else
+        @_gt e1, e2
+      return
     _gt: (e1, e2) ->
-      @S.gt get_name(e1), get_name(e2)
-      @
+      @space.gt get_name(e1), get_name(e2)
+      return
 
     '<': (e1, e2) ->
       @lt e1, e2
+      return
     lt: (e1, e2) ->
-      return @_lt(e1, e2) unless e1 instanceof Array
-      for e in e1
-        @_lt e, e2
-      @
+      if e1 instanceof Array
+        for e in e1
+          @_lt e, e2
+      else
+        @_lt e1, e2
+      return
     _lt: (e1, e2) ->
-      @S.lt get_name(e1), get_name(e2)
-      @
+      @space.lt get_name(e1), get_name(e2)
+      return
 
 
     # Conditions, ie Reified (In)equality Propagators
     _cacheReified: (op, e1, e2, boolvar) ->
       e1 = get_name(e1)
       e2 = get_name(e2)
-
       if boolvar
-        return @S.reified op, e1, e2, get_name boolvar
-
-      return @S.reified op, e1, e2
+        return @space.reified op, e1, e2, get_name boolvar
+      return @space.reified op, e1, e2
 
     '!=?': (e1, e2, boolvar) ->
-      @_cacheReified 'neq', e1, e2, boolvar
+      return @isNeq e1, e2, boolvar
     isNeq: (e1, e2, boolvar) ->
-      @_cacheReified 'neq', e1, e2, boolvar
+      return @_cacheReified 'neq', e1, e2, boolvar
 
     '==?': (e1, e2, boolvar) ->
-      @_cacheReified 'eq', e1, e2, boolvar
+      return @isEq e1, e2, boolvar
     isEq: (e1, e2, boolvar) ->
-      @_cacheReified 'eq', e1, e2, boolvar
-      #return @S.reified 'eq', _.e(e1), _.e(e2), _.e(boolvar) if boolvar
-      #return @S.reified 'eq', _.e(e1), _.e(e2)
+      return @_cacheReified 'eq', e1, e2, boolvar
 
     '>=?': (e1, e2, boolvar) ->
-      @_cacheReified 'gte', e1, e2, boolvar
+      return @isGte e1, e2, boolvar
     isGte: (e1, e2, boolvar) ->
-      @_cacheReified 'gte', e1, e2, boolvar
+      return @_cacheReified 'gte', e1, e2, boolvar
 
     '<=?': (e1, e2, boolvar) ->
-      @_cacheReified 'lte', e1, e2, boolvar
+      return @isLte e1, e2, boolvar
     isLte: (e1, e2, boolvar) ->
-      @_cacheReified 'lte', e1, e2, boolvar
+      return @_cacheReified 'lte', e1, e2, boolvar
 
     '>?': (e1, e2, boolvar) ->
-      @_cacheReified 'gt', e1, e2, boolvar
+      return @isGt e1, e2, boolvar
     isGt: (e1, e2, boolvar) ->
-      @_cacheReified 'gt', e1, e2, boolvar
+      return @_cacheReified 'gt', e1, e2, boolvar
 
     '<?': (e1, e2, boolvar) ->
-      @_cacheReified 'lt', e1, e2, boolvar
+      return @isLt e1, e2, boolvar
     isLt: (e1, e2, boolvar) ->
-      @_cacheReified 'lt', e1, e2, boolvar
+      return @_cacheReified 'lt', e1, e2, boolvar
 
     # If squashed, dont get the actual solutions. They are irrelevant for perf tests.
 

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -34,19 +34,34 @@ module.exports = (FD) ->
 
     return var_names
 
+  # This is a super class.
+  # It is extended by path_solver and path_binary_solver.
+  #
+  # @constructor
+  # @param {Object} o
+  # @property {string} o.distribute='naive'
+  # @property {string} o.search='depth_first'
+  # @property {number[]} defaultDomain=[0,1]
+
   class FD.Solver
 
     constructor: (o={}) ->
-      {@distribute, @search, @defaultDomain} = o
+      {
+        @distribute
+        @search
+        @defaultDomain
+      } = o
 
       @search ?= 'depth_first'
-
       @distribute ?= 'naive'
-
       @defaultDomain ?= domain_create_bool()
 
-      @S = new FD.space()
-      @S.solver = @
+      # TOFIX: get rid of this bi-directional dependency
+      @space = new Space
+      @space.solver = @
+
+      # TOFIX: deprecate @S in favor of @space
+      @S = @space
 
       @vars =
         byId:{}
@@ -60,7 +75,6 @@ module.exports = (FD) ->
       @_cache = {}
 
       @resetState()
-      @
 
     # Variables
 

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -103,35 +103,44 @@ module.exports = (FD) ->
 
     addVar: (v, domain) ->
       if typeof v is 'string'
-        v = {id:v, domain}
-      {id, domain, name, distribute} = v
-      throw new Error "FD Var requires id " unless id?
-      throw new Error "FDSpace var.id already added: #{id}" if @vars.byId[id]
+        v = {
+          id: v
+          domain
+        }
+
+      {
+        id,
+        domain
+        name
+        distribute
+      } = v
+
+      vars = @vars
+
+      unless id?
+        throw new Error "Solver#addVar: requires id "
+      if vars.byId[id]
+        throw new Error "Solver#addVar: var.id already added: #{id}"
+
       domain ?= @defaultDomain.slice 0
-      @S.decl id, domain
-      @vars.byId[id] = v
-      @vars.all.push v
+      @space.decl id, domain
+      vars.byId[id] = v
+      vars.all.push v
 
       if name?
-        @vars.byName[name] ?= []
-        @vars.byName[name].push v
+        vars.byName[name] ?= []
+        vars.byName[name].push v
 
       if distribute is 'markov'
-        o = v.distributeOptions
-        {matrix} = o
-        throw new Error "markov distribution requires SolverVar #{v} w/ distributeOptions:{matrix:[]}" unless matrix
+        matrix = v.distributeOptions.matrix
+        unless matrix
+          throw new Error "Solver#addVar: markov distribution requires SolverVar #{v} w/ distributeOptions:{matrix:[]}"
         for row in matrix
-          boolean = row.boolean
-          if boolean?
-            if typeof boolean is 'function'
-              row.booleanId = boolean(@,v)
+          bool_func = row.boolean
+          if typeof bool_func is 'function'
+            row.booleanId = bool_func @, v
 
-      # {classes} = v
-      # if classes
-      #   for className in classes
-      #     @vars.byClass[className] ?= []
-      #     @vars.byClass[className].push v
-      v
+      return v
 
     # Arithmetic Propagators
 

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -23,7 +23,8 @@ module.exports = (FD) ->
   } = distribution
 
   get_name = (e) ->
-    if e.id
+    # e can be the empty string (TOFIX: let's not allow this...)
+    if e.id?
       return e.id
     return e
 

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -301,11 +301,11 @@ module.exports = (FD) ->
   # Note: use #num() to give it a name. TODO: combine these funcs to a single func with optional name arg...
 
   Space::decl_value = (val) ->
-    if val >= SUB and val <= SUP # also catches NaN cases
-      return @decl_anon domain_create_value val
+    ASSERT !isNaN(val), 'Space#decl_value: Value is NaN', val
+    ASSERT val >= SUB, 'val must be above minimum value', val
+    ASSERT val <= SUP, 'val must be below max value', val
 
-    ASSERT !isNaN(val), 'FD.space.konst: Value is NaN'
-    ASSERT false, "FD.space.konst: Value out of valid range SUB:#{SUB} <= val:#{val} <= SUP:#{SUP}"
+    return @decl_anon domain_create_value val
 
   # Create N anonymous FD variables and return their names
   # in an array. Optionally set them to given dom for all


### PR DESCRIPTION
Refactors solver.coffee
Mostly adds a lot of explicit returns, fixes some confusing return code, brings code style in sync with the rest, and makes that `_.e` function local so it can be minified properly.

---

rename get_name/s and make them local funcs 0cf00d3
Import stuff the coffee way b260daa
Refactor the constructor    66c401a
deprecated Solver#constant; its a good idea but not worth it    b6a1656
Fix bug where empty string is not accepted as name but a test expects… …    42677c7
Remove reified cache, for now, it seems overengineered  39c8295
Eliminate resetState; it doesnt appear to be used   71736df
Remove unused methods valueOf and varsByName    aca199d
add deprecation comment 7ea9817
I dont think that return value was doing what you think it was doing    e3031d8
Space#decl returns a Space and Solver#decl appears to think it return… …    f532b38
Refactor Solver#addVar  23a183f
Refactor the solver propagators, make returns explicit, use @space over … 9163a4e
Refactor the solve function 21f4506
Refactor Space#decl_value a bit a0d0952
