### PR TITLE
Fallback var dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ For now, see the extensive [tests](./tests)
 
 ## Version
 
+1.0.3 (unreleased):
+- Added support for fallback var distributions so you can chain list > markov > size for var distributors
+- Internal refactoring/restructuring
+
 1.0.2:
 - Added support for `expandVectorsWith` in Markov distribution
 - Added support for `matrix[].row.boolean` to be the name of a variable, rather than the function to return this name, in Markov distributions

--- a/src/distribution/var.coffee
+++ b/src/distribution/var.coffee
@@ -126,13 +126,16 @@ module.exports = (FD) ->
     return fallback v1, v2, root_space, config_next_var_func.fallback_config
 
   by_list = (v1, v2, root_space, config_next_var_func) ->
-    # note: config_var_priority_hash is compiled by Solver#prepare
-    # if in the list, lowest prio is 1. if not in the list, prio will be undefined
-    hash = root_space.config_var_priority_hash
+    # note: config.priority_hash is compiled by Solver#prepare from given priority_list
+    # if in the list, lowest prio can be 1. if not in the list, prio will be undefined
+    hash = config_next_var_func.priority_hash
 
     # if v1 or v2 is not in the list they will end up as undefined
     p1 = hash[v1.id]
     p2 = hash[v2.id]
+
+    ASSERT p1 isnt 0, 'index 0 should never be used'
+    ASSERT p2 isnt 0, 'index 0 should never be used'
 
     unless p1 or p2
       # either p1 and p2 both dont exist on the list, or ... well no that's it

--- a/src/distribution/var.coffee
+++ b/src/distribution/var.coffee
@@ -12,6 +12,9 @@ module.exports = (FD) ->
     fdvar_upper_bound
   } = FD.Fdvar
 
+  BETTER = 1
+  SAME = 2
+  WORSE = 3
 
   # Given a list of variables return the next var to consider based on the
   # current var distribution configuration and an optional filter condition.
@@ -25,14 +28,21 @@ module.exports = (FD) ->
     config_next_var_func = root_space.config_next_var_func
     fdvars = space.vars
 
+    # if it's a function it should return the name of the next var to process
     if typeof config_next_var_func is 'function'
       return config_next_var_func space, target_vars
 
-    switch config_next_var_func
+    dist_name = config_next_var_func
+
+    # if it's an object it's a more complex config
+    if typeof config_next_var_func is 'object'
+      dist_name = config_next_var_func.dist_name
+
+    switch dist_name
       when 'naive'
         is_better_var = null
       when 'size'
-        is_better_var = by_size
+        is_better_var = by_min_size
       when 'min'
         is_better_var = by_min
       when 'max'
@@ -44,7 +54,7 @@ module.exports = (FD) ->
       when 'list'
         is_better_var = by_list
       else
-        THROW 'unknown next var func', config_next_var_func
+        THROW 'unknown next var func', dist_name
 
     config_var_filter = root_space.config_var_filter_func
     if config_var_filter and typeof config_var_filter isnt 'function'
@@ -54,7 +64,7 @@ module.exports = (FD) ->
         else
           THROW 'unknown var filter', config_var_filter
 
-    return find_best fdvars, target_vars, is_better_var, config_var_filter, root_space
+    return find_best fdvars, target_vars, is_better_var, config_var_filter, config_next_var_func, root_space
 
   # Return the best var name according to a fitness function
   # but only if the filter function is okay with it.
@@ -63,50 +73,132 @@ module.exports = (FD) ->
   # @param {string[]} names A subset of names that are properties on fdvars
   # @param {Function(fdvar,fdvar)} [fitness_func] Given two fdvars returns true iif the first var is better than the second var
   # @param {Function(fdvar)} [filter_func] If given only consider vars where this function returns true
+  # @param {string|Object} config_next_var_func From Space; either the name of the dist or specific options for a var dist
   # @param {Space} root_space
   # @returns {Fdvar}
 
-  find_best = (fdvars, names, fitness_func, filter_func, root_space) ->
+  find_best = (fdvars, names, fitness_func, filter_func, config_next_var_func, root_space) ->
     best = ''
     for name, i in names
       fdvar = fdvars[name]
       # TOFIX: if the name is the empty string this could lead to a problem. Must eliminate the empty string as var name
-      if (!filter_func or filter_func fdvar) and (!best or (fitness_func and fitness_func fdvar, best, root_space))
-        best = fdvar
+
+      if !filter_func or filter_func fdvar
+        if not best or (fitness_func and BETTER is fitness_func fdvar, best, root_space, config_next_var_func)
+          best = fdvar
     return best
 
   ######
   # preset fitness functions
   ######
 
-  by_size = (v1, v2) ->
-    return fdvar_size(v1) < fdvar_size(v2)
+  by_min_size = (v1, v2) ->
+    n = fdvar_size(v1) - fdvar_size(v2)
+    if n < 0
+      return BETTER
+    if n > 0
+      return WORSE
+    return SAME
 
   by_min = (v1, v2) ->
-    return fdvar_lower_bound(v1) < fdvar_lower_bound(v2)
+    n = fdvar_lower_bound(v1) - fdvar_lower_bound(v2)
+    if n < 0
+      return BETTER
+    if n > 0
+      return WORSE
+    return SAME
 
   by_max = (v1, v2) ->
-    return fdvar_upper_bound(v1) > fdvar_upper_bound(v2)
+    n = fdvar_upper_bound(v1) - fdvar_upper_bound(v2)
+    if n > 0
+      return BETTER
+    if n < 0
+      return WORSE
+    return SAME
 
-  by_markov = (v1, v2, root_space) ->
+  by_markov = (v1, v2, root_space, config_next_var_func) ->
     # v1 is only, but if so always, better than v2 if v1 is a markov var
-    return root_space.config_var_dist_options[v1.id]?.distributor_name is 'markov'
+    if root_space.config_var_dist_options[v1.id]?.distributor_name is 'markov'
+      return BETTER
+    if root_space.config_var_dist_options[v2.id]?.distributor_name is 'markov'
+      return WORSE
 
-  by_list = (v1, v2, root_space) ->
+    return fallback v1, v2, root_space, config_next_var_func.fallback_config
+
+  by_list = (v1, v2, root_space, config_next_var_func) ->
     # note: config_var_priority_hash is compiled by Solver#prepare
     # if in the list, lowest prio is 1. if not in the list, prio will be undefined
     hash = root_space.config_var_priority_hash
 
+    # if v1 or v2 is not in the list they will end up as undefined
     p1 = hash[v1.id]
-    if !p1
-      return false
     p2 = hash[v2.id]
-    return !p2 or p1 > p2
+
+    unless p1 or p2
+      # either p1 and p2 both dont exist on the list, or ... well no that's it
+      return fallback v1, v2, root_space, config_next_var_func.fallback_config
+
+    if !p2
+      return BETTER
+    if !p1
+      return WORSE
+
+    if p1 > p2
+      return BETTER
+    if p2 > p1
+      return WORSE
+
+    ASSERT p1 isnt p2, 'cant have same indexes, would mean same item is compared'
+    ASSERT false, 'not expecting to reach here', p1, p2, v1, v2, hash
+    return SAME
+
+  fallback = (v1, v2, root_space, config) ->
+    unless config
+      return SAME
+
+    if typeof config is 'string'
+      dist_name = config
+    else if typeof config is 'object'
+      dist_name = config.dist_name
+      unless dist_name
+        THROW "Missing fallback var distribution name: #{JSON.stringify config}"
+    else if typeof config is 'function'
+      return config v1, v2, root_space
+    else
+      THROW 'Unexpected fallback config', config
+
+    switch dist_name
+      when 'size'
+        return by_min_size v1, v2
+      when 'min'
+        return by_min v1, v2
+      when 'max'
+        return by_max v1, v2
+      when 'throw'
+        THROW 'nope'
+      when 'markov'
+        return by_markov v1, v2, root_space, config
+      when 'list'
+        return by_list v1, v2, root_space, config
+      else
+        THROW "Unknown var dist fallback name: #{dist_name}"
+
+    ASSERT false, 'should not reach here'
+    return
 
   FD.distribution.var = {
+    BETTER
+    SAME
+    WORSE
+
     distribution_get_next_var
 
+    # for testing
+    _distribution_var_list: by_list
     _distribution_var_max: by_max
+    _distribution_var_markov: by_markov
     _distribution_var_min: by_min
-    _distribution_var_size: by_size
+    _distribution_var_size: by_min_size
+    _distribution_var_throw: (s) -> THROW s
+    _distribution_var_fallback: fallback
   }

--- a/tests/spec/distribution/var.spec.coffee
+++ b/tests/spec/distribution/var.spec.coffee
@@ -51,165 +51,175 @@ describe 'distribution/var.spec', ->
 
   describe 'by_min', ->
 
-    it_ab 'min', [0, 1], [10, 11], 'A', 'should decide on lowest vars first A'
-    it_ab 'min', [20, 30], [5, 8], 'B', 'should decide on lowest vars first B'
-    it_ab 'min', [9, 21], [10, 20], 'A', 'should base decision on lowest lo, not lowest hi'
+    describe 'integration', ->
+
+      it_ab 'min', [0, 1], [10, 11], 'A', 'should decide on lowest vars first A'
+      it_ab 'min', [20, 30], [5, 8], 'B', 'should decide on lowest vars first B'
+      it_ab 'min', [9, 21], [10, 20], 'A', 'should base decision on lowest lo, not lowest hi'
 
   describe 'by_max', ->
 
-    it_ab 'max', [0, 1], [10, 11], 'B', 'should decide on highest vars first A'
-    it_ab 'max', [20, 30], [5, 8], 'A', 'should decide on highest vars first B'
-    it_ab 'max', [9, 21], [10, 20], 'A', 'should base decision on highest hi, not highest lo'
+    describe 'integration', ->
+
+      it_ab 'max', [0, 1], [10, 11], 'B', 'should decide on highest vars first A'
+      it_ab 'max', [20, 30], [5, 8], 'A', 'should decide on highest vars first B'
+      it_ab 'max', [9, 21], [10, 20], 'A', 'should base decision on highest hi, not highest lo'
 
   describe 'by_size', ->
 
-    it_ab 'size', [0, 1], [10, 12], 'A', 'should decide on largest domain first A'
-    it_ab 'size', [20, 30], [50, 55], 'B', 'should decide on largest domain first B'
+    describe 'integration', ->
 
-    it 'should count actual elements in the domain', ->
+      it_ab 'size', [0, 1], [10, 12], 'A', 'should decide on largest domain first A'
+      it_ab 'size', [20, 30], [50, 55], 'B', 'should decide on largest domain first B'
 
-      # note: further tests should be unit tests on domain_size instead
-      solver = new Solver
-      solver.addVar
-        id: 'A'
-        domain: spec_d_create_ranges [30, 100] # 71 elements
-      solver.addVar
-        id: 'B'
-        domain: spec_d_create_ranges [0, 50], [60, 90] # 82 elements
-      solver.prepare
-        distribute: var: 'size'
+      it 'should count actual elements in the domain', ->
 
-      fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
+        # note: further tests should be unit tests on domain_size instead
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+          domain: spec_d_create_ranges [30, 100] # 71 elements
+        solver.addVar
+          id: 'B'
+          domain: spec_d_create_ranges [0, 50], [60, 90] # 82 elements
+        solver.prepare
+          distribute: var: 'size'
 
-      expect(fdvar.id).to.eql 'B'
+        fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
+
+        expect(fdvar.id).to.eql 'B'
 
   describe 'by_markov', ->
 
-    it 'should prioritize markov vars', ->
+    describe 'integration', ->
 
-      solver = new Solver
-      solver.addVar
-        id: 'A'
-        domain: spec_d_create_ranges [0, 1]
-      solver.addVar
-        id: 'B'
-        domain: spec_d_create_ranges [10, 12]
-        distributeOptions:
-          distributor_name: 'markov'
-          expandVectorsWith: 1
-      solver.addVar
-        id: 'C'
-        domain: spec_d_create_ranges [5, 17]
-      solver.addVar
-        id: 'D'
-        domain: spec_d_create_ranges [13, 13]
-      solver.prepare
-        distribute: var: 'markov'
+      it 'should prioritize markov vars', ->
 
-      fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B', 'C', 'D']
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+          domain: spec_d_create_ranges [0, 1]
+        solver.addVar
+          id: 'B'
+          domain: spec_d_create_ranges [10, 12]
+          distributeOptions:
+            distributor_name: 'markov'
+            expandVectorsWith: 1
+        solver.addVar
+          id: 'C'
+          domain: spec_d_create_ranges [5, 17]
+        solver.addVar
+          id: 'D'
+          domain: spec_d_create_ranges [13, 13]
+        solver.prepare
+          distribute: var: 'markov'
 
-      expect(fdvar.id).to.eql 'B'
+        fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B', 'C', 'D']
 
-    it 'should get markov vars back to front', ->
-      # it's not really a hard requirement but that's how it works
+        expect(fdvar.id).to.eql 'B'
 
-      solver = new Solver
-      solver.addVar
-        id: 'A'
-        domain: spec_d_create_ranges [0, 1]
-      solver.addVar
-        id: 'B'
-        domain: spec_d_create_ranges [10, 12]
-        distributeOptions:
-          distributor_name: 'markov'
-          expandVectorsWith: 1
-      solver.addVar
-        id: 'C'
-        domain: spec_d_create_ranges [5, 17]
-        distributeOptions:
-          distributor_name: 'markov'
-          expandVectorsWith: 1
-      solver.addVar
-        id: 'D'
-        domain: spec_d_create_ranges [13, 13]
-      solver.prepare
-        distribute: var: 'markov'
+      it 'should get markov vars back to front', ->
+        # it's not really a hard requirement but that's how it works
 
-      fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B', 'C', 'D']
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+          domain: spec_d_create_ranges [0, 1]
+        solver.addVar
+          id: 'B'
+          domain: spec_d_create_ranges [10, 12]
+          distributeOptions:
+            distributor_name: 'markov'
+            expandVectorsWith: 1
+        solver.addVar
+          id: 'C'
+          domain: spec_d_create_ranges [5, 17]
+          distributeOptions:
+            distributor_name: 'markov'
+            expandVectorsWith: 1
+        solver.addVar
+          id: 'D'
+          domain: spec_d_create_ranges [13, 13]
+        solver.prepare
+          distribute: var: 'markov'
 
-      expect(fdvar.id).to.eql 'C'
+        fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B', 'C', 'D']
+
+        expect(fdvar.id).to.eql 'C'
 
   describe 'by_list', ->
 
-    it 'should solve vars in the explicit order of the list A', ->
+    describe 'integration', ->
+
+      it 'should solve vars in the explicit order of the list A', ->
 
 
-      solver = new Solver
-      solver.addVar
-        id: 'A'
-      solver.addVar
-        id: 'B'
-      solver.prepare
-        distribute:
-          var: 'list'
-          var_priority: ['A', 'B']
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+        solver.addVar
+          id: 'B'
+        solver.prepare
+          distribute:
+            var: 'list'
+            var_priority: ['A', 'B']
 
-      fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
+        fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
 
-      expect(fdvar.id).to.eql 'A'
+        expect(fdvar.id).to.eql 'A'
 
-    it 'should solve vars in the explicit order of the list B', ->
-
-
-      solver = new Solver
-      solver.addVar
-        id: 'A'
-      solver.addVar
-        id: 'B'
-      solver.prepare
-        distribute:
-          var: 'list'
-          var_priority: ['B', 'A']
-
-      fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
-
-      expect(fdvar.id).to.eql 'B'
-
-    it 'should not crash if a var is not on the list or when list is empty', ->
+      it 'should solve vars in the explicit order of the list B', ->
 
 
-      solver = new Solver
-      solver.addVar
-        id: 'A'
-      solver.prepare
-        distribute:
-          var: 'list'
-          var_priority: []
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+        solver.addVar
+          id: 'B'
+        solver.prepare
+          distribute:
+            var: 'list'
+            var_priority: ['B', 'A']
 
-      fdvar = distribution_get_next_var solver.space, solver.space, ['A']
+        fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
 
-      expect(fdvar.id).to.eql 'A'
+        expect(fdvar.id).to.eql 'B'
 
-    it 'should assume unlisted vars come after listed vars', ->
+      it 'should not crash if a var is not on the list or when list is empty', ->
 
 
-      solver = new Solver
-      solver.addVar
-        id: 'A'
-      solver.addVar
-        id: 'B'
-      solver.addVar
-        id: 'C'
-      solver.prepare
-        distribute:
-          var: 'list'
-          var_priority: ['A', 'C']
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+        solver.prepare
+          distribute:
+            var: 'list'
+            var_priority: []
 
-      fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B', 'C']
-      expect(fdvar.id, 'A and C should go before B').to.eql 'A'
-      fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
-      expect(fdvar.id, 'A should go before B').to.eql 'A'
-      fdvar = distribution_get_next_var solver.space, solver.space, ['B', 'C']
-      expect(fdvar.id, 'C should go before B').to.eql 'C'
-      fdvar = distribution_get_next_var solver.space, solver.space, ['B']
-      expect(fdvar.id, 'B is only one left').to.eql 'B'
+        fdvar = distribution_get_next_var solver.space, solver.space, ['A']
+
+        expect(fdvar.id).to.eql 'A'
+
+      it 'should assume unlisted vars come after listed vars', ->
+
+
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+        solver.addVar
+          id: 'B'
+        solver.addVar
+          id: 'C'
+        solver.prepare
+          distribute:
+            var: 'list'
+            var_priority: ['A', 'C']
+
+        fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B', 'C']
+        expect(fdvar.id, 'A and C should go before B').to.eql 'A'
+        fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
+        expect(fdvar.id, 'A should go before B').to.eql 'A'
+        fdvar = distribution_get_next_var solver.space, solver.space, ['B', 'C']
+        expect(fdvar.id, 'C should go before B').to.eql 'C'
+        fdvar = distribution_get_next_var solver.space, solver.space, ['B']
+        expect(fdvar.id, 'B is only one left').to.eql 'B'

--- a/tests/spec/distribution/var.spec.coffee
+++ b/tests/spec/distribution/var.spec.coffee
@@ -16,12 +16,26 @@ FD = finitedomain
 describe 'distribution/var.spec', ->
 
   {
+    Fdvar
     Solver
   } = FD
 
   {
+    BETTER
+    SAME
+    WORSE
+
     distribution_get_next_var
+    _distribution_var_min: by_min
+    _distribution_var_max: by_max
+    _distribution_var_size: by_min_size
+    _distribution_var_markov: by_markov
+    _distribution_var_list: by_list
   } = FD.distribution.var
+
+  {
+    fdvar_create
+  } = Fdvar
 
 
   describe 'distribution_var_by_throw', ->
@@ -51,6 +65,29 @@ describe 'distribution/var.spec', ->
 
   describe 'by_min', ->
 
+    describe 'unit', ->
+
+      it 'should return BETTER if lo(v1) < lo(v2)', ->
+
+        v1 = fdvar_create '1', [10, 11]
+        v2 = fdvar_create '2', [11, 11]
+
+        expect(by_min v1, v2).to.equal BETTER
+
+      it 'should return SAME if lo(v1) = lo(v2)', ->
+
+        v1 = fdvar_create '1', [11, 11]
+        v2 = fdvar_create '2', [11, 11]
+
+        expect(by_min v1, v2).to.equal SAME
+
+      it 'should return WORSE if lo(v1) > lo(v2)', ->
+
+        v1 = fdvar_create '1', [12, 11]
+        v2 = fdvar_create '2', [11, 11]
+
+        expect(by_min v1, v2).to.equal WORSE
+
     describe 'integration', ->
 
       it_ab 'min', [0, 1], [10, 11], 'A', 'should decide on lowest vars first A'
@@ -59,6 +96,29 @@ describe 'distribution/var.spec', ->
 
   describe 'by_max', ->
 
+    describe 'unit', ->
+
+      it 'should return BETTER if hi(v1) > hi(v2)', ->
+
+        v1 = fdvar_create '1', [11, 12]
+        v2 = fdvar_create '2', [11, 11]
+
+        expect(by_max v1, v2).to.equal BETTER
+
+      it 'should return SAME if hi(v1) = hi(v2)', ->
+
+        v1 = fdvar_create '1', [11, 11]
+        v2 = fdvar_create '2', [11, 11]
+
+        expect(by_max v1, v2).to.equal SAME
+
+      it 'should return WORSE if hi(v1) < hi(v2)', ->
+
+        v1 = fdvar_create '1', [11, 10]
+        v2 = fdvar_create '2', [11, 11]
+
+        expect(by_max v1, v2).to.equal WORSE
+
     describe 'integration', ->
 
       it_ab 'max', [0, 1], [10, 11], 'B', 'should decide on highest vars first A'
@@ -66,6 +126,45 @@ describe 'distribution/var.spec', ->
       it_ab 'max', [9, 21], [10, 20], 'A', 'should base decision on highest hi, not highest lo'
 
   describe 'by_size', ->
+
+    describe 'unit', ->
+
+      # note: further tests should be unit tests on domain_size instead
+
+      it 'should return BETTER if size(v1) < size(v2)', ->
+
+        v1 = fdvar_create '1', [5, 5]
+        v2 = fdvar_create '2', [11, 12]
+
+        expect(by_min_size v1, v2).to.equal BETTER
+
+      it 'should return SAME if size(v1) = size(v2) with single range', ->
+
+        v1 = fdvar_create '1', [11, 11]
+        v2 = fdvar_create '2', [8, 8]
+
+        expect(by_min_size v1, v2).to.equal SAME
+
+      it 'should return SAME if size(v1) = size(v2) with multiple ranges', ->
+
+        v1 = fdvar_create '1', spec_d_create_ranges [11, 11], [15, 19]
+        v2 = fdvar_create '2', spec_d_create_ranges [8, 10], [12, 14]
+
+        expect(by_min_size v1, v2).to.equal SAME
+
+      it 'should return SAME if size(v1) = size(v2) with different range count', ->
+
+        v1 = fdvar_create '1', spec_d_create_ranges [11, 11], [13, 14], [18, 19]
+        v2 = fdvar_create '2', spec_d_create_ranges [8, 10], [12, 13]
+
+        expect(by_min_size v1, v2).to.equal SAME
+
+      it 'should return WORSE if size(v1) > size(v2)', ->
+
+        v1 = fdvar_create '1', [11, 12]
+        v2 = fdvar_create '2', [11, 11]
+
+        expect(by_min_size v1, v2).to.equal WORSE
 
     describe 'integration', ->
 
@@ -90,6 +189,71 @@ describe 'distribution/var.spec', ->
         expect(fdvar.id).to.eql 'B'
 
   describe 'by_markov', ->
+
+    describe 'unit', ->
+
+      it 'should say v1 is BETTER if v1 is a markov var', ->
+
+        v1 = fdvar_create 'A', [11, 12]
+        v2 = fdvar_create 'B', [11, 11]
+        fake_space = config_var_dist_options: A: distributor_name: 'markov'
+
+        expect(by_markov v1, v2, fake_space).to.equal BETTER
+
+      it 'should say v2 is WORSE if v1 not a markov but v2 is', ->
+
+        v1 = fdvar_create 'A', [11, 12]
+        v2 = fdvar_create 'B', [11, 11]
+        fake_space = config_var_dist_options: B: distributor_name: 'markov'
+
+        expect(by_markov v1, v2, fake_space).to.equal WORSE
+
+      it 'should say v1 is BETTER if v1 and v2 are both markov vars', ->
+
+        v1 = fdvar_create 'A', [11, 12]
+        v2 = fdvar_create 'B', [11, 11]
+        fake_space =
+          config_var_dist_options:
+            A: distributor_name: 'markov'
+            B: distributor_name: 'markov'
+
+        expect(by_markov v1, v2, fake_space).to.equal BETTER
+
+      it 'should say v1 is SAME as v2 if neither is a markov var', ->
+
+        v1 = fdvar_create 'A', [11, 12]
+        v2 = fdvar_create 'B', [11, 11]
+        fake_space = config_var_dist_options: {}
+        fake_config = {} # its okay to expect this to exist
+
+        expect(by_markov v1, v2, fake_space, fake_config).to.equal SAME
+
+      it 'should use fallback if available and vars are SAME and then return BETTER', ->
+
+        v1 = fdvar_create 'A', [11, 11]
+        v2 = fdvar_create 'B', [11, 12]
+        fake_space = config_var_dist_options: {} # neither is markov
+        fallback_config = fallback_config: 'size'
+
+        expect(by_markov v1, v2, fake_space, fallback_config).to.equal BETTER
+
+      it 'should use fallback if available and vars are SAME but then still return SAME', ->
+
+        v1 = fdvar_create 'A', [11, 11]
+        v2 = fdvar_create 'B', [11, 11]
+        fake_space = config_var_dist_options: {} # neither is markov
+        fallback_config = fallback_config: 'size'
+
+        expect(by_markov v1, v2, fake_space, fallback_config).to.equal SAME
+
+      it 'should use fallback if available and vars are SAME and then return WORSE', ->
+
+        v1 = fdvar_create 'A', [11, 12]
+        v2 = fdvar_create 'B', [11, 11]
+        fake_space = config_var_dist_options: {} # neither is markov
+        fallback_config = fallback_config: 'size'
+
+        expect(by_markov v1, v2, fake_space, fallback_config).to.equal WORSE
 
     describe 'integration', ->
 
@@ -149,6 +313,135 @@ describe 'distribution/var.spec', ->
 
   describe 'by_list', ->
 
+    describe 'unit', ->
+
+      it 'should return BETTER if the priority hash says A is higher than B', ->
+
+        v1 = fdvar_create 'A', []
+        v2 = fdvar_create 'B', []
+        fake_space =
+          config_var_dist_options: {}
+          config_var_priority_hash:
+            A: 2
+            B: 1
+
+        expect(by_list v1, v2, fake_space, {}).to.equal BETTER
+
+      it 'should THROW if the priority hash says A is equal to B', ->
+
+        v1 = fdvar_create 'A', []
+        v2 = fdvar_create 'B', []
+        fake_space =
+          config_var_dist_options: {}
+          config_var_priority_hash:
+            A: 2
+            B: 2
+
+        expect(-> by_list v1, v2, fake_space, {}).to.throw
+
+
+      it 'should return WORSE if the priority hash says A is lower than B', ->
+
+        v1 = fdvar_create 'A', []
+        v2 = fdvar_create 'B', []
+        fake_space =
+          config_var_dist_options: {}
+          config_var_priority_hash:
+            A: 1
+            B: 2
+
+        expect(by_list v1, v2, fake_space, {}).to.equal WORSE
+
+      it 'should return BETTER if A is in the hash but B is not', ->
+
+        v1 = fdvar_create 'A', []
+        v2 = fdvar_create 'B', []
+        fake_space =
+          config_var_dist_options: {}
+          config_var_priority_hash:
+            A: 2
+
+        expect(by_list v1, v2, fake_space, {}).to.equal BETTER
+
+      it 'should return WORSE if B is in the hash but A is not', ->
+
+        v1 = fdvar_create 'A', []
+        v2 = fdvar_create 'B', []
+        fake_space =
+          config_var_dist_options: {}
+          config_var_priority_hash:
+            B: 2
+
+        expect(by_list v1, v2, fake_space, {}).to.equal WORSE
+
+      it 'should throw if A gets value 0 from the hash', ->
+
+        v1 = fdvar_create 'A', []
+        v2 = fdvar_create 'B', []
+        fake_space =
+          config_var_dist_options: {}
+          config_var_priority_hash:
+            A: 0
+
+        expect(-> by_list v1, v2, fake_space, {}).to.throw
+
+      it 'should throw if B gets value 0 from the hash', ->
+
+        v1 = fdvar_create 'A', []
+        v2 = fdvar_create 'B', []
+        fake_space =
+          config_var_dist_options: {}
+          config_var_priority_hash:
+            B: 2
+
+        expect(-> by_list v1, v2, fake_space, {}).to.throw
+
+      it 'should return SAME if neither A nor B is in the hash without fallback', ->
+
+        v1 = fdvar_create 'A', []
+        v2 = fdvar_create 'B', []
+        fake_space =
+          config_var_dist_options: {}
+          config_var_priority_hash: {}
+
+        expect(by_list v1, v2, fake_space, {}).to.equal SAME
+
+      it 'should return BETTER if neither is in the hash and fallback is size with A smaller', ->
+
+        v1 = fdvar_create 'A', [0, 0]
+        v2 = fdvar_create 'B', [0, 10]
+        fake_space =
+          config_var_dist_options: {}
+          config_var_priority_hash: {}
+        fallback =
+          fallback_config: 'size'
+
+        expect(by_list v1, v2, fake_space, fallback).to.equal BETTER
+
+      it 'should return SAME if neither is in the hash and fallback is size with A same size as B', ->
+
+        v1 = fdvar_create 'A', [0, 10]
+        v2 = fdvar_create 'B', [0, 10]
+        fake_space =
+          config_var_dist_options: {}
+          config_var_priority_hash: {}
+        fallback =
+          fallback_config: 'size'
+
+        expect(by_list v1, v2, fake_space, fallback).to.equal SAME
+
+      it 'should return WORSE if neither is in the hash and fallback is size with A larger', ->
+
+        v1 = fdvar_create 'A', [0, 10]
+        v2 = fdvar_create 'B', [0, 0]
+        fake_space =
+          config_var_dist_options: {}
+          config_var_priority_hash: {}
+        fallback =
+          fallback_config: 'size'
+
+        expect(by_list v1, v2, fake_space, fallback).to.equal WORSE
+
     describe 'integration', ->
 
       it 'should solve vars in the explicit order of the list A', ->
@@ -202,7 +495,6 @@ describe 'distribution/var.spec', ->
 
       it 'should assume unlisted vars come after listed vars', ->
 
-
         solver = new Solver
         solver.addVar
           id: 'A'
@@ -223,3 +515,94 @@ describe 'distribution/var.spec', ->
         expect(fdvar.id, 'C should go before B').to.eql 'C'
         fdvar = distribution_get_next_var solver.space, solver.space, ['B']
         expect(fdvar.id, 'B is only one left').to.eql 'B'
+
+  describe 'fallback list -> markov -> size', ->
+
+    # each test will ask for a var and supply a more limited list of vars
+
+    solver = new Solver
+    solver.addVar
+      id: 'A_list'
+      domain: [0, 10]
+    solver.addVar
+      id: 'B_list'
+      domain: [0, 20]
+    solver.addVar
+      id: 'C_markov'
+      domain: [0, 100]
+      distributeOptions:
+        distributor_name: 'markov'
+        expandVectorsWith: 1
+    solver.addVar
+      id: 'D_markov'
+      domain: [0, 50]
+      distributeOptions:
+        distributor_name: 'markov'
+        expandVectorsWith: 1
+    solver.addVar
+      id: 'E_pleb'
+      domain: [0, 100]
+    solver.addVar
+      id: 'F_pleb'
+      domain: [0, 75]
+    solver.prepare
+      distribute:
+        var_priority: ['B_list', 'A_list']
+        var:
+          dist_name: 'list'
+          fallback_config:
+            dist_name: 'markov'
+            fallback_config: 'size'
+
+    it 'base test: should get highest priority on the list; A_list', ->
+
+      fdvar = distribution_get_next_var solver.space, solver.space, ['A_list', 'B_list', 'C_markov', 'D_markov', 'E_pleb', 'F_pleb']
+
+      expect(fdvar.id).to.equal 'B_list'
+
+    it 'missing first item from list', ->
+
+      fdvar = distribution_get_next_var solver.space, solver.space, ['A_list', 'C_markov', 'D_markov', 'E_pleb', 'F_pleb']
+
+      expect(fdvar.id).to.equal 'A_list'
+
+    it 'nothing on list, fallback to markov, get last markov', ->
+
+      fdvar = distribution_get_next_var solver.space, solver.space, ['C_markov', 'D_markov', 'E_pleb', 'F_pleb']
+
+      expect(fdvar.id).to.equal 'D_markov'
+
+    it 'nothing on list, fallback to markov, get only markov', ->
+
+      fdvar = distribution_get_next_var solver.space, solver.space, ['C_markov', 'E_pleb', 'F_pleb']
+
+      expect(fdvar.id).to.equal 'C_markov'
+
+    it 'nothing on list, no markov vars, pick smallest by size', ->
+
+      fdvar = distribution_get_next_var solver.space, solver.space, ['E_pleb', 'F_pleb']
+
+      expect(fdvar.id).to.equal 'F_pleb'
+
+    it 'nothing on list, no markov vars, pick only var left', ->
+
+      fdvar = distribution_get_next_var solver.space, solver.space, ['E_pleb']
+
+      expect(fdvar.id).to.equal 'E_pleb'
+
+    it 'should just return undefined despite config', ->
+
+      fdvar = distribution_get_next_var solver.space, solver.space, []
+
+      expect(fdvar.id).to.equal undefined
+
+    it 'dont crash on randomized inclusion and order', ->
+
+      all = ['A_list', 'B_list', 'C_markov', 'D_markov', 'E_pleb', 'F_pleb']
+      for [0..20]
+        # randomly remove elements from the list
+        names = all.filter -> Math.random() > 0.3
+        # shuffle list the ugly way
+        names.sort -> Math.random() - .5
+
+        expect(-> distribution_get_next_var solver.space, solver.space, names).not.to.throw

--- a/tests/spec/distribution/var.spec.coffee
+++ b/tests/spec/distribution/var.spec.coffee
@@ -319,69 +319,64 @@ describe 'distribution/var.spec', ->
 
         v1 = fdvar_create 'A', []
         v2 = fdvar_create 'B', []
-        fake_space =
-          config_var_dist_options: {}
-          config_var_priority_hash:
+        config =
+          priority_hash:
             A: 2
             B: 1
 
-        expect(by_list v1, v2, fake_space, {}).to.equal BETTER
+        expect(by_list v1, v2, {}, config).to.equal BETTER
 
       it 'should THROW if the priority hash says A is equal to B', ->
 
         v1 = fdvar_create 'A', []
         v2 = fdvar_create 'B', []
-        fake_space =
-          config_var_dist_options: {}
-          config_var_priority_hash:
+        config =
+          priority_hash:
             A: 2
             B: 2
 
-        expect(-> by_list v1, v2, fake_space, {}).to.throw
+        expect(-> by_list v1, v2, {}, config).to.throw
 
 
       it 'should return WORSE if the priority hash says A is lower than B', ->
 
         v1 = fdvar_create 'A', []
         v2 = fdvar_create 'B', []
-        fake_space =
-          config_var_dist_options: {}
-          config_var_priority_hash:
+        config =
+          priority_hash:
             A: 1
             B: 2
 
-        expect(by_list v1, v2, fake_space, {}).to.equal WORSE
+        expect(by_list v1, v2, {}, config).to.equal WORSE
 
       it 'should return BETTER if A is in the hash but B is not', ->
 
         v1 = fdvar_create 'A', []
         v2 = fdvar_create 'B', []
-        fake_space =
-          config_var_dist_options: {}
-          config_var_priority_hash:
+        config =
+          priority_hash:
             A: 2
 
-        expect(by_list v1, v2, fake_space, {}).to.equal BETTER
+        expect(by_list v1, v2, {}, config).to.equal BETTER
 
       it 'should return WORSE if B is in the hash but A is not', ->
 
         v1 = fdvar_create 'A', []
         v2 = fdvar_create 'B', []
-        fake_space =
-          config_var_dist_options: {}
-          config_var_priority_hash:
+        config =
+          priority_hash:
             B: 2
 
-        expect(by_list v1, v2, fake_space, {}).to.equal WORSE
+        expect(by_list v1, v2, {}, config).to.equal WORSE
 
       it 'should throw if A gets value 0 from the hash', ->
 
         v1 = fdvar_create 'A', []
         v2 = fdvar_create 'B', []
         fake_space =
-          config_var_dist_options: {}
-          config_var_priority_hash:
-            A: 0
+          config_var_dist_options:
+            priority_hash:
+              A: 0
 
         expect(-> by_list v1, v2, fake_space, {}).to.throw
 
@@ -389,58 +384,50 @@ describe 'distribution/var.spec', ->
 
         v1 = fdvar_create 'A', []
         v2 = fdvar_create 'B', []
-        fake_space =
-          config_var_dist_options: {}
-          config_var_priority_hash:
+        config =
+          priority_hash:
             B: 2
 
-        expect(-> by_list v1, v2, fake_space, {}).to.throw
+        expect(-> by_list v1, v2, {}, config).to.throw
 
       it 'should return SAME if neither A nor B is in the hash without fallback', ->
 
         v1 = fdvar_create 'A', []
         v2 = fdvar_create 'B', []
-        fake_space =
-          config_var_dist_options: {}
-          config_var_priority_hash: {}
+        config =
+          priority_hash: {}
 
-        expect(by_list v1, v2, fake_space, {}).to.equal SAME
+        expect(by_list v1, v2, {}, config).to.equal SAME
 
       it 'should return BETTER if neither is in the hash and fallback is size with A smaller', ->
 
         v1 = fdvar_create 'A', [0, 0]
         v2 = fdvar_create 'B', [0, 10]
-        fake_space =
-          config_var_dist_options: {}
-          config_var_priority_hash: {}
-        fallback =
+        config =
+          priority_hash: {}
           fallback_config: 'size'
 
-        expect(by_list v1, v2, fake_space, fallback).to.equal BETTER
+        expect(by_list v1, v2, {}, config).to.equal BETTER
 
       it 'should return SAME if neither is in the hash and fallback is size with A same size as B', ->
 
         v1 = fdvar_create 'A', [0, 10]
         v2 = fdvar_create 'B', [0, 10]
-        fake_space =
-          config_var_dist_options: {}
-          config_var_priority_hash: {}
-        fallback =
+        config =
+          priority_hash: {}
           fallback_config: 'size'
 
-        expect(by_list v1, v2, fake_space, fallback).to.equal SAME
+        expect(by_list v1, v2, {}, config).to.equal SAME
 
       it 'should return WORSE if neither is in the hash and fallback is size with A larger', ->
 
         v1 = fdvar_create 'A', [0, 10]
         v2 = fdvar_create 'B', [0, 0]
-        fake_space =
-          config_var_dist_options: {}
-          config_var_priority_hash: {}
-        fallback =
+        config =
+          priority_hash: {}
           fallback_config: 'size'
 
-        expect(by_list v1, v2, fake_space, fallback).to.equal WORSE
+        expect(by_list v1, v2, {}, config).to.equal WORSE
 
     describe 'integration', ->
 
@@ -454,8 +441,9 @@ describe 'distribution/var.spec', ->
           id: 'B'
         solver.prepare
           distribute:
-            var: 'list'
-            var_priority: ['A', 'B']
+            var:
+              dist_name: 'list'
+              priority_list: ['A', 'B']
 
         fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
 
@@ -471,8 +459,9 @@ describe 'distribution/var.spec', ->
           id: 'B'
         solver.prepare
           distribute:
-            var: 'list'
-            var_priority: ['B', 'A']
+            var:
+              dist_name: 'list'
+              priority_list: ['B', 'A']
 
         fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
 
@@ -486,8 +475,9 @@ describe 'distribution/var.spec', ->
           id: 'A'
         solver.prepare
           distribute:
-            var: 'list'
-            var_priority: []
+            var:
+              dist_name: 'list'
+              priority_list: []
 
         fdvar = distribution_get_next_var solver.space, solver.space, ['A']
 
@@ -504,8 +494,9 @@ describe 'distribution/var.spec', ->
           id: 'C'
         solver.prepare
           distribute:
-            var: 'list'
-            var_priority: ['A', 'C']
+            var:
+              dist_name: 'list'
+              priority_list: ['A', 'C']
 
         fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B', 'C']
         expect(fdvar.id, 'A and C should go before B').to.eql 'A'
@@ -515,6 +506,33 @@ describe 'distribution/var.spec', ->
         expect(fdvar.id, 'C should go before B').to.eql 'C'
         fdvar = distribution_get_next_var solver.space, solver.space, ['B']
         expect(fdvar.id, 'B is only one left').to.eql 'B'
+
+      it 'should work with list as fallback dist', ->
+
+        solver = new Solver
+        solver.addVar
+          id: 'A'
+        solver.addVar
+          id: 'B'
+        solver.addVar
+          id: 'C'
+        solver.prepare
+          distribute:
+            var:
+              dist_name: 'markov' # there are no markov vars so it will fallback immediately
+              fallback_config:
+                dist_name: 'list'
+                priority_list: ['A', 'C']
+
+        fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B', 'C']
+        expect(fdvar.id, 'A and C should go before B').to.eql 'A'
+        fdvar = distribution_get_next_var solver.space, solver.space, ['A', 'B']
+        expect(fdvar.id, 'A should go before B').to.eql 'A'
+        fdvar = distribution_get_next_var solver.space, solver.space, ['B', 'C']
+        expect(fdvar.id, 'C should go before B').to.eql 'C'
+        fdvar = distribution_get_next_var solver.space, solver.space, ['B']
+        expect(fdvar.id, 'B is only one left').to.eql 'B'
+
 
   describe 'fallback list -> markov -> size', ->
 
@@ -547,9 +565,9 @@ describe 'distribution/var.spec', ->
       domain: [0, 75]
     solver.prepare
       distribute:
-        var_priority: ['B_list', 'A_list']
         var:
           dist_name: 'list'
+          priority_list: ['B_list', 'A_list']
           fallback_config:
             dist_name: 'markov'
             fallback_config: 'size'


### PR DESCRIPTION
Add capability for fallback var distributors. This allows us to declare a list distributor and prioritize certain vars explicitly. Then when all the vars on that list have been solved we can prioritize with a different distributor like markov. When all the markov vars are also solved we can move on to solve by size or whatever.

Also adds a whole bunch of unit tests for (all) the var distributors.

---

make room for unit tests     bbdb4dd
Add support for fallback var distributors …    d3008d6
Put the hash lookup for list var dist in config instead of space …     a8c9150
