### PR TITLE
1.1.2: add prepublish script and point npm to a build rather than dev

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,24 @@
+.DS_Store
+
+# Logs
+logs
+*.log
+
+# Runtime data
+build
+dist
+tests/result.xml
+
+# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+# Dependency directory
+# Commenting this out is preferred by some people, see
+# https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
+node_modules
+
+# Users Environment Variables
+.lock-wscript
+
+# allow the dist file
+!dist/finitedomain.min.js

--- a/README.md
+++ b/README.md
@@ -20,10 +20,14 @@ Use `grunt dist` (after `npm install`) to compile everything. Intermediate build
 
 ## Version
 
-1.1.1
+1.1.2:
+- Add npm prepublish script so npm can distribute a dist build rather than from dev
+- Internal update to how test target is determined
+
+1.1.1:
 - Fixed a bug where solver options were not properly passed on from `PathSolver` to its super, `Solver`
 
-1.1.0
+1.1.0:
 - Added support for fallback var distributions so you can chain list > markov > size for var distributors
 - Dropped browserify in favor of a custom concatenation technique
 - Fixed the dist, made it faster and much smaller

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "finitedomain",
-  "main": "./src/index.coffee",
+  "main": "./dist/finitedomain.min.js",
   "description": "A fast feature rich finite domain solver",
   "license": "MIT",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/the-grid/finitedomain.git"
   },
   "scripts": {
+    "prepublish": "grunt dist",
     "test": "grunt test"
   },
   "devDependencies": {
@@ -34,9 +35,5 @@
   },
   "dependencies": {
   },
-  "keywords": ["constraint solving, GSAT, finite domain solver, FD"],
-  "browserify": {
-    "name": "finitedomain",
-    "transform": ["coffeeify"]
-  }
+  "keywords": ["constraint solving, GSAT, finite domain solver, FD"]
 }


### PR DESCRIPTION
Copy .gitignore to .npmignore but allow the dist file   a22851f
Use prepublish and let npm default to dist build file, bump to 1.1.2     8950dd1
