### PR TITLE
v1.0.2: Improvements to Markov

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ For now, see the extensive [tests](./tests)
 
 ## Version
 
+1.0.2:
+- Added support for `expandVectorsWith` in Markov distribution
+- Added support for `matrix[].row.boolean` to be the name of a variable, rather than the function to return this name, in Markov distributions
+- Deprecating the `Solver.addVar()` option `distribute` in favor of option `distributeOptions.distribution_name`
+- Fix Markov distributed variables being able to end up with invalid values (-> Added a Markov propagator, every Markov var gets one now)
+- Added support for a `timeout_callback` in `Space`, which allows you to abort a search by returning `true` from a given function
+- Add var distributor that prioritizes Markov variables
+- Support var names to be passed on as string rather than a function to return that name, for `matrix.row` in variable distribution options
+- Added `throw` distributors for variables and values which will unconditionally throw when ran. Used for testing.
+- Internal refactoring/restructuring
+
 1.0.1:
 - Support legacy style of domains in Solver, will convert them to a flat array of range pairs
 - Improve input domain detection for early error reporting

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./src/index.coffee",
   "description": "A fast feature rich finite domain solver",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/the-grid/finitedomain.git"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./src/index.coffee",
   "description": "A fast feature rich finite domain solver",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/the-grid/finitedomain.git"

--- a/src/distribution/markov.coffee
+++ b/src/distribution/markov.coffee
@@ -48,7 +48,12 @@ module.exports = (FD) ->
 
   {
     domain_contains_value
+    domain_to_list
   } = FD.Domain
+
+  {
+    fdvar_is_value
+  } = FD.Fdvar
 
   # Given a domain, probability vector, value legend, and rng
   # function; return one of the values in the value legend
@@ -115,6 +120,32 @@ module.exports = (FD) ->
 
     return value_legend[index]
 
+  # If a row has no boolean condition, return it.
+  # If the boolean condition of a row is 1, return it.
+  # If no row meets these conditions, return the last row.
+
+  distribution_markov_get_next_row_to_solve = (space, matrix) ->
+    vars = space.vars
+    for row in matrix
+      bool_var = vars[row.booleanId]
+      if !bool_var or fdvar_is_value bool_var, 1
+        break
+    return row
+
+  distribution_markov_merge_domain_and_legend = (input_legend, domain) ->
+    if input_legend
+      legend = input_legend.slice 0
+    else
+      legend = []
+
+    for val in domain_to_list domain
+      if legend.indexOf(val) < 0
+        legend.push val
+
+    return legend
+
   FD.distribution.Markov = {
+    distribution_markov_get_next_row_to_solve
+    distribution_markov_merge_domain_and_legend
     distribution_markov_sampleNextFromDomain
   }

--- a/src/distribution/markov.coffee
+++ b/src/distribution/markov.coffee
@@ -48,12 +48,7 @@ module.exports = (FD) ->
 
   {
     domain_contains_value
-    domain_to_list
   } = FD.Domain
-
-  {
-    fdvar_is_value
-  } = FD.Fdvar
 
   # Given a domain, probability vector, value legend, and rng
   # function; return one of the values in the value legend
@@ -120,32 +115,6 @@ module.exports = (FD) ->
 
     return value_legend[index]
 
-  # If a row has no boolean condition, return it.
-  # If the boolean condition of a row is 1, return it.
-  # If no row meets these conditions, return the last row.
-
-  distribution_markov_get_next_row_to_solve = (space, matrix) ->
-    vars = space.vars
-    for row in matrix
-      bool_var = vars[row.booleanId]
-      if !bool_var or fdvar_is_value bool_var, 1
-        break
-    return row
-
-  distribution_markov_merge_domain_and_legend = (input_legend, domain) ->
-    if input_legend
-      legend = input_legend.slice 0
-    else
-      legend = []
-
-    for val in domain_to_list domain
-      if legend.indexOf(val) < 0
-        legend.push val
-
-    return legend
-
   FD.distribution.Markov = {
-    distribution_markov_get_next_row_to_solve
-    distribution_markov_merge_domain_and_legend
     distribution_markov_sampleNextFromDomain
   }

--- a/src/distribution/value.coffee
+++ b/src/distribution/value.coffee
@@ -311,7 +311,7 @@ module.exports = (FD) ->
   # @returns {number[]} The new domain this fdvar should get in the next space
 
   distribution_value_by_min_max_cycle = (space, fdvar, choice_index) ->
-    root_space = space.root_space or space
+    root_space = space.get_root()
     if _is_even root_space.all_var_names.indexOf fdvar.id
       return distribution_value_by_min fdvar, choice_index
     else
@@ -337,7 +337,7 @@ module.exports = (FD) ->
       when FIRST_CHOICE
         # THIS IS AN EXPENSIVE STEP!
 
-        root_space = space.root_space or space
+        root_space = space.get_root()
         domain = fdvar.dom
         var_name = fdvar.id
 

--- a/src/distribution/value.coffee
+++ b/src/distribution/value.coffee
@@ -62,9 +62,8 @@ module.exports = (FD) ->
     ASSERT !fdvar_is_rejected(fdvar), 'fdvar should not be rejected', var_name, fdvar.dom, fdvar
 
     # each var can override the value distributor
-    branch_vars_by_id = root_space.solver?.vars?.byId
-    branch_var = branch_vars_by_id?[var_name]
-    value_distributor_name = branch_var?.distribute
+    config_var_dist_options = root_space.config_var_dist_options
+    value_distributor_name = config_var_dist_options[var_name]?.distributor_name
     if value_distributor_name
       config_next_value_func = value_distributor_name
 

--- a/src/distribution/value.coffee
+++ b/src/distribution/value.coffee
@@ -57,12 +57,13 @@ module.exports = (FD) ->
 
     choice_index = space.next_distribution_choice++
     config_next_value_func = root_space.config_next_value_func
+    var_name = fdvar.id
 
-    ASSERT !fdvar_is_rejected(fdvar), 'fdvar should not be rejected', fdvar.id, fdvar.dom, fdvar
+    ASSERT !fdvar_is_rejected(fdvar), 'fdvar should not be rejected', var_name, fdvar.dom, fdvar
 
     # each var can override the value distributor
     branch_vars_by_id = root_space.solver?.vars?.byId
-    branch_var = branch_vars_by_id?[fdvar.id]
+    branch_var = branch_vars_by_id?[var_name]
     value_distributor_name = branch_var?.distribute
     if value_distributor_name
       config_next_value_func = value_distributor_name

--- a/src/distribution/value.coffee
+++ b/src/distribution/value.coffee
@@ -70,7 +70,10 @@ module.exports = (FD) ->
     if typeof config_next_value_func is 'function'
       return config_next_value_func
 
-    switch config_next_value_func
+    return _distribute_get_next_domain_for_var config_next_value_func, space, root_space, fdvar, choice_index
+
+  _distribute_get_next_domain_for_var = (value_func_name, space, root_space, fdvar, choice_index) ->
+    switch value_func_name
       when 'max'
         return distribution_value_by_max fdvar, choice_index
       when 'markov'
@@ -89,6 +92,8 @@ module.exports = (FD) ->
         return distribution_value_by_split_max fdvar, choice_index
       when 'splitMin'
         return distribution_value_by_split_min fdvar, choice_index
+      when 'throw'
+        ASSERT false, 'not expecting to pick this distributor'
 
     THROW 'unknown next var func', config_next_value_func
     return
@@ -410,4 +415,5 @@ module.exports = (FD) ->
     _distribution_value_by_min_max_cycle: distribution_value_by_min_max_cycle
     _distribution_value_by_split_max: distribution_value_by_split_max
     _distribution_value_by_split_min: distribution_value_by_split_min
+    _distribute_get_next_domain_for_var
   }

--- a/src/distribution/var.coffee
+++ b/src/distribution/var.coffee
@@ -1,6 +1,7 @@
 module.exports = (FD) ->
 
   {
+    ASSERT
     THROW
   } = FD.helpers
 
@@ -36,6 +37,8 @@ module.exports = (FD) ->
         is_better_var = by_min
       when 'max'
         is_better_var = by_max
+      when 'throw'
+        ASSERT false, 'not expecting to pick this distributor'
       else
         THROW 'unknown next var func', config_next_var_func
 

--- a/src/distribution/var.coffee
+++ b/src/distribution/var.coffee
@@ -39,6 +39,8 @@ module.exports = (FD) ->
         is_better_var = by_max
       when 'throw'
         ASSERT false, 'not expecting to pick this distributor'
+      when 'markov'
+        is_better_var = by_markov
       else
         THROW 'unknown next var func', config_next_var_func
 
@@ -50,7 +52,7 @@ module.exports = (FD) ->
         else
           THROW 'unknown var filter', config_var_filter
 
-    return find_best fdvars, target_vars, is_better_var, config_var_filter
+    return find_best fdvars, target_vars, is_better_var, config_var_filter, root_space
 
   # Return the best var name according to a fitness function
   # but only if the filter function is okay with it.
@@ -59,14 +61,15 @@ module.exports = (FD) ->
   # @param {string[]} names A subset of names that are properties on fdvars
   # @param {Function(fdvar,fdvar)} [fitness_func] Given two fdvars returns true iif the first var is better than the second var
   # @param {Function(fdvar)} [filter_func] If given only consider vars where this function returns true
+  # @param {Space} root_space
   # @returns {Fdvar}
 
-  find_best = (fdvars, names, fitness_func, filter_func) ->
+  find_best = (fdvars, names, fitness_func, filter_func, root_space) ->
     best = ''
     for name, i in names
       fdvar = fdvars[name]
       # TOFIX: if the name is the empty string this could lead to a problem. Must eliminate the empty string as var name
-      if (!filter_func or filter_func fdvar) and (!best or (fitness_func and fitness_func fdvar, best))
+      if (!filter_func or filter_func fdvar) and (!best or (fitness_func and fitness_func fdvar, best, root_space))
         best = fdvar
     return best
 
@@ -82,6 +85,10 @@ module.exports = (FD) ->
 
   by_max = (v1, v2) ->
     return fdvar_upper_bound(v1) > fdvar_upper_bound(v2)
+
+  by_markov = (v1, v2, root_space) ->
+    # v1 is only, but if so always, better than v2 if v1 is a markov var
+    return root_space.config_var_dist_options[v1.id]?.distributor_name is 'markov'
 
   FD.distribution.var = {
     distribution_get_next_var

--- a/src/domain.coffee
+++ b/src/domain.coffee
@@ -873,6 +873,7 @@ module.exports = (FD) ->
     return
 
   domain_remove_value_inline = (domain, value) ->
+    ASSERT typeof value is 'number', 'value should be a num', value
     for lo, index in domain by PAIR_SIZE
       hi = domain[index+1]
       if value >= lo and value <= hi

--- a/src/fdvar.coffee
+++ b/src/fdvar.coffee
@@ -22,6 +22,7 @@ module.exports = (FD) ->
     domain_is_determined
     domain_is_rejected
     domain_is_solved
+    domain_is_value
     domain_max
     domain_middle_element
     domain_min
@@ -71,7 +72,7 @@ module.exports = (FD) ->
     return domain_is_solved fdvar.dom
 
   # Is given var [value, value] ?
-  fdvar_is_value = (fdvar) ->
+  fdvar_is_value = (fdvar, value) ->
     return domain_is_value fdvar.dom, value
 
   # A var is rejected if its domain is empty. This means none of the

--- a/src/fdvar.coffee
+++ b/src/fdvar.coffee
@@ -70,6 +70,10 @@ module.exports = (FD) ->
   fdvar_is_solved = (fdvar) ->
     return domain_is_solved fdvar.dom
 
+  # Is given var [value, value] ?
+  fdvar_is_value = (fdvar) ->
+    return domain_is_value fdvar.dom, value
+
   # A var is rejected if its domain is empty. This means none of the
   # possible values for this var could satisfy all the constraints.
 
@@ -188,6 +192,7 @@ module.exports = (FD) ->
     fdvar_is_rejected
     fdvar_is_solved
     fdvar_is_undetermined
+    fdvar_is_value
     fdvar_upper_bound
     fdvar_middle_element
     fdvar_lower_bound

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -56,7 +56,7 @@ module.exports = (FD) ->
   # Should be removed in production. Obviously.
 
   ASSERT_DOMAIN = (domain) ->
-    if !ENABLED and !ENABLE_DOMAIN_CHECK
+    unless ENABLED and ENABLE_DOMAIN_CHECK
       return
 
     ASSERT !!domain, 'domains should be an array', domain
@@ -80,7 +80,7 @@ module.exports = (FD) ->
   # are "fresh", and at least not in use by any fdvar yet
 
   ASSERT_UNUSED_DOMAIN = (domain) ->
-    if !ENABLED and !ENABLE_DOMAIN_CHECK
+    unless ENABLED and ENABLE_DOMAIN_CHECK
       return
 
     # Note: if this expando is blowing up your test, make sure to include fixtures/helpers.spec.coffee in your test file!
@@ -89,7 +89,7 @@ module.exports = (FD) ->
     return
 
   ASSERT_VARS = (vars) ->
-    if !ENABLED
+    unless ENABLED
       return
 
     for name, fdvar of vars
@@ -97,7 +97,7 @@ module.exports = (FD) ->
     return
 
   ASSERT_SPACE = (space) ->
-    if !ENABLED
+    unless ENABLED
       return
 
     # TBD: expand with other assertions...
@@ -105,7 +105,7 @@ module.exports = (FD) ->
     return
 
   ASSERT_PROPAGATORS = (propagators) ->
-    if !ENABLED
+    unless ENABLED
       return
 
     ASSERT !!propagators, 'propagators should exist', propagators
@@ -114,7 +114,7 @@ module.exports = (FD) ->
     return
 
   ASSERT_PROPAGATOR = (propagator) ->
-    if !ENABLED
+    unless ENABLED
       return
 
     ASSERT !!propagator, 'propagators should not be sparse', propagator
@@ -129,7 +129,7 @@ module.exports = (FD) ->
     return
 
   ASSERT_DOMAIN_EMPTY_SET = (domain) ->
-    if !ENABLED and !ENABLE_EMPTY_CHECK
+    unless ENABLED and ENABLE_EMPTY_CHECK
       return
 
     if domain._trace
@@ -139,7 +139,7 @@ module.exports = (FD) ->
     return
 
   ASSERT_DOMAIN_EMPTY_CHECK = (domain) ->
-    if !ENABLED
+    unless ENABLED
       return
 
     unless domain.length
@@ -152,7 +152,7 @@ module.exports = (FD) ->
     return
 
   ASSERT_DOMAIN_EMPTY_SET_OR_CHECK = (domain) ->
-    if !ENABLED
+    unless ENABLED
       return
 
     if domain.length

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -43,7 +43,12 @@ module.exports = (FD) ->
       console.log 'Error args:', args
     #      console.trace()
     #      process.exit() # uncomment for quick error access :)
-    THROW "Assertion fail: #{msg}#{((args.length and (" Args (#{args.length}x): [#{_stringify(args).join ', '}]")) or '')}"
+
+    suffix = ''
+    if args?.length
+      suffix = " Args (#{args.length}x): [#{_stringify(args).join ', '}]"
+
+    THROW "Assertion fail: #{msg}#{suffix}"
     return
 
   _stringify = (o) ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -133,7 +133,7 @@ module.exports = (FD) ->
       return
 
     if domain._trace
-      throw new Error 'Domain already marked as set to empty...: ' + domain._trace
+      THROW 'Domain already marked as set to empty...: ' + domain._trace
     # Note: if this expando is blowing up your test, make sure to include fixtures/helpers.spec.coffee in your test file!
     domain._trace = new Error().stack
     return
@@ -145,9 +145,9 @@ module.exports = (FD) ->
     unless domain.length
       if ENABLE_EMPTY_CHECK
         if domain._trace
-          throw new Error 'Domain should not be empty but was set empty at: ' + domain._trace
-        throw new Error 'Domain should not be empty but was set empty at an untrapped point (investigate!)'
-      throw new Error 'Domain should not be empty but was set empty (ASSERT_DOMAIN_EMPTY_CHECK is disabled so no trace)'
+          THROW 'Domain should not be empty but was set empty at: ' + domain._trace
+        THROW 'Domain should not be empty but was set empty at an untrapped point (investigate!)'
+      THROW 'Domain should not be empty but was set empty (ASSERT_DOMAIN_EMPTY_CHECK is disabled so no trace)'
     ASSERT_DOMAIN domain
     return
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -11,6 +11,7 @@ require('./domain')(FD)
 # core API
 require('./fdvar')(FD)
 require('./bvar')(FD)
+require('./markov')(FD)
 require('./propagators/eq')(FD)
 require('./propagators/neq')(FD)
 require('./propagators/lt')(FD)
@@ -21,6 +22,7 @@ require('./propagators/callback')(FD)
 require('./propagators/scale_div')(FD)
 require('./propagators/scale_mul')(FD)
 require('./propagators/ring')(FD)
+require('./propagators/markov')(FD)
 require('./propagators/stepper_any')(FD) # should be last of the props
 require('./propagators/prop_is_solved')(FD) # should be last of the props
 require('./distribution/markov')(FD)

--- a/src/markov.coffee
+++ b/src/markov.coffee
@@ -1,0 +1,63 @@
+# markov helper functions
+
+module.exports = (FD) ->
+
+  {
+    domain_to_list
+  } = FD.Domain
+
+  {
+    fdvar_is_value
+  } = FD.Fdvar
+
+  # If a row has no boolean condition, return it.
+  # If the boolean condition of a row is 1, return it.
+  # If no row meets these conditions, return the last row.
+
+  markov_get_next_row_to_solve = (space, matrix) ->
+    vars = space.vars
+    for row in matrix
+      bool_var = vars[row.booleanId]
+      if !bool_var or fdvar_is_value bool_var, 1
+        break
+    return row
+
+  markov_create_legend = (merge, input_legend, domain) ->
+    if merge
+      return markov_merge_domain_and_legend input_legend, domain
+    return input_legend
+
+  markov_merge_domain_and_legend = (input_legend, domain) ->
+    if input_legend
+      legend = input_legend.slice 0
+    else
+      legend = []
+
+    for val in domain_to_list domain
+      if legend.indexOf(val) < 0
+        legend.push val
+
+    return legend
+
+  markov_create_prob_vector = (space, matrix, expand_vectors_with, value_count) ->
+    row = markov_get_next_row_to_solve space, matrix
+
+    if expand_vectors_with? # could be 0
+      prob_vector = row.vector and row.vector.slice(0) or []
+      delta = value_count - prob_vector.length
+      if delta > 0
+        for [0...delta]
+          prob_vector.push expand_vectors_with
+      return prob_vector
+
+    prob_vector = row.vector
+    unless prob_vector
+      THROW "distribution_value_by_markov error, each markov var must have a prob vector or use `expandVectorsWith:{Number}`"
+    if prob_vector.length isnt value_count
+      THROW "distribution_value_by_markov error, vector must be same length of legend or use `expandVectorsWith:{Number}`"
+    return prob_vector
+
+  FD.Markov = {
+    markov_create_legend
+    markov_create_prob_vector
+  }

--- a/src/path_solver.coffee
+++ b/src/path_solver.coffee
@@ -55,7 +55,9 @@ module.exports = (FD) ->
         if solution_value isnt 0
           branch_var = bvars_by_id[var_id]
           if branch_var
-            path[branch_var.branchId] = find_path_for_val_or_throw branch_var.pathMeta, solution_value
+            path_name = find_path_for_val_or_throw branch_var.pathMeta, solution_value
+            if path_name?
+              path[branch_var.branchId] = path_name
       return path
 
     find_path_for_val_or_throw = (path_meta, value) ->

--- a/src/path_solver.coffee
+++ b/src/path_solver.coffee
@@ -43,6 +43,8 @@ module.exports = (FD) ->
     constructor: ({rawtree}, o = {}) ->
       super
 
+      @_class = 'path_solver'
+
       @root_branch_name = rawtree.branchName
 
       @vars.root = undefined # initialized by compile_tree

--- a/src/path_solver.coffee
+++ b/src/path_solver.coffee
@@ -56,7 +56,7 @@ module.exports = (FD) ->
           branch_var = bvars_by_id[var_id]
           if branch_var
             path_name = find_path_for_val_or_throw branch_var.pathMeta, solution_value
-            if path_name?
+            if path_name isnt false
               path[branch_var.branchId] = path_name
       return path
 
@@ -64,9 +64,7 @@ module.exports = (FD) ->
       for path_name, meta of path_meta
         if meta.value is value
           return path_name
-
-      THROW "solution to Path error"
-      return
+      return false
 
     # walk the whole tree from this node downward
     # walks in depth first search order

--- a/src/propagators/markov.coffee
+++ b/src/propagators/markov.coffee
@@ -31,7 +31,7 @@ module.exports = (FD) ->
 
     ASSERT typeof var_name is 'string', 'arg should be a string', var_name
 
-    root_space = space.root_space or space
+    root_space = space.get_root()
     fdvar = space.vars[var_name]
 
     unless fdvar_is_solved fdvar
@@ -45,7 +45,6 @@ module.exports = (FD) ->
     ASSERT distribution_options, 'var should have a config', var_name, distribution_options or JSON.stringify config_var_dist_options
     ASSERT distribution_options.distributor_name is 'markov', 'var should be a markov var', distribution_options.distributor_name
 
-    root_space = space.root_space or space
     domain = fdvar.dom
     var_name = fdvar.id
 

--- a/src/propagators/markov.coffee
+++ b/src/propagators/markov.coffee
@@ -1,0 +1,65 @@
+module.exports = (FD) ->
+  {
+    ASSERT
+
+    REJECTED
+    ZERO_CHANGES
+  } = FD.helpers
+
+  {
+    fdvar_is_solved
+    fdvar_lower_bound
+  } = FD.Fdvar
+
+  {
+    markov_create_legend
+    markov_create_prob_vector
+  } = FD.Markov
+
+  # Markov uses a special system for trying values. The domain doesn't
+  # govern the list of possible values, only acts as a mask for the
+  # current node in the search tree (-> space). But since FD will work
+  # based on this domain anyways we will need this extra step to verify
+  # whether a solved var is solved to a valid value in current context.
+  #
+  # Return REJECTED if that is the value is invalid, else ZERO_CHANGES.
+  # Every markov variable should have a propagator. Perhaps later
+  # there can be one markov propagator that checks all markov vars.
+
+  markov_step_bare = (space, var_name) ->
+    # THIS IS VERY EXPENSIVE IF expand_vectors_with IS ENABLED
+
+    ASSERT typeof var_name is 'string', 'arg should be a string', var_name
+
+    root_space = space.root_space or space
+    fdvar = space.vars[var_name]
+
+    unless fdvar_is_solved fdvar
+      return ZERO_CHANGES
+
+    value = fdvar_lower_bound fdvar # note: solved so lo=hi=value
+
+    config_var_dist_options = root_space.config_var_dist_options
+    distribution_options = config_var_dist_options[var_name]
+
+    ASSERT distribution_options, 'var should have a config', var_name, distribution_options or JSON.stringify config_var_dist_options
+    ASSERT distribution_options.distributor_name is 'markov', 'var should be a markov var', distribution_options.distributor_name
+
+    root_space = space.root_space or space
+    domain = fdvar.dom
+    var_name = fdvar.id
+
+    expand_vectors_with = distribution_options.expandVectorsWith
+    ASSERT distribution_options.matrix, 'there should be a matrix available for every var', distribution_options.matrix or JSON.stringify(fdvar), distribution_options.matrix or JSON.stringify distribution_options
+    ASSERT distribution_options.legend or expand_vectors_with?, 'every var should have a legend or expand_vectors_with set', distribution_options.legend or expand_vectors_with? or JSON.stringify(fdvar), distribution_options.legend or expand_vectors_with? or JSON.stringify distribution_options
+
+    # note: expand_vectors_with can be 0, so check with ?
+    values = markov_create_legend expand_vectors_with?, distribution_options.legend, domain
+    probabilities = markov_create_prob_vector space, distribution_options.matrix, expand_vectors_with, values.length
+
+    pos = values.indexOf value
+    if pos >= 0 and pos < probabilities.length and probabilities[pos] isnt 0
+      return ZERO_CHANGES
+    return REJECTED
+
+  FD.propagators.markov_step_bare = markov_step_bare

--- a/src/propagators/prop_is_solved.coffee
+++ b/src/propagators/prop_is_solved.coffee
@@ -53,6 +53,10 @@ module.exports = (FD) ->
         # (maybe we do want to ditch it if its argument vars are solved?)
         return false
 
+      when 'markov'
+        # markov doesnt reduce the domain, only validates (in the propagator, not here)
+        return false
+
       else
         return comparison_is_solved op_name, v1, v2
 

--- a/src/propagators/stepper_any.coffee
+++ b/src/propagators/stepper_any.coffee
@@ -17,6 +17,7 @@ module.exports = (FD) ->
     mul_step_bare
     div_step_bare
     callback_step_bare
+    markov_step_bare
     reified_step_bare
     ring_step_bare
     step_comparison
@@ -65,6 +66,9 @@ module.exports = (FD) ->
       when 'ring'
         return _ring space, vn1, vn2, prop_var_names, prop_datails
 
+      when 'markov'
+        return _markov space, vn1
+
       else
         THROW 'unsupported propagator: [' + prop_datails + ']'
 
@@ -103,6 +107,9 @@ module.exports = (FD) ->
         ASSERT false, 'UNKNOWN ring opname', op_name
 
     return
+
+  _markov = (space, vn1) ->
+    return markov_step_bare space, vn1
 
   FD.propagators.step_any = stepper_prop_step
 

--- a/src/propagators/stepper_any.coffee
+++ b/src/propagators/stepper_any.coffee
@@ -19,10 +19,6 @@ module.exports = (FD) ->
     callback_step_bare
     reified_step_bare
     ring_step_bare
-    lt_step_bare
-    lte_step_bare
-    eq_step_bare
-    neq_step_bare
     step_comparison
   } = FD.propagators
 

--- a/src/propagators/stepper_comparison.coffee
+++ b/src/propagators/stepper_comparison.coffee
@@ -20,9 +20,10 @@ module.exports = (FD) ->
     lte_step_bare
     eq_step_bare
     neq_step_bare
+    distinct_step_bare
   } = FD.propagators
 
-  stepper_step_comparison = (space, op_name, var_name_1, var_name_2) ->
+  step_comparison = (space, op_name, var_name_1, var_name_2) ->
     v1 = space.vars[var_name_1]
     v2 = space.vars[var_name_2]
 
@@ -35,11 +36,11 @@ module.exports = (FD) ->
 
       when 'gt'
       # TOFIX: should go to lte
-        return stepper_step_comparison space, 'lt', var_name_2, var_name_1
+        return step_comparison space, 'lt', var_name_2, var_name_1
 
       when 'gte'
       # TOFIX: should go to lt
-        return stepper_step_comparison space, 'lte', var_name_2, var_name_1
+        return step_comparison space, 'lte', var_name_2, var_name_1
 
       when 'eq'
         return eq_step_bare v1, v2
@@ -78,6 +79,6 @@ module.exports = (FD) ->
         THROW 'stepper_step_read_only: unsupported propagator: [' + op_name + ']'
         return
 
-  FD.propagators.step_comparison = stepper_step_comparison
+  FD.propagators.step_comparison = step_comparison
   FD.propagators.step_would_reject = step_would_reject
 

--- a/src/propagators/stepper_comparison.coffee
+++ b/src/propagators/stepper_comparison.coffee
@@ -20,7 +20,6 @@ module.exports = (FD) ->
     lte_step_bare
     eq_step_bare
     neq_step_bare
-    distinct_step_bare
   } = FD.propagators
 
   step_comparison = (space, op_name, var_name_1, var_name_2) ->

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -60,6 +60,7 @@ module.exports = (FD) ->
         on_reject state, space, stack
 
       else if space.is_solved space
+        # TOFIX: the "next" space is not made now, so if search continues does it do so properly?
         on_solve state, space, stack
         return
 
@@ -92,7 +93,7 @@ module.exports = (FD) ->
 
   default_space_factory = (space) ->
     # all config should be read from root. sub-nodes dont clone this data
-    root_space = space.root_space or space
+    root_space = space.get_root()
 
     target_vars = _get_vars_unfiltered root_space, space
     fdvar = distribution_get_next_var root_space, space, target_vars

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -14,6 +14,7 @@ module.exports = (FD) ->
     SUB
     SUP
 
+    ASSERT
     ASSERT_SPACE
     THROW
   } = helpers
@@ -110,6 +111,7 @@ module.exports = (FD) ->
       return @space.decl_value num
 
     addVars: (vs) ->
+      ASSERT vs instanceof Array, 'Expecting array', vs
       for v in vs
         @addVar v
       return
@@ -132,6 +134,7 @@ module.exports = (FD) ->
     # S.addVar {id: 'foo', domain: [1, 2], distribution: 'markov'}
 
     addVar: (v, dom) ->
+      ASSERT !(v instanceof Array), 'Not expecting to receive an array', v
       if typeof v is 'string'
         v = {
           id: v
@@ -166,7 +169,10 @@ module.exports = (FD) ->
       if distribute is 'markov'
         matrix = v.distributeOptions.matrix
         unless matrix
-          THROW "Solver#addVar: markov distribution requires SolverVar #{v} w/ distributeOptions:{matrix:[]}"
+          if v.distributeOptions.expandVectorsWith
+            matrix = v.distributeOptions.matrix = [vector: []]
+          else
+            THROW "Solver#addVar: markov distribution requires SolverVar #{JSON.stringify v} w/ distributeOptions:{matrix:[]}"
         for row in matrix
           bool_func = row.boolean
           if typeof bool_func is 'function'

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -172,7 +172,7 @@ module.exports = (FD) ->
         vars.byName[name] ?= []
         vars.byName[name].push v
 
-      if distribute is 'markov'
+      if distribute is 'markov' or (v.distributeOptions and v.distributeOptions.distributor_name is 'markov')
         matrix = v.distributeOptions.matrix
         unless matrix
           if v.distributeOptions.expandVectorsWith
@@ -437,7 +437,7 @@ module.exports = (FD) ->
     # @param {boolean} squash If squashed, dont get the actual solutions. They are irrelevant for perf tests.
 
     solve: (options, squash) ->
-      obj = @prepare options, squash
+      obj = @prepare options
       ASSERT !options?.dbg or !console.log @state.space.__debug_string()
       @run obj
       return @solutions

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -54,6 +54,8 @@ module.exports = (FD) ->
     # @property {Object} [o.searchDefaults]
 
     constructor: (o={}) ->
+      @_class = 'solver'
+
       {
         @distribute
         @search

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -183,6 +183,10 @@ module.exports = (FD) ->
           bool_func = row.boolean
           if typeof bool_func is 'function'
             row.booleanId = bool_func @, v
+          else if typeof bool_func is 'string'
+            row.booleanId = bool_func # only considers a row if the var is solved to 1
+          else
+            ASSERT !bool_func, 'row.boolean should be a function returning a var name or just a var name'
 
       return v
 

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -438,7 +438,7 @@ module.exports = (FD) ->
 
     solve: (options, squash) ->
       obj = @prepare options, squash
-      #console.log obj.state.space.__debug_string()
+      ASSERT !options?.dbg or !console.log @state.space.__debug_string()
       @run obj
       return @solutions
 
@@ -540,6 +540,7 @@ module.exports = (FD) ->
           overrides[name] ?= {}
           for key, val of dist_opts
             overrides[name][key] = val
+        # TOFIX: change upstreams to put this override in the config as well instead of directly on the bvar
         if bvar?.distribute
           overrides ?= {}
           overrides[name] ?= {}

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -72,10 +72,7 @@ module.exports = (FD) ->
       @distribute ?= 'naive'
       @defaultDomain ?= domain_create_bool()
 
-      # TOFIX: get rid of this bi-directional dependency Space <> Solver
       @space = new Space
-      @space.solver = @
-
       # TOFIX: deprecate @S in favor of @space
       @S = @space
 
@@ -543,5 +540,9 @@ module.exports = (FD) ->
           overrides[name] ?= {}
           for key, val of dist_opts
             overrides[name][key] = val
+        if bvar?.distribute
+          overrides ?= {}
+          overrides[name] ?= {}
+          overrides[name].distributor_name = bvar.distribute
 
       return overrides

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -466,7 +466,7 @@ module.exports = (FD) ->
       var_names = get_names bvars
       distribution_options ?= @distribute # TOFIX: this is weird. if @distribute is a string this wont do anything...
 
-      overrides = collect_distribution_overrides var_names, @vars.byId
+      overrides = collect_distribution_overrides var_names, @vars.byId, @space
       if overrides
         @space.set_options var_dist_config: overrides
 
@@ -535,7 +535,7 @@ module.exports = (FD) ->
     # @param {Object} bvars_by_id Maps var names to their Bvar
     # @returns {Object|null} Contains data for each var that has dist options
 
-    collect_distribution_overrides = (var_names, bvars_by_id) ->
+    collect_distribution_overrides = (var_names, bvars_by_id, root_space) ->
       overrides = null
       for name in var_names
         bvar = bvars_by_id[name]
@@ -549,5 +549,9 @@ module.exports = (FD) ->
           overrides ?= {}
           overrides[name] ?= {}
           overrides[name].distributor_name = bvar.distribute
+
+        # add a markov verifier propagator for each markov var
+        if overrides?[name]?.distributor_name is 'markov'
+          root_space._propagators.push ['markov', [name]]
 
       return overrides

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -189,8 +189,8 @@ module.exports = (FD) ->
       if msg = _confirm_domain domain
         fixed_domain = _try_to_fix_legacy_domain domain
         if fixed_domain
-          if console?.warn
-            console.warn msg, domain, 'auto-converted to', fixed_domain
+#          if console?.warn
+#            console.warn msg, domain, 'auto-converted to', fixed_domain
         else
           if console?.warn
             console.warn msg, domain, 'unable to fix'
@@ -501,7 +501,11 @@ module.exports = (FD) ->
     collect_distribution_overrides = (var_names, bvars_by_id) ->
       overrides = null
       for name in var_names
-        if dist_opts = bvars_by_id[name]?.distributeOptions
+        bvar = bvars_by_id[name]
+        if dist_opts = bvar?.distributeOptions
           overrides ?= {}
-          overrides[name] = dist_opts
+          overrides[name] ?= {}
+          for key, val of dist_opts
+            overrides[name][key] = val
+
       return overrides

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -208,8 +208,8 @@ module.exports = (FD) ->
       fdvar = vars[name]
       ASSERT !fdvar.was_solved, 'should not be set yet at this stage' # we may change this though...
       ASSERT_DOMAIN fdvar.dom, 'is_solved extra domain validation check'
+
       if fdvar_is_solved fdvar
-        ASSERT !fdvar.was_solved, 'should not have been marked as solved yet'
         fdvar.was_solved = true # makes Space#clone faster
       else
         unsolved_names[j++] = name
@@ -792,7 +792,7 @@ module.exports = (FD) ->
 
         if c[0] is 'reified'
           things.push "  #{c[0]}: '#{c[2]}', '#{c[1].join '\', \''}' \# [#{vars[c[1][0]].dom}] #{c[2]} [#{vars[c[1][1]].dom}] -> [#{vars[c[1][2]].dom}] | solved: #{solved}"
-        if c[0] is 'ring'
+        else if c[0] is 'ring'
           things.push "  #{c[0]}: '#{c[2]}', '#{c[1].join '\', \''}' \# [#{vars[c[1][0]].dom}] #{c[2]} [#{vars[c[1][1]].dom}] -> [#{vars[c[1][2]].dom}] | solved: #{solved}"
         else
           things.push "  #{c[0]} '#{c[1].join ', '}' \# [#{vars[c[1][0]].dom}] #{c[0]} [#{vars[c[1][1]].dom}] | solved: #{solved}"

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -429,8 +429,8 @@ module.exports = (FD) ->
   # Greater than propagator.
 
   Space::gt = (v1name, v2name) ->
-    # _swap_ v1 and v2 because: a>b is b<=a
-    return add_lte @, v2name, v1name
+    # _swap_ v1 and v2 because: a>b is b<a
+    return add_lt @, v2name, v1name
 
   # Less than or equal to propagator.
 
@@ -440,8 +440,7 @@ module.exports = (FD) ->
   # Greater than or equal to.
 
   Space::gte = (v1name, v2name) ->
-    # TODO: fix this as per https://github.com/srikumarks/FD.js/issues/6
-    # _swap_ v1 and v2 because: a>=b is b<a
+    # _swap_ v1 and v2 because: a>b is b<a
     return add_lte @, v2name, v1name
 
   # Ensures that the two variables take on different values.

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -172,11 +172,12 @@ module.exports = (FD) ->
         n = step_any prop_details, @ # TODO: if we can get a "solved" state here we can prevent an "is_solved" check later...
 
         # the domain of either var of a propagator can only be empty if the prop REJECTED
-        ASSERT n is REJECTED or (@.vars[prop_details[1][0]].dom.length and @.vars[prop_details[1][1]].dom.length), 'prop var empty but it didnt REJECT'
+        ASSERT n is REJECTED or @.vars[prop_details[1][0]].dom.length, 'prop var empty but it didnt REJECT'
+        ASSERT n is REJECTED or !prop_details[1][1] or @.vars[prop_details[1][1]].dom.length, 'prop var empty but it didnt REJECT'
         # if a domain was set empty and the flag is on the property should be set or
         # the unit test setup is unsound and it should be fixed (ASSERT_DOMAIN_EMPTY_SET)
         ASSERT !ENABLED or !ENABLE_EMPTY_CHECK or @.vars[prop_details[1][0]].dom.length or @.vars[prop_details[1][0]].dom._trace, 'domain empty but not marked'
-        ASSERT !ENABLED or !ENABLE_EMPTY_CHECK or @.vars[prop_details[1][1]].dom.length or @.vars[prop_details[1][1]].dom._trace, 'domain empty but not marked'
+        ASSERT !ENABLED or !ENABLE_EMPTY_CHECK or !prop_details[1][1] or @.vars[prop_details[1][1]].dom.length or @.vars[prop_details[1][1]].dom._trace, 'domain empty but not marked'
 
         if n is SOMETHING_CHANGED
           changed = true

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -57,7 +57,6 @@ module.exports = (FD) ->
 
     # used from Search
     @next_distribution_choice = 0
-    @solver = undefined # see clone
 
     # these configs are only read from the root_space
     @config_var_filter_func = 'unsolved'
@@ -99,9 +98,6 @@ module.exports = (FD) ->
     pseudo_clone_vars all_names, @vars, clone_vars, unsolved_names
     clone = space_new root, unsolved_propagators, clone_vars, all_names, unsolved_names
 
-    # D4:
-    # - add ref to high level solver
-    clone.solver = @solver if @solver
     return clone
 
   # Return best var according to some fitness function `is_better_var`

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -717,29 +717,32 @@ module.exports = (FD) ->
 
     things = ['Config:']
 
-    things.push '- config_var_filter_func:' + @config_var_filter_func
-    things.push '- config_next_var_func:' + @config_next_var_func
-    things.push '- config_next_value_func:' + @config_next_value_func
-    things.push '- config_targeted_vars:' + @config_targeted_vars
-    things.push '- config_when_solved:' + @config_when_solved
+    things.push '- config_var_filter_func: ' + @config_var_filter_func
+    things.push '- config_next_var_func: ' + @config_next_var_func
+    things.push '- config_next_value_func: ' + @config_next_value_func
+    things.push '- config_targeted_vars: ' + @config_targeted_vars
+    things.push '- config_when_solved: ' + @config_when_solved
 
-    things.push 'Vars:'
+    things.push "Vars (#{@all_var_names.length}x):"
 
-    for name of @vars
-      things.push '  '+name+': ['+@vars[name].dom.join(', ')+']'
+    vars = @vars
+    for name of vars
+      things.push '  '+name+': ['+vars[name].dom.join(', ')+']'
 
-    things.push 'Var names:'
-    things.push @all_var_names
-    things.push 'Unsolved vars:'
-    things.push @unsolved_var_names
+    things.push "Var (#{@all_var_names.length}x):"
+    things.push '  ' + @all_var_names
+    things.push "Unsolved vars (#{@unsolved_var_names.length}x):"
+    things.push '  ' + @unsolved_var_names
 
-    things.push 'Propagators:'
+    things.push "Propagators (#{@_propagators.length}x):"
 
     @_propagators.forEach (c) ->
       if c[0] is 'reified'
-        things.push '  '+c[0]+': \''+c[2]+'\', \''+c[1].join('\', \'')+'\''
+        things.push "  #{c[0]}: '#{c[2]}', '#{c[1].join '\', \''}' \# [#{vars[c[1][0]].dom}] #{c[2]} [#{vars[c[1][1]].dom}] -> [#{vars[c[1][2]].dom}]"
+      if c[0] is 'ring'
+        things.push "  #{c[0]}: '#{c[2]}', '#{c[1].join '\', \''}' \# [#{vars[c[1][0]].dom}] #{c[2]} [#{vars[c[1][1]].dom}] -> [#{vars[c[1][2]].dom}]"
       else
-        things.push '  '+c[0]+' \''+c[1].join('\', \'')+'\''
+        things.push "  #{c[0]} '#{c[1].join ', '}' \# [#{vars[c[1][0]].dom}] #{c[0]} [#{vars[c[1][1]].dom}]"
     unless @_propagators.length
       things.push '  - none'
 

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -101,21 +101,6 @@ module.exports = (FD) ->
 
     return clone
 
-  # Return best var according to some fitness function `is_better_var`
-  # Note that this function originates from `get_distributor_var_func()`
-
-  get_next_var = (space, vars, is_better_var) ->
-    if vars.length is 0
-      return null
-
-    for var_i, i in vars
-      if i is 0
-        first = var_i
-      else unless is_better_var space, first, var_i
-        first = var_i
-
-    return first
-
   # Set solving options on this space. Only required for the root.
 
   Space::set_options = (options) ->

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -453,10 +453,7 @@ module.exports = (FD) ->
   # ensure that they are pairwise distinct.
 
   Space::distinct = (vars) ->
-    for var_i, i in vars
-      for j in [0...i]
-        add_neq @, vars[i], vars[j]
-    return
+    return add_distinct @, vars
 
   # Bidirectional addition propagator.
   # Returns either @ or the anonymous var name if no sumname was given
@@ -572,6 +569,12 @@ module.exports = (FD) ->
   add_neq = (space, v1name, v2name) ->
     space._propagators.push ['neq', [v1name, v2name]]
     ASSERT_PROPAGATORS space._propagators
+    return
+
+  add_distinct = (space, var_names) ->
+    for var_name_i, i in var_names
+      for j in [0...i]
+        add_neq space, var_name_i, var_names[j]
     return
 
   # Once you create an fdvar in a space with the given

--- a/src/space.coffee
+++ b/src/space.coffee
@@ -48,7 +48,7 @@ module.exports = (FD) ->
     @vars = vars
     @all_var_names = all_var_names # shared by reference in whole tree! should have all keys of @vars
     @unsolved_var_names = unsolved_var_names
-    @root_space = root_space
+    @_root_space = root_space
 
     @constant_cache = {}
 
@@ -85,7 +85,7 @@ module.exports = (FD) ->
     return
 
   Space::clone = () ->
-    root = @root_space or @
+    root = @get_root()
     all_names = @all_var_names
     unsolved_names = []
     clone_vars = {}
@@ -148,6 +148,13 @@ module.exports = (FD) ->
   Space::set_defaults = (name) ->
     @set_options FD.distribution.get_defaults name
     return
+
+  # Get the root space for this search tree
+  #
+  # @returns {Space}
+
+  Space::get_root = ->
+    return @_root_space or @
 
   # A monotonically increasing class-global counter for unique temporary variable names.
   _temp_count = 1

--- a/tests/spec/distribution/distribute.spec.coffee
+++ b/tests/spec/distribution/distribute.spec.coffee
@@ -102,7 +102,7 @@ describe 'distribute.spec', ->
       # note: this is pretty much the same as the previous min/max test except it uses
       # markov for it but it mimics min/max because we fixate the random() outcome
 
-      S = new Solver {distribute: {val: 'mid'}} # ignored because overridden
+      S = new Solver {}
       S.addVar
         id: 'V1'
         domain: spec_d_create_range 0, 4

--- a/tests/spec/distribution/distribute.spec.coffee
+++ b/tests/spec/distribution/distribute.spec.coffee
@@ -12,363 +12,139 @@ if typeof require is 'function'
 {expect, assert} = chai
 FD = finitedomain
 
-describe "FD -", ->
+describe 'distribute.spec', ->
 
-  describe "Distribute - ", ->
+  {
+    Solver
+  } = FD
 
-    describe "value distribution -", ->
-      itDistributes = (o, solutionMap) ->
-        o ?= {}
-        it "itDistributes(o = #{JSON.stringify(o)})", ->
-          S = new FD.Solver o
-          S.addVars [
-            {id:'Hello', domain: spec_d_create_range 1, 99}
-            {id:'World', domain: spec_d_create_value 0}
+  describe 'override value distribution strategy per var', ->
+
+    it 'v1=min, v2=max', ->
+
+      S = new Solver {}
+      S.addVar
+        id: 'V1'
+        domain: spec_d_create_range 1, 4
+        distribute: 'min'
+      S.addVar
+        id: 'V2'
+        domain: spec_d_create_range 1, 4
+        distribute: 'max'
+      S['>'] 'V1', S.constant 0
+      S['>'] 'V2', S.constant 0
+
+      solutions = S.solve()
+      expect(solutions.length, 'all solutions').to.equal 16
+
+
+      # (basically V1 solves lo to hi, V2 goes hi to lo)
+      expect(strip_anon_vars_a solutions).to.eql [
+        {V1: 1, V2: 4}
+        {V1: 1, V2: 3}
+        {V1: 1, V2: 2}
+        {V1: 1, V2: 1}
+        {V1: 2, V2: 4}
+        {V1: 2, V2: 3}
+        {V1: 2, V2: 2}
+        {V1: 2, V2: 1}
+        {V1: 3, V2: 4}
+        {V1: 3, V2: 3}
+        {V1: 3, V2: 2}
+        {V1: 3, V2: 1}
+        {V1: 4, V2: 4}
+        {V1: 4, V2: 3}
+        {V1: 4, V2: 2}
+        {V1: 4, V2: 1}
+      ]
+
+    it 'v1=min, v2=max (regression)', ->
+
+      # regression: when domains include 0, should still lead to same result
+
+      S = new Solver {}
+      S.addVar
+        id: 'V1'
+        domain: spec_d_create_range 0, 4
+        distribute: 'min'
+      S.addVar
+        id: 'V2'
+        domain: spec_d_create_range 0, 4
+        distribute: 'max'
+      S['>'] 'V1', S.constant 0
+      S['>'] 'V2', S.constant 0
+
+      solutions = S.solve()
+      expect(solutions.length, 'all solutions').to.equal 16
+
+
+      # (basically V1 solves lo to hi, V2 goes hi to lo)
+      expect(strip_anon_vars_a solutions).to.eql [
+        {V1: 1, V2: 4}
+        {V1: 1, V2: 3}
+        {V1: 1, V2: 2}
+        {V1: 1, V2: 1}
+        {V1: 2, V2: 4}
+        {V1: 2, V2: 3}
+        {V1: 2, V2: 2}
+        {V1: 2, V2: 1}
+        {V1: 3, V2: 4}
+        {V1: 3, V2: 3}
+        {V1: 3, V2: 2}
+        {V1: 3, V2: 1}
+        {V1: 4, V2: 4}
+        {V1: 4, V2: 3}
+        {V1: 4, V2: 2}
+        {V1: 4, V2: 1}
+      ]
+    it 'should pick a random() value in markov', ->
+
+      # note: this is pretty much the same as the previous min/max test except it uses
+      # markov for it but it mimics min/max because we fixate the random() outcome
+
+      S = new Solver {distribute: {val: 'mid'}} # ignored because overridden
+      S.addVar
+        id: 'V1'
+        domain: spec_d_create_range 0, 4
+        distribute: 'markov'
+        distributeOptions:
+          legend: [1, 2, 3, 4]
+          random: -> 0 # always take the first element
+          matrix: [
+            vector: [1, 1, 1, 1]
           ]
-          S['>'] 'Hello', 'World'
-          solutions = S.solve()
-          expect(solutions.length, 'all solutions').to.equal(99)
-          for n, val of solutionMap
-            expect(solutions[n].Hello, "nth: #{n} solution").to.equal(val)
-
-      # min
-      describe "min", ->
-        itDistributes {}                                            , {0:1,         98:99}
-        itDistributes {distribute:'naive'}                          , {0:1,         98:99}
-        itDistributes {distribute:'fail_first'}                     , {0:1,         98:99}
-        itDistributes {distribute:'split'}                          , {0:1,         98:99}
-        itDistributes {distribute:{var:'naive'}}                    , {0:1,         98:99}
-        itDistributes {distribute:{val:'min'}}                      , {0:1,         98:99}
-        itDistributes {distribute:{val:'min',var:'naive'}}          , {0:1,         98:99}
-        itDistributes {distribute:{val:'min',var:'size'}}           , {0:1,         98:99}
-        itDistributes {distribute:{val:'min',var:'min'}}            , {0:1,         98:99}
-        itDistributes {distribute:{val:'min',var:'max'}}            , {0:1,         98:99}
-
-      # max
-      describe "max", ->
-        itDistributes {distribute:{val:'max'}}                      , {0:99,        98:1 }
-        itDistributes {distribute:{val:'max',var:'naive'}}          , {0:99,        98:1 }
-        itDistributes {distribute:{val:'max',var:'size'}}           , {0:99,        98:1 }
-        itDistributes {distribute:{val:'max',var:'min'}}            , {0:99,        98:1 }
-        itDistributes {distribute:{val:'max',var:'max'}}            , {0:99,        98:1 }
-
-      # mid
-      describe 'mid', ->
-        itDistributes {distribute:{val:'mid'}}                      , {0:50, 97:99, 98:1 }
-        itDistributes {distribute:{val:'mid',var:'naive'}}          , {0:50, 97:99, 98:1 }
-        itDistributes {distribute:{val:'mid',var:'size'}}           , {0:50, 97:99, 98:1 }
-        itDistributes {distribute:{val:'mid',var:'min'}}            , {0:50, 97:99, 98:1 }
-        itDistributes {distribute:{val:'mid',var:'max'}}            , {0:50, 97:99, 98:1 }
-
-      # splitMin
-      describe 'splitMin', ->
-        itDistributes {distribute:{val:'splitMin'}}                 , {0:1,  97:98, 98:99}
-        itDistributes {distribute:{val:'splitMin',var:'naive'}}     , {0:1,  97:98, 98:99}
-        itDistributes {distribute:{val:'splitMin',var:'size'}}      , {0:1,  97:98, 98:99}
-        itDistributes {distribute:{val:'splitMin',var:'min'}}       , {0:1,  97:98, 98:99}
-        itDistributes {distribute:{val:'splitMin',var:'max'}}       , {0:1,  97:98, 98:99}
-
-      # splitMax
-      describe 'splitMax', ->
-        itDistributes {distribute:{val:'splitMax'}}                 , {0:99, 97:2, 98:1}
-        itDistributes {distribute:{val:'splitMax',var:'naive'}}     , {0:99, 97:2, 98:1}
-        itDistributes {distribute:{val:'splitMax',var:'size'}}      , {0:99, 97:2, 98:1}
-        itDistributes {distribute:{val:'splitMax',var:'min'}}       , {0:99, 97:2, 98:1}
-        itDistributes {distribute:{val:'splitMax',var:'max'}}       , {0:99, 97:2, 98:1}
-
-      # dynamic methods
-
-      describe "minMaxCycle", ->
-        o = {distribute:{val:'minMaxCycle'}}
-        S = new FD.Solver o
-        S.addVars [
-          {id:'V1', domain: spec_d_create_range 1, 4}
-          {id:'V2', domain: spec_d_create_range 1, 4}
-        ]
-        S['>'] 'V1', S.constant(0)
-        S['>'] 'V2', S.constant(0)
-        it 'all solutions', ->
-          solutions = S.solve()
-          expect(solutions.length, 'all solutions').to.equal(16)
-          expect(strip_anon_vars_a solutions).to.eql [
-            { V1: 1, V2: 4 }
-            { V1: 1, V2: 3 }
-            { V1: 1, V2: 2 }
-            { V1: 1, V2: 1 }
-            { V1: 2, V2: 4 }
-            { V1: 2, V2: 3 }
-            { V1: 2, V2: 2 }
-            { V1: 2, V2: 1 }
-            { V1: 3, V2: 4 }
-            { V1: 3, V2: 3 }
-            { V1: 3, V2: 2 }
-            { V1: 3, V2: 1 }
-            { V1: 4, V2: 4 }
-            { V1: 4, V2: 3 }
-            { V1: 4, V2: 2 }
-            { V1: 4, V2: 1 }
+      S.addVar
+        id: 'V2'
+        domain: spec_d_create_range 0, 4
+        distribute: 'markov'
+        distributeOptions:
+          legend: [1, 2, 3, 4]
+          random: -> 1 - 1e-5 # always take the last element
+          matrix: [
+            vector: [1, 1, 1, 1]
           ]
+      S['>'] 'V1', S.constant 0
+      S['>'] 'V2', S.constant 0
 
-      describe "per var val-distribution", ->
-        o = {distribute:{val:'mid'}} # doesnt actually matter
-        S = new FD.Solver o
-        S.addVars [
-          {id:'V1', domain: spec_d_create_range(1, 4), distribute:'min'}
-          {id:'V2', domain: spec_d_create_range(1, 4), distribute:'max'}
-        ]
-        S['>'] 'V1', S.constant(0)
-        S['>'] 'V2', S.constant(0)
-        it 'all solutions', ->
-          solutions = S.solve()
-          expect(solutions.length, 'all solutions').to.equal(16)
-          expect(strip_anon_vars_a solutions).to.eql [
-            { V1: 1, V2: 4 }
-            { V1: 1, V2: 3 }
-            { V1: 1, V2: 2 }
-            { V1: 1, V2: 1 }
-            { V1: 2, V2: 4 }
-            { V1: 2, V2: 3 }
-            { V1: 2, V2: 2 }
-            { V1: 2, V2: 1 }
-            { V1: 3, V2: 4 }
-            { V1: 3, V2: 3 }
-            { V1: 3, V2: 2 }
-            { V1: 3, V2: 1 }
-            { V1: 4, V2: 4 }
-            { V1: 4, V2: 3 }
-            { V1: 4, V2: 2 }
-            { V1: 4, V2: 1 }
-          ]
-
-      describe "per var list value distribution", ->
-        o = {distribute:{val:'mid'}} # doesnt actually matter
-        S = new FD.Solver o
-        S.addVars [
-          {id:'V1', domain: spec_d_create_range(1, 4), distribute:'list', distributeOptions:{list:[2,4,3,1]}, }
-          {id:'V2', domain: spec_d_create_range(1, 4), distribute:'list', distributeOptions:{list:[3,1,4,2]}, }
-        ]
-        S['>'] 'V1', S.constant(0)
-        S['>'] 'V2', S.constant(0)
-        it 'all solutions', ->
-          solutions = S.solve()
-          expect(solutions.length, 'all solutions').to.equal(16)
-          expect(strip_anon_vars_a solutions).to.eql [
-            { V1: 2, V2: 3 }
-            { V1: 2, V2: 1 }
-            { V1: 2, V2: 4 }
-            { V1: 2, V2: 2 }
-
-            { V1: 4, V2: 3 }
-            { V1: 4, V2: 1 }
-            { V1: 4, V2: 4 }
-            { V1: 4, V2: 2 }
-
-            { V1: 3, V2: 3 }
-            { V1: 3, V2: 1 }
-            { V1: 3, V2: 4 }
-            { V1: 3, V2: 2 }
-
-            { V1: 1, V2: 3 }
-            { V1: 1, V2: 1 }
-            { V1: 1, V2: 4 }
-            { V1: 1, V2: 2 }
-          ]
-
-      describe "Dynamic list value distribution, no memmory", ->
-        o = {distribute:{val:'mid'}} # doesnt actually matter
-        S = new FD.Solver o
-
-        listCallback = (S, v) ->
-          solution = S.solutionFor(['STATE','STATE2','V1','V2'], false)
-          if solution['STATE'] is 5
-            if v is 'V1'
-              return [2,4,3,1]
-            else if v is 'V2'
-              if solution['V1'] > 0
-                return [3,1,4,2]
-          return [1,2,3,4]
-
-        S.addVars [
-          {id:'STATE', domain: spec_d_create_range(0, 10)}
-          {id:'V1', domain: spec_d_create_range(1, 4), distribute:'list', distributeOptions:{list:listCallback} }
-          {id:'V2', domain: spec_d_create_range(1, 4), distribute:'list', distributeOptions:{list:listCallback} }
-          # {id:'STATE2', domain: spec_d_create_range(0, 10)}
-        ]
-
-        S['=='] 'STATE', S.constant(5)
-        S['>'] 'V1', S.constant(0)
-        S['>'] 'V2', S.constant(0)
-        # S['=='] S['==?']('STATE',S.constant(5)), 'STATE2'
-        it 'all solutions', ->
-          solutions = S.solve()
-          expect(solutions.length, 'all solutions').to.equal(16)
-          expect(strip_anon_vars_a solutions).to.eql [
-            { V1: 2, V2: 3, STATE:5 }
-            { V1: 2, V2: 1, STATE:5 }
-            { V1: 2, V2: 4, STATE:5 }
-            { V1: 2, V2: 2, STATE:5 }
-
-            { V1: 4, V2: 3, STATE:5 }
-            { V1: 4, V2: 1, STATE:5 }
-            { V1: 4, V2: 4, STATE:5 }
-            { V1: 4, V2: 2, STATE:5 }
-
-            { V1: 3, V2: 3, STATE:5 }
-            { V1: 3, V2: 1, STATE:5 }
-            { V1: 3, V2: 4, STATE:5 }
-            { V1: 3, V2: 2, STATE:5 }
-
-            { V1: 1, V2: 3, STATE:5 }
-            { V1: 1, V2: 1, STATE:5 }
-            { V1: 1, V2: 4, STATE:5 }
-            { V1: 1, V2: 2, STATE:5 }
-          ]
-
-
-
-      describe "Markov value distribution", ->
-
-        describe "basic Markov matrix", ->
-
-          setupSolver = ->
-            o = {distribute:{val:'min'}} # doesnt actually matter
-            S = new FD.Solver o
-
-            S.addVars [
-              {id:'STATE', domain: spec_d_create_range 0, 10}
-              {
-                id:'V1',
-                domain: spec_d_create_bool(),
-                distribute:'markov',
-                distributeOptions:{
-                  legend: [0,1]
-                  matrix: [
-                    vector: [.1,1]
-                    boolean: (S, varId) ->
-                      return S['==?'] 'STATE', S.constant(5)
-                  ,
-                    vector: [1,1]
-                  ]
-                }
-              }
-              {
-                id:'V2',
-                domain: spec_d_create_bool(),
-                distribute:'markov',
-                distributeOptions:{
-                  legend: [0,1]
-                  matrix: [
-                    vector: [.1,1]
-                    boolean: (Solver, varId) ->
-                      return Solver['==?'] 'STATE', S.constant(100)
-                  ,
-                    vector: [1,1]
-                  ]
-                }
-              }
-            ]
-
-            S['=='] 'STATE', S.constant(5)
-
-            return S
-
-          it 'first solution expresses markov probabilities x1000 times', ->
-            V1_count = [0,0]
-            V2_count = [0,0]
-            for i in [0...1000]
-
-              S = setupSolver()
-
-              solutions = S.solve(max:1)
-
-              #expect(solutions.length, 'all solutions').to.equal(1)
-              for solution in solutions
-                #solution = solutions[0]
-                V1_count[solution['V1']]++
-                V2_count[solution['V2']]++
-
-#            console.log 'V1_count: ',V1_count
-#            console.log 'V2_count: ',V2_count
-
-            assert (V1_count[0] / V1_count[1]) - (1 / 10) < .15
-            assert (V1_count[0] / V1_count[1]) - (1 / 1) < .15
-
-          it 'all solutions express equal probabilities x500 times', ->
-            V1_count = [0,0]
-            V2_count = [0,0]
-            for i in [0...500]
-
-              S = setupSolver()
-
-              solutions = S.solve()
-
-              #expect(solutions.length, 'all solutions').to.equal(1)
-              for solution in solutions
-                #solution = solutions[0]
-                V1_count[solution['V1']]++
-                V2_count[solution['V2']]++
-
-#            console.log 'V1_count: ',V1_count
-#            console.log 'V2_count: ',V2_count
-
-            assert V1_count[0] is V1_count[1]
-            assert V1_count[0] is V1_count[1]
-
-
-        describe "large domain w/ sparse legend & 0 probability acts as constraint", ->
-
-          setupSolver = ->
-            o = {distribute:{val:'min'}} # doesnt actually matter
-            S = new FD.Solver o
-
-            S.addVars [
-              {
-                id:'STATE',
-                domain: spec_d_create_range 0, 10
-              }
-              {
-                id:'V1',
-                domain: spec_d_create_range(0, 100),
-                distribute:'markov',
-                distributeOptions:{
-                  legend: [10,100]
-                  matrix: [
-                    vector: [1,0]
-                    boolean: (S, varId) ->
-                      return S['==?'] 'STATE', S.constant(5)
-                  ,
-                    vector: [0,1]
-                  ]
-                }
-              }
-              {
-                id:'V2',
-                domain: spec_d_create_range(0, 100),
-                distribute:'markov',
-                distributeOptions:{
-                  legend: [10,100]
-                  matrix: [
-                    vector: [1,0]
-                    boolean: (Solver, varId) ->
-                      return Solver['==?'] 'STATE', S.constant(100)
-                  ,
-                    vector: [0,1]
-                  ]
-                }
-              }
-            ]
-
-            S['=='] 'STATE', S.constant(5)
-
-            return S
-
-          it 'only 1 solution', ->
-            S = setupSolver()
-            solutions = S.solve()
-            expect(solutions.length).to.equal 1
-            expect(strip_anon_vars solutions[0]).to.eql
-              STATE: 5
-              V1: 10
-              V2: 100
+      solutions = S.solve()
+      expect(solutions.length, 'all solutions').to.equal(16)
+      expect(strip_anon_vars_a solutions).to.eql [
+        {V1: 1, V2: 4}
+        {V1: 1, V2: 3}
+        {V1: 1, V2: 2}
+        {V1: 1, V2: 1}
+        {V1: 2, V2: 4}
+        {V1: 2, V2: 3}
+        {V1: 2, V2: 2}
+        {V1: 2, V2: 1}
+        {V1: 3, V2: 4}
+        {V1: 3, V2: 3}
+        {V1: 3, V2: 2}
+        {V1: 3, V2: 1}
+        {V1: 4, V2: 4}
+        {V1: 4, V2: 3}
+        {V1: 4, V2: 2}
+        {V1: 4, V2: 1}
+      ]
 
 

--- a/tests/spec/distribution/markov.spec.coffee
+++ b/tests/spec/distribution/markov.spec.coffee
@@ -1,0 +1,173 @@
+if typeof require is 'function'
+  finitedomain = require '../../../src/index'
+  chai = require 'chai'
+  {
+    spec_d_create_bool
+    spec_d_create_range
+    spec_d_create_value
+    strip_anon_vars
+  } = require '../../fixtures/domain.spec.coffee'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe 'markov.spec', ->
+
+  RNG_UNNORMALIZED = false
+  RNG_NORMALIZED = true
+
+  {distribution_markov_sampleNextFromDomain} = FD.distribution.Markov
+
+  it 'should return a number', ->
+
+    domain = spec_d_create_range 0, 10
+    value_legend = [5]
+    prob_vector = [1]
+    rng_func = -> 1 - 1e-5 # always pick last in legend
+    expect(distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func).to.equal 5
+
+  it 'should return first value in legend if rng is 0', ->
+
+    domain = spec_d_create_range 0, 10
+    value_legend = [2, 5]
+    prob_vector = [1, 1] # equal odds (irrelevant for this test)
+    rng_func = -> 0 # always pick last in legend
+    expect(distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func).to.equal 2
+
+  it 'should return first value in legend if rng is 1', ->
+
+    domain = spec_d_create_range 0, 10
+    value_legend = [2, 8]
+    prob_vector = [1, 1] # equal odds (irrelevant for this test)
+    rng_func = -> 0.9999 # always pick last in legend
+    expect(distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_NORMALIZED).to.equal 8
+
+  it 'should throw if normalized rng returns 1', ->
+
+    domain = spec_d_create_range 0, 10
+    value_legend = [2, 8]
+    prob_vector = [1, 1] # equal odds (irrelevant for this test)
+    rng_func = -> 1 # not a valid normalized value
+    expect(-> distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_NORMALIZED).to.throw
+
+  it 'should throw if normalized rng returns 1.1', ->
+
+    domain = spec_d_create_range 0, 10
+    value_legend = [2, 8]
+    prob_vector = [1, 1] # equal odds (irrelevant for this test)
+    rng_func = -> 1.1 # not a valid normalized value
+    expect(-> distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_NORMALIZED).to.throw
+
+  it 'should throw if normalized rng returns -1', ->
+
+    domain = spec_d_create_range 0, 10
+    value_legend = [2, 8]
+    prob_vector = [1, 1] # equal odds (irrelevant for this test)
+    rng_func = -> -1 # not a valid normalized value
+    expect(-> distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_NORMALIZED).to.throw
+
+  it 'should return middle value in legend if rng is .5 with equal probs', ->
+
+    domain = spec_d_create_range 0, 10
+    value_legend = [1, 2, 3]
+    prob_vector = [1, 1, 1] # equal odds (irrelevant for this test)
+    rng_func = -> .5 # always pick last in legend
+    expect(distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func).to.equal 2
+
+  it 'should not consider values with zero probability', ->
+
+    domain = spec_d_create_range 0, 10
+    value_legend = [1, 2, 3, 4, 5, 6]
+    prob_vector = [0, 0, 0, 0, 1, 0] # only `5` has non-zero chance
+    rng_func = -> .5 # irrelevant, there is only one choice
+    expect(distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func).to.equal 5
+
+  it 'should ignore values not in current domain', ->
+
+    domain = spec_d_create_range 3, 10 # note: 1 and 2 are not part of domain!
+    value_legend = [1, 2, 3, 4, 5, 6]
+    prob_vector = [1, 1, 0, 0, 1, 0] # 1, 2, and 5 have non-zero probability
+    rng_func = -> 0 # picks first "considered" value
+    expect(distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func).to.equal 5
+
+  describe 'distribute according to probability weight', ->
+
+    it 'should solve an explicit case', ->
+
+      # tricky to explain. rng works on the total of probabilities and "consumes" left-to-right
+      # so since `2` has probability of `5/total` and the only value before it has a prob of
+      # `1/total`, the `2` will be chosen if rng outcome is one of [1, 6]. We'll fix it to `4`
+      # in this test so we'll know this must be the case.
+      domain = spec_d_create_range 0, 10
+      value_legend = [1, 2, 3, 4, 5, 6]
+      prob_vector = [1, 5, 1, 1, 1, 1] # total probability is 10
+      rng_func = -> 4 # whole number to prevent precision errors (-> RNG_UNNORMALIZED)
+      expect(distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_UNNORMALIZED).to.equal 2
+
+    describe 'more cases, unnormalized', ->
+
+      # Make sure that: rng_roll < sum(prob_vector).
+      # The roll must be less! Not lte.
+      case_it = (prob_vector, rng_roll, outcome, desc) ->
+
+        if rng_roll >= prob_vector.reduce((a,b) -> a + b)
+          throw new Error "test fail, roll must be < prob sum (#{rng_roll} >= #{prob_vector.reduce((a,b) -> a + b)})"
+
+        it "should solve case probs: #{prob_vector} roll: #{rng_roll} out: #{outcome} #{desc and ('desc: ' + desc) or ''}", ->
+          domain = spec_d_create_range 0, 10
+          value_legend = [1, 2, 3, 4, 5, 6]
+          rng_func = -> rng_roll
+          expect(distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_UNNORMALIZED).to.equal outcome
+
+      case_it [1, 1, 1, 1, 1, 1], 0, 1
+      case_it [1, 1, 1, 1, 1, 1], 1, 2
+      case_it [1, 1, 1, 1, 1, 1], 4, 5
+      case_it [1, 5, 1, 1, 1, 1], 1, 2
+      case_it [1, 5, 1, 1, 1, 1], 4, 2, 'the 5 "adds" the second index 5x to the pool so 4 ends up picking the second index'
+      case_it [1, 5, 1, 1, 1, 1], 6, 3, 'the 6 roll skips over index 1 and 5x index 2 so it picks index 3'
+      case_it [1, 5, 1, 1, 1, 1], 9, 6
+      case_it [1, 8, 1, 12, 1, 1], 22, 5, 'roll 23, skips 1x 1, 8x 2, 1x 3, 12x 4 (=22 indices) to get index 5 (not 6 because it offsets at 0)'
+
+    describe 'more cases, normalized', ->
+
+      # Make sure that: rng_roll < sum(prob_vector).
+      # The roll must be less! Not lte.
+      case_it = (prob_vector, rng_roll, outcome, desc) ->
+
+        if rng_roll >= 1
+          throw new Error "test fail, roll must be < 1 (#{rng_roll} >= 1"
+        if Math.abs(prob_vector.reduce((a,b) -> a + b) - 1) > 1e-4
+          throw new Error "test fail, prob total should be 1 (1-#{prob_vector.reduce((a,b) -> a + b)} > #{1e-4})"
+
+        it "should solve case probs: #{prob_vector} roll: #{rng_roll} out: #{outcome} #{desc and ('desc: ' + desc) or ''}", ->
+          domain = spec_d_create_range 0, 10
+          value_legend = [1, 2, 3, 4, 5, 6]
+          rng_func = -> rng_roll
+          expect(distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_NORMALIZED).to.equal outcome
+
+      case_it [1/6, 1/6, 1/6, 1/6, 1/6, 1/6], 0, 1
+      case_it [1/6, 1/6, 1/6, 1/6, 1/6, 1/6], 1 - 1e-6, 6
+      #case_it [1/6, 1/6, 1/6, 1/6, 1/6, 1/6], 1/6, 2 # rounding makes this test difficult
+      #case_it [1/6, 0, 2/6, 1/6, 1/6, 1/6], 1/6, 3, 'Second index has zero prob so it becomes 3' # rounding makes this test difficult
+      case_it [1/6, 0, 2/6, 1/6, 1/6, 1/6], 2/6, 3, 'Second index has zero prob so it becomes 3'
+
+  it 'should always return a value from legend (100x)', ->
+
+    generate_normalized_probs = (r, n) ->
+      # returns an array of 2^n random values, which should sum up to 1
+      x = r * Math.random()
+      y = r - x
+      if --n
+        return [].concat generate_normalized_probs(x, n), generate_normalized_probs(y, n)
+      return [x, y]
+
+    for [0...100]
+      domain = spec_d_create_value 100
+      value_legend = [100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100] # 16x 100
+      prob_vector = generate_normalized_probs(1, 4) # 16 values
+      r = Math.random()
+      rng = -> r
+
+      out = distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng, RNG_NORMALIZED
+
+      expect(out, "domain: #{domain} value_legend: #{value_legend} prob_vector: #{prob_vector} r: #{r} out: #{out}").to.equal 100 # should end up picking a valid index

--- a/tests/spec/distribution/value.spec.coffee
+++ b/tests/spec/distribution/value.spec.coffee
@@ -24,6 +24,12 @@ describe 'value.spec', ->
 
     expect(fdvar_create_bool?).to.be.true
 
+  describe 'distribution_value_by_throw', ->
+
+    it 'should throw', ->
+
+      expect(-> FD.distribution.value._distribute_get_next_domain_for_var 'throw').to.throw 'not expecting to pick this distributor'
+
   describe 'distribution_value_by_min', ->
 
     {_distribution_value_by_min: distribution_value_by_min} = FD.distribution.value

--- a/tests/spec/distribution/var.spec.coffee
+++ b/tests/spec/distribution/var.spec.coffee
@@ -16,12 +16,125 @@ FD = finitedomain
 describe 'var.spec', ->
 
   {
-    fdvar_create
-    fdvar_create_bool
-  } = FD.Fdvar
+    Solver
+  } = FD
+
+  {
+    distribution_get_next_var
+  } = FD.distribution.var
+
 
   describe 'distribution_var_by_throw', ->
 
     it 'should throw', ->
 
-      expect(-> FD.distribution.var.distribution_get_next_var {config_next_var_func: 'throw'}, {}).to.throw 'not expecting to pick this distributor'
+      expect(-> distribution_get_next_var {config_next_var_func: 'throw'}, {}).to.throw 'not expecting to pick this distributor'
+
+
+  it_ab = (dist_name, range_a, range_b, out, desc) ->
+
+    it desc, ->
+
+      solver = new Solver
+      solver.addVar
+        id: 'A'
+        domain: spec_d_create_ranges range_a
+      solver.addVar
+        id: 'B'
+        domain: spec_d_create_ranges range_b
+      solver.prepare
+        distribute: var: dist_name
+
+      fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
+
+      expect(fdvar.id).to.eql out
+
+  describe 'by_min', ->
+
+    it_ab 'min', [0, 1], [10, 11], 'A', 'should decide on lowest vars first A'
+    it_ab 'min', [20, 30], [5, 8], 'B', 'should decide on lowest vars first B'
+    it_ab 'min', [9, 21], [10, 20], 'A', 'should base decision on lowest lo, not lowest hi'
+
+  describe 'by_max', ->
+
+    it_ab 'max', [0, 1], [10, 11], 'B', 'should decide on highest vars first A'
+    it_ab 'max', [20, 30], [5, 8], 'A', 'should decide on highest vars first B'
+    it_ab 'max', [9, 21], [10, 20], 'A', 'should base decision on highest hi, not highest lo'
+
+  describe 'by_size', ->
+
+    it_ab 'size', [0, 1], [10, 12], 'A', 'should decide on largest domain first A'
+    it_ab 'size', [20, 30], [50, 55], 'B', 'should decide on largest domain first B'
+
+    it 'should count actual elements in the domain', ->
+
+      # note: further tests should be unit tests on domain_size instead
+      solver = new Solver
+      solver.addVar
+        id: 'A'
+        domain: spec_d_create_ranges [30, 100] # 71 elements
+      solver.addVar
+        id: 'B'
+        domain: spec_d_create_ranges [0, 50], [60, 90] # 82 elements
+      solver.prepare
+        distribute: var: 'size'
+
+      fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
+
+      expect(fdvar.id).to.eql 'B'
+
+  describe 'by_markov', ->
+
+    it 'should prioritize markov vars', ->
+
+      solver = new Solver
+      solver.addVar
+        id: 'A'
+        domain: spec_d_create_ranges [0, 1]
+      solver.addVar
+        id: 'B'
+        domain: spec_d_create_ranges [10, 12]
+        distributeOptions:
+          distributor_name: 'markov'
+          expandVectorsWith: 1
+      solver.addVar
+        id: 'C'
+        domain: spec_d_create_ranges [5, 17]
+      solver.addVar
+        id: 'D'
+        domain: spec_d_create_ranges [13, 13]
+      solver.prepare
+        distribute: var: 'markov'
+
+      fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B', 'C', 'D']
+
+      expect(fdvar.id).to.eql 'B'
+
+    it 'should get markov vars back to front', ->
+      # it's not really a hard requirement but that's how it works
+
+      solver = new Solver
+      solver.addVar
+        id: 'A'
+        domain: spec_d_create_ranges [0, 1]
+      solver.addVar
+        id: 'B'
+        domain: spec_d_create_ranges [10, 12]
+        distributeOptions:
+          distributor_name: 'markov'
+          expandVectorsWith: 1
+      solver.addVar
+        id: 'C'
+        domain: spec_d_create_ranges [5, 17]
+        distributeOptions:
+          distributor_name: 'markov'
+          expandVectorsWith: 1
+      solver.addVar
+        id: 'D'
+        domain: spec_d_create_ranges [13, 13]
+      solver.prepare
+        distribute: var: 'markov'
+
+      fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B', 'C', 'D']
+
+      expect(fdvar.id).to.eql 'C'

--- a/tests/spec/distribution/var.spec.coffee
+++ b/tests/spec/distribution/var.spec.coffee
@@ -1,0 +1,27 @@
+if typeof require is 'function'
+  finitedomain = require '../../../src/index'
+  chai = require 'chai'
+  require '../../fixtures/helpers.spec'
+  {
+    spec_d_create_bool
+    spec_d_create_value
+    spec_d_create_range
+    spec_d_create_ranges
+    spec_d_create_zero
+  } = require '../../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe 'var.spec', ->
+
+  {
+    fdvar_create
+    fdvar_create_bool
+  } = FD.Fdvar
+
+  describe 'distribution_var_by_throw', ->
+
+    it 'should throw', ->
+
+      expect(-> FD.distribution.var.distribution_get_next_var {config_next_var_func: 'throw'}, {}).to.throw 'not expecting to pick this distributor'

--- a/tests/spec/propagators/markov.spec.coffee
+++ b/tests/spec/propagators/markov.spec.coffee
@@ -1,0 +1,156 @@
+if typeof require is 'function'
+  finitedomain = require '../../../src/index'
+  chai = require 'chai'
+  {
+    spec_d_create_bool
+    spec_d_create_range
+    spec_d_create_ranges
+    spec_d_create_value
+  } = require '../../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe "propagators/markov.spec", ->
+
+  {
+    Fdvar
+    helpers
+    propagators
+    Solver
+  } = FD
+
+  {
+    REJECTED
+    ZERO_CHANGES
+  } = helpers
+
+  {
+    markov_step_bare
+  } = propagators
+
+  it 'should exist', ->
+
+    expect(markov_step_bare?).to.be.true
+
+  describe 'simple unit tests', ->
+
+    it 'should pass if solved value is in legend with prob>0', ->
+
+      solver = new Solver
+      solver.addVar
+        id: 'A'
+        domain: spec_d_create_range 0, 0
+        distributeOptions:
+          distributor_name: 'markov'
+          legend: [0]
+          matrix: [
+            vector: [1]
+          ]
+      solver.prepare() # sets up dist options in solver.space
+
+      # A=0, which is in legend and has prob=1
+      expect(markov_step_bare solver.space, 'A').to.eql ZERO_CHANGES
+
+    it 'should reject if solved value is not in legend', ->
+
+      solver = new Solver
+      solver.addVar
+        id: 'A'
+        domain: spec_d_create_range 0, 0
+        distributeOptions:
+          distributor_name: 'markov'
+          legend: [1]
+          matrix: [
+            vector: [1]
+          ]
+      solver.prepare() # sets up dist options in solver.space
+
+      # A=0, which is not in legend
+      expect(markov_step_bare solver.space, 'A').to.eql REJECTED
+
+    describe 'matrix with one row', ->
+
+      it 'should reject if solved value does not have prob>0', ->
+
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+          domain: spec_d_create_range 0, 0
+          distributeOptions:
+            distributor_name: 'markov'
+            legend: [0]
+            matrix: [
+              vector: [0]
+            ]
+        solver.prepare() # sets up dist options in solver.space
+
+        # A=0, which is in legend but has prob=0
+        expect(markov_step_bare solver.space, 'A').to.eql REJECTED
+
+      it 'should pass if solved value does has prob>0', ->
+
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+          domain: spec_d_create_range 0, 0
+          distributeOptions:
+            distributor_name: 'markov'
+            legend: [0]
+            matrix: [
+              vector: [0]
+            ]
+        solver.prepare() # sets up dist options in solver.space
+
+        # A=0, which is in legend and has prob=1
+        expect(markov_step_bare solver.space, 'A').to.eql REJECTED
+
+    describe 'multi layer matrix', ->
+
+      it 'should pass if second row gives value prob>0', ->
+
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+          domain: spec_d_create_range 0, 0
+          distributeOptions:
+            distributor_name: 'markov'
+            legend: [0]
+            matrix: [
+              {
+                vector: [0]
+                boolean: solver.constant 0
+              }
+              {
+                vector: [1]
+              }
+            ]
+        solver.prepare() # sets up dist options in solver.space
+
+        # A=0, which is in legend and has prob=0 in first row,
+        # but only second row is considered which gives prob=1
+        expect(markov_step_bare solver.space, 'A').to.eql ZERO_CHANGES
+
+      it 'should reject if second row gives value prob=0', ->
+
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+          domain: spec_d_create_range 0, 0
+          distributeOptions:
+            distributor_name: 'markov'
+            legend: [0]
+            matrix: [
+              {
+                vector: [1]
+                boolean: solver.constant 0
+              }
+              {
+                vector: [0]
+              }
+            ]
+        solver.prepare() # sets up dist options in solver.space
+
+        # A=0, which is in legend and has prob=1 in first row,
+        # but only second row is considered which gives prob=0
+        expect(markov_step_bare solver.space, 'A').to.eql REJECTED

--- a/tests/spec/search.spec.coffee
+++ b/tests/spec/search.spec.coffee
@@ -1,0 +1,102 @@
+if typeof require is 'function'
+  finitedomain = require '../../src/index'
+  chai = require 'chai'
+
+  {
+    spec_d_create_bool
+    spec_d_create_range
+    spec_d_create_ranges
+  } = require '../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe "search.spec", ->
+
+  {
+    search: Search
+    space: Space
+  } = FD
+
+  {
+    depth_first: depth_first_search
+  } = Search
+
+  describe 'depth first search', ->
+
+    it 'should solve 4 branch 2 level example (binary)', ->
+
+      ###
+      A
+        1
+        2 - B
+        3     1
+              2
+              3
+      C
+        1
+        2 - D
+        3     1
+              2
+              3
+      ###
+
+      S = new Space
+
+      # branch vars
+      branchVars = ['A', 'C', 'B', 'D']
+      S.decl branchVars, spec_d_create_bool()
+
+      # path vars
+      Avars = ['A1', 'A2', 'A3']
+      Bvars = ['B1', 'B2', 'B3']
+      Cvars = ['C1', 'C2', 'C3']
+      Dvars = ['D1', 'D2', 'D3']
+      pathVars = [].concat Avars, Bvars, Cvars, Dvars
+      S.decl pathVars, spec_d_create_bool()
+
+      # path to branch binding
+      S.sum Avars, 'A'
+      S.sum Bvars, 'B'
+      S.sum Cvars, 'C'
+      S.sum Dvars, 'D'
+
+      # root branches must be on
+      S.eq 'A', S.decl_value 1
+      S.eq 'C', S.decl_value 1
+
+      # child-parent binding
+      S.eq 'B', 'A2'
+      S.eq 'D', 'C2'
+
+      # D & B counterpoint
+      S.decl 'BsyncD', spec_d_create_bool()
+      S.reified 'eq', 'B', 'D', 'BsyncD'
+      S.gte(
+        S.reified 'eq', 'B1', 'D1'
+        'BsyncD'
+      )
+      S.gte(
+        S.reified 'eq', 'B2', 'D2'
+        'BsyncD'
+      )
+      S.gte(
+        S.reified 'eq', 'B3', 'D3'
+        'BsyncD'
+      )
+
+      S.set_defaults 'fail_first'
+      S.set_options targeted_var_names: pathVars
+
+      state = {space: S, more: true}
+
+      count = 0
+      console.time 'TIME'
+      while state.more
+        depth_first_search state
+        break if state.status is 'end'
+        count++
+      console.timeEnd 'TIME'
+      console.log "iterations: #{count}"
+
+      expect(count).to.equal 19

--- a/tests/spec/solver.list.spec.coffee
+++ b/tests/spec/solver.list.spec.coffee
@@ -1,0 +1,173 @@
+if typeof require is 'function'
+  finitedomain = require '../../src/index'
+  chai = require 'chai'
+  {
+  spec_d_create_bool
+  spec_d_create_range
+  spec_d_create_value
+  strip_anon_vars
+  strip_anon_vars_a
+  } = require '../fixtures/domain.spec.coffee'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe 'solver.list.spec', ->
+
+  it 'FD?', ->
+
+    expect(FD?).to.be.true
+
+  it 'FD.Solver?', ->
+
+    expect(FD.Solver).to.be.ok
+
+  {
+    Solver
+  } = FD
+
+  describe 'explicit list per var of distribution', ->
+
+    it 'should try values in order of the list', ->
+
+      S = new Solver {}
+      S.addVar
+        id: 'V1'
+        domain: spec_d_create_range 1, 4
+        distribute: 'list'
+        distributeOptions:
+          list: [2, 4, 3, 1]
+      S.addVar
+        id: 'V2'
+        domain: spec_d_create_range 1, 4
+        distribute: 'list'
+        distributeOptions:
+          list: [3, 1, 4, 2]
+      S['>'] 'V1', S.constant(0)
+      S['>'] 'V2', S.constant(0)
+      solutions = S.solve()
+
+      expect(solutions.length, 'all solutions').to.equal(16)
+      expect(strip_anon_vars_a solutions).to.eql [
+        {V1: 2, V2: 3}
+        {V1: 2, V2: 1}
+        {V1: 2, V2: 4}
+        {V1: 2, V2: 2}
+
+        {V1: 4, V2: 3}
+        {V1: 4, V2: 1}
+        {V1: 4, V2: 4}
+        {V1: 4, V2: 2}
+
+        {V1: 3, V2: 3}
+        {V1: 3, V2: 1}
+        {V1: 3, V2: 4}
+        {V1: 3, V2: 2}
+
+        {V1: 1, V2: 3}
+        {V1: 1, V2: 1}
+        {V1: 1, V2: 4}
+        {V1: 1, V2: 2}
+      ]
+
+    it "should solve markov according to the list in order when random=0", ->
+
+      S = new Solver {}
+      S.addVar
+        id: 'V1'
+        domain: [[1, 4]]
+        distribute: 'markov'
+        distributeOptions:
+          legend: [2, 4, 3, 1]
+          expandVectorsWith: 1
+          random: -> 0 # causes first element in legend to be picked
+      S.addVar
+        id: 'V2'
+        domain: [[1, 4]]
+        distribute: 'markov'
+        distributeOptions:
+          legend: [3, 1, 4, 2]
+          expandVectorsWith: 1
+          random: -> 0 # causes first element in legend to be picked
+      S['>'] 'V1', S.constant(0)
+      S['>'] 'V2', S.constant(0)
+
+      solutions = S.solve()
+      expect(solutions.length, 'all solutions').to.equal(16)
+      expect(strip_anon_vars_a solutions).to.eql [
+        {V1: 2, V2: 3}
+        {V1: 2, V2: 1}
+        {V1: 2, V2: 4}
+        {V1: 2, V2: 2}
+
+        {V1: 4, V2: 3}
+        {V1: 4, V2: 1}
+        {V1: 4, V2: 4}
+        {V1: 4, V2: 2}
+
+        {V1: 3, V2: 3}
+        {V1: 3, V2: 1}
+        {V1: 3, V2: 4}
+        {V1: 3, V2: 2}
+
+        {V1: 1, V2: 3}
+        {V1: 1, V2: 1}
+        {V1: 1, V2: 4}
+        {V1: 1, V2: 2}
+      ]
+
+    it "should call the list if it is a function", ->
+
+      listCallback = (S, v) ->
+        solution = S.solutionFor(['STATE', 'STATE2', 'V1', 'V2'], false)
+        if solution['STATE'] is 5
+          if v is 'V1'
+            return [2, 4, 3, 1]
+          else if v is 'V2'
+            if solution['V1'] > 0
+              return [3, 1, 4, 2]
+        return [1, 2, 3, 4]
+
+      S = new Solver {}
+      S.addVar
+        id: 'STATE'
+        domain: spec_d_create_range 0, 10
+      S.addVar
+        id: 'V1'
+        domain: spec_d_create_range 1, 4
+        distribute: 'list'
+        distributeOptions:
+          list: listCallback
+      S.addVar
+        id: 'V2'
+        domain: spec_d_create_range 1, 4
+        distribute: 'list'
+        distributeOptions:
+          list: listCallback
+      S['=='] 'STATE', S.constant 5
+      S['>'] 'V1', S.constant 0
+      S['>'] 'V2', S.constant 0
+
+      solutions = S.solve()
+      expect(solutions.length, 'all solutions').to.equal(16)
+      expect(strip_anon_vars_a solutions).to.eql [
+        {V1: 2, V2: 3, STATE: 5}
+        {V1: 2, V2: 1, STATE: 5}
+        {V1: 2, V2: 4, STATE: 5}
+        {V1: 2, V2: 2, STATE: 5}
+
+        {V1: 4, V2: 3, STATE: 5}
+        {V1: 4, V2: 1, STATE: 5}
+        {V1: 4, V2: 4, STATE: 5}
+        {V1: 4, V2: 2, STATE: 5}
+
+        {V1: 3, V2: 3, STATE: 5}
+        {V1: 3, V2: 1, STATE: 5}
+        {V1: 3, V2: 4, STATE: 5}
+        {V1: 3, V2: 2, STATE: 5}
+
+        {V1: 1, V2: 3, STATE: 5}
+        {V1: 1, V2: 1, STATE: 5}
+        {V1: 1, V2: 4, STATE: 5}
+        {V1: 1, V2: 2, STATE: 5}
+      ]

--- a/tests/spec/solver.markov.spec.coffee
+++ b/tests/spec/solver.markov.spec.coffee
@@ -1,0 +1,303 @@
+if typeof require is 'function'
+  finitedomain = require '../../src/index'
+  chai = require 'chai'
+
+  {
+    spec_d_create_bool
+    spec_d_create_range
+    spec_d_create_ranges
+    strip_anon_vars
+    strip_anon_vars_a
+  } = require '../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+# These Solver specs focus on using Markov
+
+describe "solver.markov.spec", ->
+
+  {
+    Solver
+  } = FD
+
+  it 'should solve an unconstrained Markov matrix', ->
+
+    solver = new Solver {}
+
+    solver.addVar
+      id: 'V'
+      domain: spec_d_create_bool()
+      distribute: 'markov'
+      distributeOptions:
+        legend: [0, 0]
+        matrix: [
+          vector: [1, 1]
+        ]
+
+    solutions = solver.solve()
+
+    # will try V=0 and V=1 and not find any rejects
+    expect(solutions.length, 'number of solutions').to.equal 2
+    expect(solutions).to.eql [{V: 0}, {V: 1}]
+
+  describe 'random functions', ->
+
+    random_funcs =
+
+      default: undefined
+
+      'Math.random': Math.random
+
+    # Multiverse.Random should be tested on its own in its own package...
+    #'seeded': new Multiverse.Random "sjf20ru"
+
+      # redundant.
+      'custom': () ->
+        return Math.random()
+
+      'MIN_FIRST': () ->
+        return 0
+
+      'MAX_FIRST': () ->
+        return 1 - 1e-5
+
+    setup_solver_for_random_test = (random_func) ->
+
+      solver = new Solver {}
+
+      solver.addVar
+        id: 'STATE'
+        domain: spec_d_create_range 0, 10
+      solver.addVar
+        id: 'V1'
+        domain: spec_d_create_bool()
+        distribute: 'markov'
+        distributeOptions:
+          legend: [0, 1]
+          random: random_func
+          matrix: [
+            {
+              vector: [.1, 1]
+              boolean: (S) ->
+                return S['==?'] 'STATE', S.constant 5
+            }, {
+              vector: [1, 1]
+            }
+          ]
+      solver.addVar
+        id: 'V2'
+        domain: spec_d_create_bool()
+        distribute: 'markov'
+        distributeOptions:
+          legend: [0, 1]
+          random: random_func
+          matrix: [
+            {
+              vector: [.1, 1]
+              boolean: (Solver) ->
+                return Solver['==?'] 'STATE', solver.constant 100
+            }, {
+              vector: [1, 1]
+            }
+          ]
+
+      solver['=='] 'STATE', solver.constant 5
+
+      return solver
+
+    test_random = (random_name) ->
+
+      random_func = random_funcs[random_name]
+
+      describe "random function: #{random_name}", ->
+
+        it 'should have a certain probability distribution of the random function when getting _one_ solution 1000x', ->
+
+          v1_count = [0, 0]
+          v2_count = [0, 0]
+          for i in [0...1000]
+            solver = setup_solver_for_random_test random_func
+
+            solutions = solver.solve max: 1
+
+            expect(solutions.length).to.equal 1
+            for solution in solutions
+              v1_count[solution['V1']]++
+              v2_count[solution['V2']]++
+
+          switch random_name
+            when 'MIN_FIRST'
+              expect(v1_count, 'minfirst v1 count').to.eql [1000, 0]
+              expect(v2_count, 'minfirst v2 count').to.eql [1000, 0]
+            when 'MAX_FIRST'
+              expect(v1_count, 'maxfirst v1 count').to.eql [0, 1000]
+              expect(v2_count, 'maxfirst v2 count').to.eql [0, 1000]
+            else # random functions are within 15% error assuming a normal distribution
+              v1_c = (v1_count[0] / v1_count[1]) - (1 / 10)
+              v2_c = (v2_count[0] / v2_count[1]) - (1 / 10)
+              expect(v1_c < .15, "#{v1_c} < .15").to.be.true
+              #expect(v2_c > .85, "#{v2_c} > .85").to.be.true # TOFIX: confirm and fix this line....
+
+        it 'should express equal probabilities when getting _all_ solutions x500 times', ->
+
+          v1_count = [0, 0]
+          v2_count = [0, 0]
+          for i in [0...500]
+
+            solver = setup_solver_for_random_test random_func
+
+            solutions = solver.solve() # no max!
+
+            for solution in solutions
+              v1_count[solution['V1']]++
+              v2_count[solution['V2']]++
+
+          assert v1_count[0] is v1_count[1]
+          assert v2_count[0] is v2_count[1]
+
+    Object.keys(random_funcs).forEach test_random
+
+  it 'should interpret large domain w/ sparse legend & 0 probability as a constraint', ->
+
+    solver = new Solver {}
+
+    solver.addVar
+      id: 'STATE'
+      domain: spec_d_create_range 0, 10
+    solver.addVar
+      id: 'V1',
+      domain: spec_d_create_range 0, 100
+      distribute: 'markov',
+      distributeOptions:
+        legend: [10, 100]
+        matrix: [
+          {
+            vector: [1, 0]
+            boolean: (S) ->
+              return S['==?'] 'STATE', S.constant 5
+          }, {
+            vector: [0, 1]
+          }
+        ]
+    solver.addVar
+      id: 'V2',
+      domain: spec_d_create_range 0, 100
+      distribute: 'markov',
+      distributeOptions:
+        legend: [10, 100]
+        matrix: [
+          {
+            vector: [1, 0]
+            boolean: (S) ->
+              return S['==?'] 'STATE', solver.constant 100
+          }, {
+            vector: [0, 1]
+          }
+        ]
+
+    solver['=='] 'STATE', solver.constant(5)
+
+    solutions = solver.solve()
+    expect(solutions.length).to.equal 1
+    expect(strip_anon_vars solutions[0]).to.eql
+      STATE: 5
+      V1: 10
+      V2: 100
+
+  it 'should expand vectors in markov with the expandVectorsWith option', ->
+
+    # same as previous markov test, but with incomplete, to-be-padded, vectors
+
+    S = new Solver {}
+    S.addVar
+      id: 'V1'
+      domain: spec_d_create_range 1, 4
+      distribute: 'markov'
+      distributeOptions:
+        legend: [1, 2] # 3,4]
+        expandVectorsWith: 1
+        random: () -> 0 # always pick first element
+        matrix: [
+          vector: [1, 1] # 1,1] padded by expandVectorsWith
+        ]
+
+    S.addVar
+      id: 'V2'
+      domain: spec_d_create_range 1, 4
+      distribute: 'markov'
+      distributeOptions:
+        legend: [1, 2] # 3,4]
+        expandVectorsWith: 1
+        random: () -> return 1 - 1e-5 # always pick last element
+        matrix: [
+          vector: [1, 1] # 1,1] padded by expandVectorsWith
+        ]
+    S['>'] 'V1', S.constant(0)
+    S['>'] 'V2', S.constant(0)
+
+    solutions = S.solve()
+    expect(solutions.length, 'all solutions').to.equal(16)
+    expect(strip_anon_vars_a solutions).to.eql [
+      {V1: 1, V2: 4}
+      {V1: 1, V2: 3}
+      {V1: 1, V2: 2}
+      {V1: 1, V2: 1}
+      {V1: 2, V2: 4}
+      {V1: 2, V2: 3}
+      {V1: 2, V2: 2}
+      {V1: 2, V2: 1}
+      {V1: 3, V2: 4}
+      {V1: 3, V2: 3}
+      {V1: 3, V2: 2}
+      {V1: 3, V2: 1}
+      {V1: 4, V2: 4}
+      {V1: 4, V2: 3}
+      {V1: 4, V2: 2}
+      {V1: 4, V2: 1}
+    ]
+
+  it "Markov expandVectorsWith w/o any legend or vector", ->
+
+    S = new Solver {}
+    S.addVar
+      id: 'V1'
+      domain: spec_d_create_range 1, 4
+      distribute: 'markov'
+      distributeOptions:
+        # legend: [1,2,3,4]
+        expandVectorsWith: 1
+        random: -> 0 # pick first eligible legend value
+        # matrix is added by expandVectorsWith, set to [1, 1, 1, 1]
+    S.addVar
+      id: 'V2'
+      domain: spec_d_create_range 1, 4
+      distribute: 'markov'
+      distributeOptions:
+        # legend: [1,2,3,4]
+        expandVectorsWith: 1
+        random: -> 1 - 1e-5 # pick last eligible legend value
+        # matrix is added by expandVectorsWith, set to [1, 1, 1, 1]
+    S['>'] 'V1', S.constant(0)
+    S['>'] 'V2', S.constant(0)
+
+    solutions = S.solve()
+    expect(solutions.length, 'all solutions').to.equal(16)
+    expect(strip_anon_vars_a solutions).to.eql [
+      {V1: 1, V2: 4}
+      {V1: 1, V2: 3}
+      {V1: 1, V2: 2}
+      {V1: 1, V2: 1}
+      {V1: 2, V2: 4}
+      {V1: 2, V2: 3}
+      {V1: 2, V2: 2}
+      {V1: 2, V2: 1}
+      {V1: 3, V2: 4}
+      {V1: 3, V2: 3}
+      {V1: 3, V2: 2}
+      {V1: 3, V2: 1}
+      {V1: 4, V2: 4}
+      {V1: 4, V2: 3}
+      {V1: 4, V2: 2}
+      {V1: 4, V2: 1}
+    ]

--- a/tests/spec/solver.max.spec.coffee
+++ b/tests/spec/solver.max.spec.coffee
@@ -1,0 +1,52 @@
+if typeof require is 'function'
+  finitedomain = require '../../src/index'
+  chai = require 'chai'
+
+  {
+    spec_d_create_bool
+    spec_d_create_range
+    spec_d_create_value
+  } = require '../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe 'solver.max.spec', ->
+
+  it 'FD?', ->
+
+    expect(FD?).to.be.true
+
+  it 'FD.Solver?', ->
+
+    expect(FD.Solver).to.be.ok
+
+  {
+    Solver
+  } = FD
+
+  describe 'process values in from high to low', ->
+
+    itDistributes = (o, solutionMap) ->
+
+      it "itDistributes(o = #{JSON.stringify(o)})", ->
+
+        S = new Solver o
+        S.addVar
+          id:'Hello'
+          domain: spec_d_create_range 1, 99
+        S.addVar
+          id:'World'
+          domain: spec_d_create_value 0
+        S['>'] 'Hello', 'World'
+
+        solutions = S.solve()
+        expect(solutions.length, 'all solutions').to.equal(99)
+        for n, val of solutionMap
+          expect(solutions[n].Hello, "nth: #{n} solution").to.equal(val)
+
+    itDistributes {distribute:{val:'max'}}             , {0:99, 98:1 }
+    itDistributes {distribute:{val:'max',var:'naive'}} , {0:99, 98:1 }
+    itDistributes {distribute:{val:'max',var:'size'}}  , {0:99, 98:1 }
+    itDistributes {distribute:{val:'max',var:'min'}}   , {0:99, 98:1 }
+    itDistributes {distribute:{val:'max',var:'max'}}   , {0:99, 98:1 }

--- a/tests/spec/solver.mid.spec.coffee
+++ b/tests/spec/solver.mid.spec.coffee
@@ -1,0 +1,52 @@
+if typeof require is 'function'
+  finitedomain = require '../../src/index'
+  chai = require 'chai'
+
+  {
+    spec_d_create_bool
+    spec_d_create_range
+    spec_d_create_value
+  } = require '../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe "solver.mid.spec", ->
+
+  it 'FD?', ->
+
+    expect(FD?).to.be.true
+
+  it 'FD.Solver?', ->
+
+    expect(FD.Solver).to.be.ok
+
+  {
+    Solver
+  } = FD
+
+  describe 'process values by picking the middle value', ->
+
+    itDistributes = (o, solutionMap) ->
+
+      it "itDistributes(o = #{JSON.stringify(o)})", ->
+
+        S = new Solver o
+        S.addVar
+          id:'Hello'
+          domain: spec_d_create_range 1, 99
+        S.addVar
+          id:'World'
+          domain: spec_d_create_value 0
+        S['>'] 'Hello', 'World'
+
+        solutions = S.solve()
+        expect(solutions.length, 'all solutions').to.equal(99)
+        for n, val of solutionMap
+          expect(solutions[n].Hello, "nth: #{n} solution").to.equal(val)
+
+    itDistributes {distribute:{val:'mid'}}             , {0:50, 97:99, 98:1 }
+    itDistributes {distribute:{val:'mid',var:'naive'}} , {0:50, 97:99, 98:1 }
+    itDistributes {distribute:{val:'mid',var:'size'}}  , {0:50, 97:99, 98:1 }
+    itDistributes {distribute:{val:'mid',var:'min'}}   , {0:50, 97:99, 98:1 }
+    itDistributes {distribute:{val:'mid',var:'max'}}   , {0:50, 97:99, 98:1 }

--- a/tests/spec/solver.min.spec.coffee
+++ b/tests/spec/solver.min.spec.coffee
@@ -1,0 +1,57 @@
+if typeof require is 'function'
+  finitedomain = require '../../src/index'
+  chai = require 'chai'
+
+  {
+    spec_d_create_bool
+    spec_d_create_range
+    spec_d_create_value
+  } = require '../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe "solver.min.spec", ->
+
+  it 'FD?', ->
+
+    expect(FD?).to.be.true
+
+  it 'FD.Solver?', ->
+
+    expect(FD.Solver).to.be.ok
+
+  {
+    Solver
+  } = FD
+
+  describe 'process values by picking the lowest value', ->
+
+    itDistributes = (o, solutionMap) ->
+
+      it "itDistributes(o = #{JSON.stringify(o)})", ->
+
+        S = new Solver o
+        S.addVar
+          id:'Hello'
+          domain: spec_d_create_range 1, 99
+        S.addVar
+          id:'World'
+          domain: spec_d_create_value 0
+        S['>'] 'Hello', 'World'
+
+        solutions = S.solve()
+        expect(solutions.length, 'all solutions').to.equal(99)
+        for n, val of solutionMap
+          expect(solutions[n].Hello, "nth: #{n} solution").to.equal(val)
+
+    itDistributes {}                                    , {0:1, 98:99}
+    itDistributes {distribute:'naive'}                  , {0:1, 98:99}
+    itDistributes {distribute:'fail_first'}             , {0:1, 98:99}
+    itDistributes {distribute:'split'}                  , {0:1, 98:99}
+    itDistributes {distribute:{var:'naive'}}            , {0:1, 98:99}
+    itDistributes {distribute:{val:'min'}}              , {0:1, 98:99}
+    itDistributes {distribute:{val:'min',var:'naive'}}  , {0:1, 98:99}
+    itDistributes {distribute:{val:'min',var:'size'}}   , {0:1, 98:99}
+    itDistributes {distribute:{val:'min',var:'min'}}    , {0:1, 98:99}
+    itDistributes {distribute:{val:'min',var:'max'}}    , {0:1, 98:99}

--- a/tests/spec/solver.minmaxcycle.spec.coffee
+++ b/tests/spec/solver.minmaxcycle.spec.coffee
@@ -1,0 +1,64 @@
+if typeof require is 'function'
+  finitedomain = require '../../src/index'
+  chai = require 'chai'
+
+  {
+    spec_d_create_bool
+    spec_d_create_range
+    spec_d_create_ranges
+    strip_anon_vars
+    strip_anon_vars_a
+  } = require '../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe "solver.minmaxcycle.spec", ->
+
+  it 'FD?', ->
+
+    expect(FD?).to.be.true
+
+  it 'FD.Solver?', ->
+
+    expect(FD.Solver).to.be.ok
+
+  {
+    Solver
+  } = FD
+
+  describe 'process values by alternating between picking the lowest and highest value', ->
+
+    it 'should cycle', ->
+
+      o = {distribute: {val: 'minMaxCycle'}}
+      S = new Solver o
+      S.addVar
+        id: 'V1'
+        domain: spec_d_create_range 1, 4
+      S.addVar
+        id: 'V2'
+        domain: spec_d_create_range 1, 4
+      S['>'] 'V1', S.constant(0)
+      S['>'] 'V2', S.constant(0)
+
+      solutions = S.solve()
+      expect(solutions.length, 'all solutions').to.equal(16)
+      expect(strip_anon_vars_a solutions).to.eql [
+        {V1: 1, V2: 4}
+        {V1: 1, V2: 3}
+        {V1: 1, V2: 2}
+        {V1: 1, V2: 1}
+        {V1: 2, V2: 4}
+        {V1: 2, V2: 3}
+        {V1: 2, V2: 2}
+        {V1: 2, V2: 1}
+        {V1: 3, V2: 4}
+        {V1: 3, V2: 3}
+        {V1: 3, V2: 2}
+        {V1: 3, V2: 1}
+        {V1: 4, V2: 4}
+        {V1: 4, V2: 3}
+        {V1: 4, V2: 2}
+        {V1: 4, V2: 1}
+      ]

--- a/tests/spec/solver.spec.coffee
+++ b/tests/spec/solver.spec.coffee
@@ -13,99 +13,15 @@ FD = finitedomain
 
 describe "solver.spec", ->
 
-  it 'FD?', ->
-
-    expect(FD?).to.be.true
+  {
+    Solver
+  } = FD
 
   it 'FD.Solver?', ->
-    expect(FD.Solver).to.be.ok
+
+    expect(Solver?).to.be.ok
 
   describe 'API integration tests', ->
-
-    it '4 branch 2 level example (binary)', ->
-      ###
-      A
-        1
-        2 - B
-        3     1
-              2
-              3
-      C
-        1
-        2 - D
-        3     1
-              2
-              3
-      ###
-
-      S = new FD.space()
-
-      # branch vars
-      branchVars = ['A','C','B','D']
-      S.decl(branchVars, spec_d_create_bool())
-
-      # constants
-      one = S.konst(1)
-      zero = S.konst(0)
-      booleanDomain = spec_d_create_bool()
-
-      # path vars
-      Avars = ['A1','A2','A3']
-      Bvars = ['B1','B2','B3']
-      Cvars = ['C1','C2','C3']
-      Dvars = ['D1','D2','D3']
-      pathVars = [].concat(Avars).concat(Bvars).concat(Cvars).concat(Dvars)
-      S.decl(pathVars, booleanDomain)
-
-      # path to branch binding
-      S.sum Avars, 'A'
-      S.sum Bvars, 'B'
-      S.sum Cvars, 'C'
-      S.sum Dvars, 'D'
-
-      # root branches must be on
-      S.eq 'A', one
-      S.eq 'C', one
-
-      # child-parent binding
-      S.eq 'B', 'A2'
-      S.eq 'D', 'C2'
-
-      # D & B counterpoint
-      S.decl('BsyncD',booleanDomain)
-      S.reified('eq', 'B', 'D','BsyncD')
-      S.gte(
-        S.reified('eq', 'B1', 'D1'),
-        'BsyncD'
-      )
-      S.gte(
-        S.reified('eq', 'B2', 'D2'),
-        'BsyncD'
-      )
-      S.gte(
-        S.reified('eq', 'B3', 'D3'),
-        'BsyncD'
-      )
-
-      S.set_options FD.distribution.get_defaults 'fail_first'
-      S.set_options targeted_var_names: pathVars
-
-      depth_first_search = FD.search.depth_first
-
-      state = {space:S, more:true}
-
-      count = 0
-      console.time 'TIME'
-      while state.more
-        depth_first_search state
-        break if state.status is 'end'
-        count++
-        #console.log "/////////"
-        #console.log JSON.stringify(state.space.solution())
-        #console.log JSON.stringify(state.more)
-      console.timeEnd 'TIME'
-      console.log "iterations: #{count}"
-      expect(count).to.equal 19
 
     it '4 branch 2 level example w/ string vars (binary)', ->
       ###
@@ -123,7 +39,8 @@ describe "solver.spec", ->
               3
       ###
 
-      S = new FD.Solver {defaultDomain:spec_d_create_bool()}
+      S = new Solver
+        defaultDomain: spec_d_create_bool()
 
       # branch vars
       branchVars = S.addVars ['A','C','B','D']
@@ -170,9 +87,7 @@ describe "solver.spec", ->
         'BsyncD'
       )
 
-      solutions = S.solve()
-
-      expect(solutions.length).to.equal(19)
+      expect(S.solve().length).to.equal(19)
 
     it '4 branch 2 level example w/ var objs (binary)', ->
       ###
@@ -190,7 +105,7 @@ describe "solver.spec", ->
               3
       ###
 
-      S = new FD.Solver {defaultDomain:spec_d_create_bool()}
+      S = new Solver {defaultDomain:spec_d_create_bool()}
 
       branches =
         A:3
@@ -256,7 +171,7 @@ describe "solver.spec", ->
               3
       ###
 
-      S = new FD.Solver {defaultDomain:spec_d_create_bool()}
+      S = new Solver {defaultDomain:spec_d_create_bool()}
 
       S.addVar {id:'A',domain:spec_d_create_range(0,3)}
       S.addVar {id:'B',domain:spec_d_create_range(0,3)}
@@ -297,16 +212,17 @@ describe "solver.spec", ->
 
       expect(solutions.length).to.equal(19)
 
-  describe "sparse domain test", ->
-    it 'works', ->
+  describe 'plain tests', ->
 
-      S = new FD.Solver {}
+    it 'should solve a sparse domain', ->
 
-      S.decl 'item1', spec_d_create_range(1, 5)
-      S.decl 'item2', spec_d_create_ranges([2, 2],[4,5])
-      S.decl 'item3', spec_d_create_range(1, 5)
-      S.decl 'item4', spec_d_create_range(4, 4)
-      S.decl 'item5', spec_d_create_range(1, 5)
+      S = new Solver {}
+
+      S.decl 'item1', spec_d_create_range 1, 5
+      S.decl 'item2', spec_d_create_ranges [2, 2], [4, 5]
+      S.decl 'item3', spec_d_create_range 1, 5
+      S.decl 'item4', spec_d_create_range 4, 4
+      S.decl 'item5', spec_d_create_range 1, 5
 
       S['<'] 'item1', 'item2'
       S['<'] 'item2', 'item3'
@@ -315,21 +231,85 @@ describe "solver.spec", ->
 
       solutions = S.solve()
 
-      expect(solutions.length, 'solution count').to.equal(1)
-      expect(solutions[0].item1, 'item1').to.equal(1)
-      expect(solutions[0].item2, 'item2').to.equal(2)
+      expect(solutions.length, 'solution count').to.equal 1
+      expect(solutions[0].item1, 'item1').to.equal 1
+      expect(solutions[0].item2, 'item2').to.equal 2
 
-  describe 'dont stop when all props are unchanged and there are domains left to solve', ->
+    it "should reject a simple > test (regression)", ->
+
+      # regression: x>y was wrongfully mapped to y<=x
+      S = new Solver {}
+
+      S.decl 'item5', spec_d_create_range 1, 5
+      S.decl 'item4', spec_d_create_ranges [2, 2], [3, 5]
+      S.decl 'item3', spec_d_create_range 1, 5
+      S.decl 'item2', spec_d_create_range 4, 4
+      S.decl 'item1', spec_d_create_range 1, 5
+
+      S['=='] 'item5', S.constant 5
+      S['>'] 'item1', 'item2'
+      S['>'] 'item2', 'item3'
+      S['>'] 'item3', 'item4'
+      S['>'] 'item4', 'item5'
+
+      # there is no solution since item 5 must be 5 and item 2 must be 4
+      solutions = S.solve()
+
+      expect(solutions.length, 'solution count').to.equal 0
+
+    it "should solve a simple >= test", ->
+
+      S = new Solver {}
+
+      S.decl 'item5', spec_d_create_range 1, 5
+      S.decl 'item4', spec_d_create_ranges [2, 2], [3, 5]
+      S.decl 'item3', spec_d_create_range 1, 5
+      S.decl 'item2', spec_d_create_range 4, 5
+      S.decl 'item1', spec_d_create_range 1, 5
+
+      S['=='] 'item5', S.constant 5
+      S['>='] 'item1', 'item2'
+      S['>='] 'item2', 'item3'
+      S['>='] 'item3', 'item4'
+      S['>='] 'item4', 'item5'
+
+      solutions = S.solve()
+
+      # only solution is where everything is `5`
+      expect(solutions.length, 'solution count').to.equal 1
+
+    it "should solve a simple < test", ->
+
+      S = new Solver {}
+
+      S.decl 'item5', spec_d_create_range 1, 5
+      S.decl 'item4', spec_d_create_range 4, 4
+      S.decl 'item3', spec_d_create_range 1, 5
+      S.decl 'item2', spec_d_create_ranges [2, 2], [3, 5]
+      S.decl 'item1', spec_d_create_range 1, 5
+
+      S['=='] 'item5', S.constant 5
+      S['<'] 'item1', 'item2'
+      S['<'] 'item2', 'item3'
+      S['<'] 'item3', 'item4'
+      S['<'] 'item4', 'item5'
+
+      solutions = S.solve()
+
+      # only solution is where each var is prev+1, 1 2 3 4 5
+      expect(solutions.length, 'solution count').to.equal 1
+
+  describe 'brute force entire space', ->
 
     it 'should solve a single unconstrainted var', ->
 
-      S = new FD.Solver {}
+      S = new Solver {}
       S.addVar 'A', [1, 2]
-      expect(S.solve().length).to.eql 2
+      expect(S.solve().length, 'solution count').to.eql 2
 
-    it 'combine multiple unconstrained vars', ->
+    it 'should combine multiple unconstrained vars', ->
 
-      S = new FD.Solver {}
+      S = new Solver {}
 
       S.addVar '2', [ 1, 1 ]
       S.addVar '3', [ 0, 0 ]
@@ -352,11 +332,11 @@ describe "solver.spec", ->
 
       # 2×3×2×2×2×3×2×2×3×2×2 (size of each domain multiplied)
       # there are no constraints so it's just all combinations
-      expect(S.solve({max: 10000}).length).to.eql 6912
+      expect(S.solve({max: 10000}).length, 'solution count').to.eql 6912
 
-    it 'constrain one var to be equal to another', ->
+    it 'should constrain one var to be equal to another', ->
 
-      S = new FD.Solver {}
+      S = new Solver {}
 
       S.addVar '2', [ 1, 1 ]
       S.addVar '3', [ 0, 0 ]
@@ -380,11 +360,11 @@ describe "solver.spec", ->
       S.eq '_ROOT_BRANCH_', 'SECTION'
 
       # same as 'combine multiple unconstrained vars' but one var has one instead of two options, so /2
-      expect(S.solve({max:10000}).length).to.eql 6912/2
+      expect(S.solve({max:10000}).length, 'solution count').to.eql 6912/2
 
-    it 'add useless constraints', ->
+    it 'should allow useless constraints', ->
 
-      S = new FD.Solver {}
+      S = new Solver {}
 
       S.addVar '2', [ 1, 1 ]
       S.addVar '3', [ 0, 0 ]
@@ -431,331 +411,10 @@ describe "solver.spec", ->
       # only two conditions are relevant and cuts the space by 2x2, so we get 6912/4
       expect(S.solve({max:10000}).length).to.eql 6912/4
 
-    it 'should resolve a simple reified eq case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'ONE', [1, 1]
-      S.addVar 'FOUR', [4, 4]
-      S.addVar 'LIST', [2, 2, 4, 4, 9, 9] # becomes 4
-      S.addVar 'IS_LIST_FOUR', [0, 1] # becomes 1
-
-      S._cacheReified 'eq', 'LIST', 'FOUR', 'IS_LIST_FOUR'
-      S.eq 'IS_LIST_FOUR', 'ONE'
-
-      # list can be one of three elements.
-      # there is a bool var that checks whether list is resolved to 4
-      # there is a constraint that requires the above bool to be 1
-      # ergo; list must be 4 to satisfy all constraints
-      # ergo; there is 1 possible solution
-
-      expect(S.solve({max:10000}).length).to.eql 1
-
-    it 'should resolve a simple reified !eq case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'ZERO', [0, 0]
-      S.addVar 'FOUR', [4, 4]
-      S.addVar 'LIST', [2, 2, 4, 4, 9, 9] # becomes 4
-      S.addVar 'IS_LIST_FOUR', [0, 1] # becomes 1
-
-      S._cacheReified 'eq', 'LIST', 'FOUR', 'IS_LIST_FOUR'
-      S.eq 'IS_LIST_FOUR', 'ZERO'
-
-      # list can be one of three elements.
-      # there is a bool var that checks whether list is resolved to 4
-      # there is a constraint that requires the above bool to be 0
-      # ergo; list must be 2 or 9 to satisfy all constraints
-      # ergo; there are 2 possible solutions
-
-      expect(S.solve({max:10000}).length).to.eql 2
-
-    it 'should resolve a simple reified neq case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'ONE', [1, 1]
-      S.addVar 'FOUR', [4, 4]
-      S.addVar 'LIST', [2, 2, 4, 4, 9, 9] # becomes 2 or 9
-      S.addVar 'IS_LIST_FOUR', [0, 1] # becomes 1
-
-      S._cacheReified 'neq', 'LIST', 'FOUR', 'IS_LIST_FOUR'
-      S.eq 'IS_LIST_FOUR', 'ONE'
-
-      # list can be one of three elements.
-      # there is a bool var that checks whether list is resolved to 4
-      # there is a constraint that requires the above bool to be 1
-      # ergo; list must be 2 or 9 to satisfy all constraints
-      # ergo; there are 2 possible solutions
-
-      expect(S.solve({max:10000}).length).to.eql 2
-
-    it 'should resolve a simple reified !neq case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'ZERO', [0, 0]
-      S.addVar 'FOUR', [4, 4]
-      S.addVar 'LIST', [2, 2, 4, 4, 9, 9] # becomes 4
-      S.addVar 'IS_LIST_FOUR', [0, 1] # becomes 0
-
-      S._cacheReified 'neq', 'LIST', 'FOUR', 'IS_LIST_FOUR'
-      S.eq 'IS_LIST_FOUR', 'ZERO'
-
-      # list can be one of three elements.
-      # there is a bool var that checks whether list is resolved to 4
-      # there is a constraint that requires the above bool to be 0
-      # ergo; list must be 4 to satisfy all constraints
-      # ergo; there is 1 possible solution
-
-      expect(S.solve({max:10000}).length).to.eql 1
-
-    it 'should resolve a simple reified lt case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'STATE', [1, 1]
-      S.addVar 'ONE_TWO_THREE', [1, 3] # 1 2 or 3
-      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3 4 or 5
-      S.addVar 'IS_LT', [0, 1] # becomes 1
-
-      S._cacheReified 'lt', 'ONE_TWO_THREE', 'THREE_FOUR_FIVE', 'IS_LT'
-      S.eq 'IS_LT', 'STATE'
-
-      # two lists, 123 and 345
-      # reified checks whether 123<345 which is only the case when
-      # the 3 is dropped from at least one side
-      # IS_LT is required to have one outcome
-      # 3 + 3 + 2 = 8  ->  1:3 1:4 1:5 2:3 2:4 2:5 3:4 3:5
-
-      expect(S.solve({max:10000}).length).to.eql 8
-
-    it 'should resolve a simple reified !lt case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'STATE', [0, 0]
-      S.addVar 'ONE_TWO_THREE', [1, 3] # 3
-      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3
-      S.addVar 'IS_LT', [0, 1] # 0
-
-      S._cacheReified 'lt', 'ONE_TWO_THREE', 'THREE_FOUR_FIVE', 'IS_LT'
-      S.eq 'IS_LT', 'STATE'
-
-      # two lists, 123 and 345
-      # reified checks whether 123<345 which is only the case when
-      # the 3 is dropped from at least one side
-      # IS_LT is required to have one outcome
-      # since it must be 0, that is only when both lists are 3
-      # ergo; one solution
-
-      expect(S.solve({max:10000}).length).to.eql 1
-
-    it 'should resolve a simple reified lte case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'STATE', [1, 1]
-      S.addVar 'ONE_TWO_THREE_FOUR', [1, 4] # 1 2 or 3
-      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3 4 or 5
-      S.addVar 'IS_LTE', [0, 1] # becomes 1
-
-      S._cacheReified 'lte', 'ONE_TWO_THREE_FOUR', 'THREE_FOUR_FIVE', 'IS_LTE'
-      S.eq 'IS_LTE', 'STATE'
-
-      # two lists, 123 and 345
-      # reified checks whether 1234<=345 which is only the case when
-      # the 4 is dropped from at least one side
-      # IS_LTE is required to have one outcome
-      # 3 + 3 + 3 + 2 = 11  ->  1:3 1:4 1:5 2:3 2:4 2:5 3:3 3:4 3:5 4:4 4:5
-
-      expect(S.solve({max:10000}).length).to.eql 11
-
-    it 'should resolve a simple reified !lte case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'STATE', [0, 0]
-      S.addVar 'ONE_TWO_THREE_FOUR', [1, 4] # 4
-      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3
-      S.addVar 'IS_LTE', [0, 1] # 0
-
-      S._cacheReified 'lte', 'ONE_TWO_THREE_FOUR', 'THREE_FOUR_FIVE', 'IS_LTE'
-      S.eq 'IS_LTE', 'STATE'
-
-      # two lists, 123 and 345
-      # reified checks whether 1234<=345 which is only the case when
-      # the 4 is dropped from at least one side
-      # IS_LTE is required to have one outcome
-      # since it must be 0, that is only when left is 4 and right is 3
-      # ergo; one solution
-
-      expect(S.solve({max:10000}).length).to.eql 1
-
-    it 'should resolve a simple reified gt case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'STATE', [1, 1]
-      S.addVar 'ONE_TWO_THREE', [1, 3] # 1 2 or 3
-      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3 4 or 5
-      S.addVar 'IS_GT', [0, 1] # becomes 1
-
-      S._cacheReified 'gt', 'THREE_FOUR_FIVE', 'ONE_TWO_THREE', 'IS_GT'
-      S.eq 'IS_GT', 'STATE'
-
-      # two lists, 123 and 345
-      # reified checks whether 345>123 which is only the case when
-      # the 3 is dropped from at least one side
-      # IS_GT is required to have one outcome
-      # 3 + 3 + 2 = 8  ->  3:1 4:1 5:1 3:2 4:2 5:2 3:1 3:2
-
-      expect(S.solve({max:10000}).length).to.eql 8
-
-    it 'should resolve a simple reified !gt case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'STATE', [0, 0]
-      S.addVar 'ONE_TWO_THREE', [1, 3] # 3
-      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3
-      S.addVar 'IS_GT', [0, 1] # 0
-
-      S._cacheReified 'gt', 'THREE_FOUR_FIVE', 'ONE_TWO_THREE', 'IS_GT'
-      S.eq 'IS_GT', 'STATE'
-
-      # two lists, 123 and 345
-      # reified checks whether 123<345 which is only the case when
-      # the 3 is dropped from at least one side
-      # IS_GT is required to have one outcome
-      # since it must be 0, that is only when both lists are 3
-      # ergo; one solution
-
-      expect(S.solve({max:10000}).length).to.eql 1
-
-    it 'should resolve a simple reified gte case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'STATE', [1, 1]
-      S.addVar 'ONE_TWO_THREE_FOUR', [1, 4] # 1 2 or 3
-      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3 4 or 5
-      S.addVar 'IS_GTE', [0, 1] # becomes 1
-
-      S._cacheReified 'gte', 'THREE_FOUR_FIVE', 'ONE_TWO_THREE_FOUR', 'IS_GTE'
-      S.eq 'IS_GTE', 'STATE'
-
-      # two lists, 123 and 345
-      # reified checks whether 345>=1234 which is only the case when
-      # left is not 3 or right is not 4
-      # IS_GTE is required to have one outcome
-      # 3 + 3 + 3 + 2 = 11  ->  3:1 4:1 5:1 3:2 4:2 5:2 3:3 4:4 5:4
-
-      expect(S.solve({max:10000}).length).to.eql 11
-
-    it 'should resolve a simple reified !gte case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'STATE', [0, 0]
-      S.addVar 'ONE_TWO_THREE_FOUR', [1, 4] # 4
-      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3
-      S.addVar 'IS_GTE', [0, 1] # 0
-
-      S._cacheReified 'gte', 'THREE_FOUR_FIVE', 'ONE_TWO_THREE_FOUR', 'IS_GTE'
-      S.eq 'IS_GTE', 'STATE'
-
-      # two lists, 123 and 345
-      # reified checks whether 1234<=345 which is only the case when
-      # the 4 is dropped from at least one side
-      # IS_LTE is required to have one outcome
-      # since it must be 0, that is only when left is 3 and right is 4
-      # ergo; one solution
-
-      expect(S.solve({max:10000}).length).to.eql 1
-
-    it 'should resolve a simple sum with lte case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'A', [0, 10]
-      S.addVar 'B', [0, 10]
-      S.addVar 'MAX', [5, 5]
-      S.addVar 'SUM', [0, 100]
-
-      S.sum ['A', 'B'], 'SUM'
-      S.lte 'SUM', 'MAX'
-
-      # a+b<=5
-      # so that's the case for: 0+0, 0+1, 0+2, 0+3,
-      # 0+4, 0+5, 1+0, 1+1, 1+2, 1+3, 1+4, 2+0, 2+1,
-      # 2+2, 2+3, 3+0, 3+1, 3+2, 4+0, 4+1, and 5+0
-      # ergo: 21 solutions
-
-      expect(S.solve({max:10000}).length).to.eql 21
-
-    it 'should resolve a simple sum with lt case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'A', [0, 10]
-      S.addVar 'B', [0, 10]
-      S.addVar 'MAX', [5, 5]
-      S.addVar 'SUM', [0, 100]
-
-      S.sum ['A', 'B'], 'SUM'
-      S.lt 'SUM', 'MAX'
-
-      # a+b<5
-      # so that's the case for: 0+0, 0+1, 0+2,
-      # 0+3, 0+4, 1+0, 1+1, 1+2, 1+3, 2+0, 2+1,
-      # 2+2, 3+0, 3+1, and 4+0
-      # ergo: 16 solutions
-
-      expect(S.solve({max:10000}).length).to.eql 15
-
-    it 'should resolve a simple sum with gt case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'A', [0, 10]
-      S.addVar 'B', [0, 10]
-      S.addVar 'MAX', [5, 5]
-      S.addVar 'SUM', [0, 100]
-
-      S.sum ['A', 'B'], 'SUM'
-      S.gt 'SUM', 'MAX'
-
-      # a+b>5
-      # there are 11x11=121 cases. a+b<=5 is 21 cases
-      # (see other test) so there must be 100 results.
-      # TOFIX: right now it maps to !lt so there are 6 more cases where a+b=5
-
-      expect(S.solve({max:10000}).length).to.eql 106 # 100
-
-    it 'should resolve a simple sum with gte case', ->
-
-      S = new FD.Solver {}
-
-      S.addVar 'A', [0, 10]
-      S.addVar 'B', [0, 10]
-      S.addVar 'MAX', [5, 5]
-      S.addVar 'SUM', [0, 100]
-
-      S.sum ['A', 'B'], 'SUM'
-      S.gte 'SUM', 'MAX'
-
-      # a+b>=5
-      # there are 11x11=121 cases. a+b<5 is 15 cases
-      # (see other test) so there must be 106 results.
-
-      expect(S.solve({max:10000}).length).to.eql 106
-
     # there was a "sensible reason" why this test doesnt work but I forgot about it right now... :)
     it.skip 'should resolve a simple sum with times case', ->
 
-      S = new FD.Solver {}
+      S = new Solver {}
 
       S.addVar 'A', [0, 10]
       S.addVar 'B', [0, 10]
@@ -786,10 +445,9 @@ describe "solver.spec", ->
 
       expect(S.solve({max:10000, vars:['A','B','MUL']}).length).to.eql 73
 
+    it 'should solve a simplified case from old PathBinarySolver tests', ->
 
-    it 'simplified case from PathBinarySolver tests', ->
-
-      S = new FD.Solver {}
+      S = new Solver {}
 
       S.addVar '2', [1, 1]
       S.addVar '3', [0, 0]
@@ -851,9 +509,346 @@ describe "solver.spec", ->
       S.eq '14', '3' # so vi2 must not be 1 (so 3 or 7)
 
       # 2×2×2×2×2×2×2×2=256
-      expect(S.solve({max:10000, vars: [
-        '_ROOT_BRANCH_', 'SECTION', 'VERSE_INDEX', 'ITEM_INDEX', 'align',
-        'text_align', 'SECTION&n=1', 'VERSE_INDEX&n=1', 'ITEM_INDEX&n=1',
-        'align&n=1', 'text_align&n=1', 'SECTION&n=2', 'VERSE_INDEX&n=2',
-        'ITEM_INDEX&n=2', 'align&n=2', 'text_align&n=2'
-      ]}).length).to.eql 256
+      expect(S.solve(
+        max:10000
+        vars: [
+          '_ROOT_BRANCH_'
+          'SECTION'
+          'VERSE_INDEX'
+          'ITEM_INDEX'
+          'align'
+          'text_align'
+          'SECTION&n=1'
+          'VERSE_INDEX&n=1'
+          'ITEM_INDEX&n=1'
+          'align&n=1'
+          'text_align&n=1'
+          'SECTION&n=2'
+          'VERSE_INDEX&n=2'
+          'ITEM_INDEX&n=2'
+          'align&n=2'
+          'text_align&n=2'
+        ]
+      ).length).to.eql 256
+
+  describe 'reifiers', ->
+
+    it 'should resolve a simple reified eq case', ->
+
+      S = new Solver {}
+
+      S.addVar 'ONE', [1, 1]
+      S.addVar 'FOUR', [4, 4]
+      S.addVar 'LIST', [2, 2, 4, 4, 9, 9] # becomes 4
+      S.addVar 'IS_LIST_FOUR', [0, 1] # becomes 1
+
+      S._cacheReified 'eq', 'LIST', 'FOUR', 'IS_LIST_FOUR'
+      S.eq 'IS_LIST_FOUR', 'ONE'
+
+      # list can be one of three elements.
+      # there is a bool var that checks whether list is resolved to 4
+      # there is a constraint that requires the above bool to be 1
+      # ergo; list must be 4 to satisfy all constraints
+      # ergo; there is 1 possible solution
+
+      expect(S.solve(max: 10000).length).to.eql 1
+
+    it 'should resolve a simple reified !eq case', ->
+
+      S = new Solver {}
+
+      S.addVar 'ZERO', [0, 0]
+      S.addVar 'FOUR', [4, 4]
+      S.addVar 'LIST', [2, 2, 4, 4, 9, 9] # becomes 4
+      S.addVar 'IS_LIST_FOUR', [0, 1] # becomes 1
+
+      S._cacheReified 'eq', 'LIST', 'FOUR', 'IS_LIST_FOUR'
+      S.eq 'IS_LIST_FOUR', 'ZERO'
+
+      # list can be one of three elements.
+      # there is a bool var that checks whether list is resolved to 4
+      # there is a constraint that requires the above bool to be 0
+      # ergo; list must be 2 or 9 to satisfy all constraints
+      # ergo; there are 2 possible solutions
+
+      expect(S.solve(max: 10000).length).to.eql 2
+
+    it 'should resolve a simple reified neq case', ->
+
+      S = new Solver {}
+
+      S.addVar 'ONE', [1, 1]
+      S.addVar 'FOUR', [4, 4]
+      S.addVar 'LIST', [2, 2, 4, 4, 9, 9] # becomes 2 or 9
+      S.addVar 'IS_LIST_FOUR', [0, 1] # becomes 1
+
+      S._cacheReified 'neq', 'LIST', 'FOUR', 'IS_LIST_FOUR'
+      S.eq 'IS_LIST_FOUR', 'ONE'
+
+      # list can be one of three elements.
+      # there is a bool var that checks whether list is resolved to 4
+      # there is a constraint that requires the above bool to be 1
+      # ergo; list must be 2 or 9 to satisfy all constraints
+      # ergo; there are 2 possible solutions
+
+      expect(S.solve(max: 10000).length).to.eql 2
+
+    it 'should resolve a simple reified !neq case', ->
+
+      S = new Solver {}
+
+      S.addVar 'ZERO', [0, 0]
+      S.addVar 'FOUR', [4, 4]
+      S.addVar 'LIST', [2, 2, 4, 4, 9, 9] # becomes 4
+      S.addVar 'IS_LIST_FOUR', [0, 1] # becomes 0
+
+      S._cacheReified 'neq', 'LIST', 'FOUR', 'IS_LIST_FOUR'
+      S.eq 'IS_LIST_FOUR', 'ZERO'
+
+      # list can be one of three elements.
+      # there is a bool var that checks whether list is resolved to 4
+      # there is a constraint that requires the above bool to be 0
+      # ergo; list must be 4 to satisfy all constraints
+      # ergo; there is 1 possible solution
+
+      expect(S.solve(max: 10000).length).to.eql 1
+
+    it 'should resolve a simple reified lt case', ->
+
+      S = new Solver {}
+
+      S.addVar 'STATE', [1, 1]
+      S.addVar 'ONE_TWO_THREE', [1, 3] # 1 2 or 3
+      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3 4 or 5
+      S.addVar 'IS_LT', [0, 1] # becomes 1
+
+      S._cacheReified 'lt', 'ONE_TWO_THREE', 'THREE_FOUR_FIVE', 'IS_LT'
+      S.eq 'IS_LT', 'STATE'
+
+      # two lists, 123 and 345
+      # reified checks whether 123<345 which is only the case when
+      # the 3 is dropped from at least one side
+      # IS_LT is required to have one outcome
+      # 3 + 3 + 2 = 8  ->  1:3 1:4 1:5 2:3 2:4 2:5 3:4 3:5
+
+      expect(S.solve(max: 10000).length).to.eql 8
+
+    it 'should resolve a simple reified !lt case', ->
+
+      S = new Solver {}
+
+      S.addVar 'STATE', [0, 0]
+      S.addVar 'ONE_TWO_THREE', [1, 3] # 3
+      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3
+      S.addVar 'IS_LT', [0, 1] # 0
+
+      S._cacheReified 'lt', 'ONE_TWO_THREE', 'THREE_FOUR_FIVE', 'IS_LT'
+      S.eq 'IS_LT', 'STATE'
+
+      # two lists, 123 and 345
+      # reified checks whether 123<345 which is only the case when
+      # the 3 is dropped from at least one side
+      # IS_LT is required to have one outcome
+      # since it must be 0, that is only when both lists are 3
+      # ergo; one solution
+
+      expect(S.solve(max: 10000).length).to.eql 1
+
+    it 'should resolve a simple reified lte case', ->
+
+      S = new Solver {}
+
+      S.addVar 'STATE', [1, 1]
+      S.addVar 'ONE_TWO_THREE_FOUR', [1, 4] # 1 2 or 3
+      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3 4 or 5
+      S.addVar 'IS_LTE', [0, 1] # becomes 1
+
+      S._cacheReified 'lte', 'ONE_TWO_THREE_FOUR', 'THREE_FOUR_FIVE', 'IS_LTE'
+      S.eq 'IS_LTE', 'STATE'
+
+      # two lists, 123 and 345
+      # reified checks whether 1234<=345 which is only the case when
+      # the 4 is dropped from at least one side
+      # IS_LTE is required to have one outcome
+      # 3 + 3 + 3 + 2 = 11  ->  1:3 1:4 1:5 2:3 2:4 2:5 3:3 3:4 3:5 4:4 4:5
+
+      expect(S.solve(max: 10000).length).to.eql 11
+
+    it 'should resolve a simple reified !lte case', ->
+
+      S = new Solver {}
+
+      S.addVar 'STATE', [0, 0]
+      S.addVar 'ONE_TWO_THREE_FOUR', [1, 4] # 4
+      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3
+      S.addVar 'IS_LTE', [0, 1] # 0
+
+      S._cacheReified 'lte', 'ONE_TWO_THREE_FOUR', 'THREE_FOUR_FIVE', 'IS_LTE'
+      S.eq 'IS_LTE', 'STATE'
+
+      # two lists, 123 and 345
+      # reified checks whether 1234<=345 which is only the case when
+      # the 4 is dropped from at least one side
+      # IS_LTE is required to have one outcome
+      # since it must be 0, that is only when left is 4 and right is 3
+      # ergo; one solution
+
+      expect(S.solve(max: 10000).length).to.eql 1
+
+    it 'should resolve a simple reified gt case', ->
+
+      S = new Solver {}
+
+      S.addVar 'STATE', [1, 1]
+      S.addVar 'ONE_TWO_THREE', [1, 3] # 1 2 or 3
+      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3 4 or 5
+      S.addVar 'IS_GT', [0, 1] # becomes 1
+
+      S._cacheReified 'gt', 'THREE_FOUR_FIVE', 'ONE_TWO_THREE', 'IS_GT'
+      S.eq 'IS_GT', 'STATE'
+
+      # two lists, 123 and 345
+      # reified checks whether 345>123 which is only the case when
+      # the 3 is dropped from at least one side
+      # IS_GT is required to have one outcome
+      # 3 + 3 + 2 = 8  ->  3:1 4:1 5:1 3:2 4:2 5:2 3:1 3:2
+
+      expect(S.solve(max: 10000).length).to.eql 8
+
+    it 'should resolve a simple reified !gt case', ->
+
+      S = new Solver {}
+
+      S.addVar 'STATE', [0, 0]
+      S.addVar 'ONE_TWO_THREE', [1, 3] # 3
+      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3
+      S.addVar 'IS_GT', [0, 1] # 0
+
+      S._cacheReified 'gt', 'THREE_FOUR_FIVE', 'ONE_TWO_THREE', 'IS_GT'
+      S.eq 'IS_GT', 'STATE'
+
+      # two lists, 123 and 345
+      # reified checks whether 123<345 which is only the case when
+      # the 3 is dropped from at least one side
+      # IS_GT is required to have one outcome
+      # since it must be 0, that is only when both lists are 3
+      # ergo; one solution
+
+      expect(S.solve(max: 10000).length).to.eql 1
+
+    it 'should resolve a simple reified gte case', ->
+
+      S = new Solver {}
+
+      S.addVar 'STATE', [1, 1]
+      S.addVar 'ONE_TWO_THREE_FOUR', [1, 4] # 1 2 or 3
+      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3 4 or 5
+      S.addVar 'IS_GTE', [0, 1] # becomes 1
+
+      S._cacheReified 'gte', 'THREE_FOUR_FIVE', 'ONE_TWO_THREE_FOUR', 'IS_GTE'
+      S.eq 'IS_GTE', 'STATE'
+
+      # two lists, 123 and 345
+      # reified checks whether 345>=1234 which is only the case when
+      # left is not 3 or right is not 4
+      # IS_GTE is required to have one outcome
+      # 3 + 3 + 3 + 2 = 11  ->  3:1 4:1 5:1 3:2 4:2 5:2 3:3 4:4 5:4
+
+      expect(S.solve(max: 10000).length).to.eql 11
+
+    it 'should resolve a simple reified !gte case', ->
+
+      S = new Solver {}
+
+      S.addVar 'STATE', [0, 0]
+      S.addVar 'ONE_TWO_THREE_FOUR', [1, 4] # 4
+      S.addVar 'THREE_FOUR_FIVE', [3, 5] # 3
+      S.addVar 'IS_GTE', [0, 1] # 0
+
+      S._cacheReified 'gte', 'THREE_FOUR_FIVE', 'ONE_TWO_THREE_FOUR', 'IS_GTE'
+      S.eq 'IS_GTE', 'STATE'
+
+      # two lists, 123 and 345
+      # reified checks whether 1234<=345 which is only the case when
+      # the 4 is dropped from at least one side
+      # IS_LTE is required to have one outcome
+      # since it must be 0, that is only when left is 3 and right is 4
+      # ergo; one solution
+
+      expect(S.solve(max: 10000).length).to.eql 1
+
+    it 'should resolve a simple sum with lte case', ->
+
+      S = new Solver {}
+
+      S.addVar 'A', [0, 10]
+      S.addVar 'B', [0, 10]
+      S.addVar 'MAX', [5, 5]
+      S.addVar 'SUM', [0, 100]
+
+      S.sum ['A', 'B'], 'SUM'
+      S.lte 'SUM', 'MAX'
+
+      # a+b<=5
+      # so that's the case for: 0+0, 0+1, 0+2, 0+3,
+      # 0+4, 0+5, 1+0, 1+1, 1+2, 1+3, 1+4, 2+0, 2+1,
+      # 2+2, 2+3, 3+0, 3+1, 3+2, 4+0, 4+1, and 5+0
+      # ergo: 21 solutions
+
+      expect(S.solve(max: 10000).length).to.eql 21
+
+    it 'should resolve a simple sum with lt case', ->
+
+      S = new Solver {}
+
+      S.addVar 'A', [0, 10]
+      S.addVar 'B', [0, 10]
+      S.addVar 'MAX', [5, 5]
+      S.addVar 'SUM', [0, 100]
+
+      S.sum ['A', 'B'], 'SUM'
+      S.lt 'SUM', 'MAX'
+
+      # a+b<5
+      # so that's the case for: 0+0, 0+1, 0+2,
+      # 0+3, 0+4, 1+0, 1+1, 1+2, 1+3, 2+0, 2+1,
+      # 2+2, 3+0, 3+1, and 4+0
+      # ergo: 16 solutions
+
+      expect(S.solve(max: 10000).length).to.eql 15
+
+    it 'should resolve a simple sum with gt case', ->
+
+      S = new Solver {}
+
+      S.addVar 'A', [0, 10]
+      S.addVar 'B', [0, 10]
+      S.addVar 'MAX', [5, 5]
+      S.addVar 'SUM', [0, 100]
+
+      S.sum ['A', 'B'], 'SUM'
+      S.gt 'SUM', 'MAX'
+
+      # a+b>5
+      # there are 11x11=121 cases. a+b<=5 is 21 cases
+      # (see other test) so there must be 100 results.
+
+      expect(S.solve(max: 10000).length).to.eql 100
+
+    it 'should resolve a simple sum with gte case', ->
+
+      S = new Solver {}
+
+      S.addVar 'A', [0, 10]
+      S.addVar 'B', [0, 10]
+      S.addVar 'MAX', [5, 5]
+      S.addVar 'SUM', [0, 100]
+
+      S.sum ['A', 'B'], 'SUM'
+      S.gte 'SUM', 'MAX'
+
+      # a+b>=5
+      # there are 11x11=121 cases. a+b<5 is 15 cases
+      # (see other test) so there must be 106 results.
+
+      expect(S.solve(max: 10000).length).to.eql 106

--- a/tests/spec/solver.splitmax.spec.coffee
+++ b/tests/spec/solver.splitmax.spec.coffee
@@ -1,0 +1,40 @@
+if typeof require is 'function'
+  finitedomain = require '../../src/index'
+  chai = require 'chai'
+
+  {
+    spec_d_create_bool
+    spec_d_create_range
+    spec_d_create_ranges
+  } = require '../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe "solver.splitmax.spec", ->
+
+  describe 'process values by divide and conquer, high split first', ->
+
+    itDistributes = (o, solutionMap) ->
+
+      it "itDistributes(o = #{JSON.stringify(o)})", ->
+
+        S = new FD.Solver o
+        S.addVar
+          id:'Hello'
+          domain: spec_d_create_range 1, 99
+        S.addVar
+          id:'World'
+          domain: spec_d_create_value 0
+        S['>'] 'Hello', 'World'
+
+        solutions = S.solve()
+        expect(solutions.length, 'all solutions').to.equal(99)
+        for n, val of solutionMap
+          expect(solutions[n].Hello, "nth: #{n} solution").to.equal(val)
+
+      itDistributes {distribute:{val:'splitMax'}}             , {0:99, 97:2, 98:1}
+      itDistributes {distribute:{val:'splitMax',var:'naive'}} , {0:99, 97:2, 98:1}
+      itDistributes {distribute:{val:'splitMax',var:'size'}}  , {0:99, 97:2, 98:1}
+      itDistributes {distribute:{val:'splitMax',var:'min'}}   , {0:99, 97:2, 98:1}
+      itDistributes {distribute:{val:'splitMax',var:'max'}}   , {0:99, 97:2, 98:1}

--- a/tests/spec/solver.splitmin.spec.coffee
+++ b/tests/spec/solver.splitmin.spec.coffee
@@ -1,0 +1,40 @@
+if typeof require is 'function'
+  finitedomain = require '../../src/index'
+  chai = require 'chai'
+
+  {
+    spec_d_create_bool
+    spec_d_create_range
+    spec_d_create_ranges
+  } = require '../fixtures/domain.spec'
+
+{expect, assert} = chai
+FD = finitedomain
+
+describe "solver.splitmin.spec", ->
+
+  describe 'process values by divide and conquer, low split first', ->
+
+    itDistributes = (o, solutionMap) ->
+
+      it "itDistributes(o = #{JSON.stringify(o)})", ->
+
+        S = new FD.Solver o
+        S.addVar
+          id:'Hello'
+          domain: spec_d_create_range 1, 99
+        S.addVar
+          id:'World'
+          domain: spec_d_create_value 0
+        S['>'] 'Hello', 'World'
+
+        solutions = S.solve()
+        expect(solutions.length, 'all solutions').to.equal(99)
+        for n, val of solutionMap
+          expect(solutions[n].Hello, "nth: #{n} solution").to.equal(val)
+
+      itDistributes {distribute:{val:'splitMin'}}             , {0:1,  97:98, 98:99}
+      itDistributes {distribute:{val:'splitMin',var:'naive'}} , {0:1,  97:98, 98:99}
+      itDistributes {distribute:{val:'splitMin',var:'size'}}  , {0:1,  97:98, 98:99}
+      itDistributes {distribute:{val:'splitMin',var:'min'}}   , {0:1,  97:98, 98:99}
+      itDistributes {distribute:{val:'splitMin',var:'max'}}   , {0:1,  97:98, 98:99}

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -14,12 +14,14 @@ if typeof require is 'function'
 {expect, assert} = chai
 FD = finitedomain
 
-describe "FD", ->
+describe "space.spec", ->
 
   it 'FD?', ->
+
     expect(FD?).to.be.true
 
   describe 'Space class', ->
+
     {space:Space} = FD
 
     it 'should exist', ->
@@ -478,8 +480,6 @@ describe "FD", ->
           ]
 
           expect(S.propagate()).to.eql true
-
-
 
 # the propagator methods on Space are to be tested later, after I change them completely;
     # reified

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -43,12 +43,16 @@ describe "space.spec", ->
 
       it 'should set root_space to null unless given', ->
 
-        expect(new Space().root_space).to.be.null
+        space = new Space()
+        expect(space._root_space).to.be.null
+        expect(space.get_root()).to.equal space
 
       it 'should set root_space to given root_space', ->
 
         root = {}
-        expect(new Space(root).root_space).to.equal root
+        space = new Space(root)
+        expect(space._root_space).to.equal root
+        expect(space.get_root()).to.equal root
 
     describe '#clone()', ->
 
@@ -62,15 +66,15 @@ describe "space.spec", ->
       it 'should deep clone the space and set root_space', ->
 
         lclone = space.clone() # local!
-        expect(lclone.root_space).to.equal space
-        expect(space.root_space).to.equal null
-        lclone.root_space = null # exception to the rule
+        expect(lclone._root_space).to.equal space
+        expect(space._root_space).to.equal null
+        lclone._root_space = null # exception to the rule
         expect(lclone, 'clone should be space').to.eql space
 
       it 'should set root_space to cloned space if not yet set there', ->
 
-        expect(clone.root_space, 'clone.root_space').to.equal space
-        expect(clone.clone().root_space, 'clone.clone().root_space').to.equal space
+        expect(clone._root_space, 'clone._root_space').to.equal space
+        expect(clone.clone()._root_space, 'clone.clone()._root_space').to.equal space
 
       it 'should clone vars', ->
 
@@ -215,7 +219,7 @@ describe "space.spec", ->
       it 'should not modify its space', ->
         space = new Space()
         clone = space.clone()
-        clone.root_space = null # since space is the root, it does not have itself as a root_space prop.
+        clone._root_space = null # since space is the root, it does not have itself as a root_space prop.
         space.inject ->
         expect(space).to.eql clone
 

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -474,6 +474,53 @@ describe "space.spec", ->
 
           expect(S.propagate()).to.eql true
 
+      describe 'timeout callback', ->
+
+        it 'should ignore timeout callback if not set at all', ->
+
+          # (base timeout callback test)
+
+          space = new Space()
+
+          space.decl 'A', [0, 10]
+          space.decl 'B', [0, 10]
+
+          space._propagators = [
+            ['lt', ['A', 'B']]
+          ]
+
+          expect(space.propagate()).to.eql true
+
+        it 'should not break early if callback doesnt return true', ->
+
+          space = new Space()
+
+          space.decl 'A', [0, 10]
+          space.decl 'B', [0, 10]
+
+          space._propagators = [
+            ['lt', ['A', 'B']]
+          ]
+
+          space.set_options timeout_callback: -> false
+
+          expect(space.propagate()).to.eql true
+
+        it 'should break early if callback returns true', ->
+
+          space = new Space()
+
+          space.decl 'A', [0, 10]
+          space.decl 'B', [0, 10]
+
+          space._propagators = [
+            ['lt', ['A', 'B']]
+          ]
+
+          space.set_options timeout_callback: -> true
+
+          expect(space.propagate()).to.eql false
+
 # the propagator methods on Space are to be tested later, after I change them completely;
     # reified
     # callback

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -88,13 +88,6 @@ describe "space.spec", ->
         expect(space.all_var_names).to.equal clone.all_var_names
         expect(space._propagators).to.eql clone._propagators
 
-      it 'should copy the solver', ->
-
-        expect(clone.solver).to.equal space.solver
-        s = new Space()
-        s.solver = {}
-        expect(s.clone().solver).to.equal s.solver
-
     describe '#get_value_distributor()', ->
 
       # TODO


### PR DESCRIPTION
Version 1.0.2:
- Added support for `expandVectorsWith` in Markov distribution
- Added support for `matrix[].row.boolean` to be the name of a variable, rather than the function to return this name, in Markov distributions
- Deprecating the `Solver.addVar()` option `distribute` in favor of option `distributeOptions.distribution_name`
- Fix Markov distributed variables being able to end up with invalid values (-> Added a Markov propagator, every Markov var gets one now)
- Added support for a `timeout_callback` in `Space`, which allows you to abort a search by returning `true` from a given function
- Add var distributor that prioritizes Markov variables
- Support var names to be passed on as string rather than a function to return that name, for `matrix.row` in variable distribution options
- Added `throw` distributors for variables and values which will unconditionally throw when ran. Used for testing.
- Internal refactoring/restructuring

---

version bump     0889e4a
Fix bad and broken logic    546826d
Use abstractions for throwing   6f9bc44
Improve debug output    531a01c
Satisfy linter  a5167b4
Abstract all the operation api endpoints so we can add logging  4159611
Group api end points and their abstractions together    686428c
Remove unused deps  0e469ef
Use same name as export 0588a18
Dont throw if path cannot be found as per PR Multiverse#35  d2825ef
Remove unused dep   ce770fd
Import changes from MultiverseJSON#35, reorganize tests …  e05f1fb
Cache var name  67f98e1
Make path name optional when getting solution to path   c17054b
Abstract Space#distinct too fc33775
Fix this bad thought     7ea04c3
Add @_class for debugging to Solver and PathSolver  21e6687
Disable legacy domain warning, refactor loop    3f74915
Improve Space debugging function    5bd2762
Drop useless object argument stuff   87be15a
Separate prepare and run more explicit. Make log level constants    b8df8e4
Remove cyclic reference Space<=>Solver …  560ae0f
Remove dupe unit test, fix debug branching logic    7bda55d
Refactor the markov value distributor, abstract it a little 6c054c7
Add fdvar_is_value  b948a5b
Add unit test to domain_remove_value_inline ade2bed
debug/comment update    89ee445
Add `throw` value distributor for testing   4dd7c87
Add `throw` to var distributions for testing    8e9770e
Fix solver ignoring distributor_name in distribution options    f7474b2
Accept var names as `row.boolean` too, same end result  94c762d
Add Markov propagator, refactor/dedupe markov stuff 3f9bc3d
Dont require a second var for propagators (unit test issue) e7b0303
Add markov propagator for markov vars to prevent bad value solves    185b2cd
Add markov var distributor  2e8503a
Add support for a timeout callback in Space 0b8509c
Remove unused local function    d4b1ac7
Add `Space#get_root()` and make `Space#root_space` a "private" prop  ea38193
Version bump, 1.0.2  77aec2b
