### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Use `grunt dist` (after `npm install`) to compile everything. Intermediate build
 
 ## Version
 
+1.2.3:
+- The reified methods on Solver can no longer return REJECTED state for using a boolean var without zero or one in its domain, instead it simply throws when this happens.
+
 1.2.2:
 - Remove debugging statements on large sets introduced in 1.2.1. Oops.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Use `grunt dist` (after `npm install`) to compile everything. Intermediate build
 1.2.3:
 - The reified methods on Solver can no longer return REJECTED state for using a boolean var without zero or one in its domain, instead it simply throws when this happens.
 - Support numbers or strings on some internal propagator creators and make them return more consistent values (`propagator_add_reified`, `propagator_add_eq`, `propagator_add_lt`, `propagator_add_gt`, `_propagator_add_ring`, `propagator_add_scale`).
+- Removed the PathSolver subclass and Bvar class and moved it to the right (private) repo
 
 1.2.2:
 - Remove debugging statements on large sets introduced in 1.2.1. Oops.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Use `grunt dist` (after `npm install`) to compile everything. Intermediate build
 
 1.2.3:
 - The reified methods on Solver can no longer return REJECTED state for using a boolean var without zero or one in its domain, instead it simply throws when this happens.
+- Support numbers or strings on some internal propagator creators and make them return more consistent values (`propagator_add_reified`, `propagator_add_eq`, `propagator_add_lt`, `propagator_add_gt`, `_propagator_add_ring`, `propagator_add_scale`).
 
 1.2.2:
 - Remove debugging statements on large sets introduced in 1.2.1. Oops.

--- a/src/domain.coffee
+++ b/src/domain.coffee
@@ -118,6 +118,7 @@ module.exports = do ->
   domain_remove_next_from_list = (domain, list) ->
     ASSERT_DOMAIN_EMPTY_CHECK domain
     for value in list
+      ASSERT value >= SUB and value <= SUP, 'lists with oob values probably indicate a bug'
       index = domain_range_index_of domain, value
       if index >= 0
         return _deep_clone_without_value domain, value, index
@@ -164,6 +165,7 @@ module.exports = do ->
   domain_get_value_of_first_contained_value_in_list = (domain, list) ->
     ASSERT_DOMAIN domain
     for value in list
+      ASSERT value >= SUB and value <= SUP, 'OOB values probably indicate a bug in the code', list
       if domain_contains_value domain, value
         return value
     return NO_SUCH_VALUE
@@ -237,6 +239,7 @@ module.exports = do ->
 
   domain_sort_by_range = (domain) ->
     len = domain.length
+    ASSERT len > 0, 'input domain should not be empty', domain
     if len >= 4
       quick_sort_inline domain, 0, domain.length-PAIR_SIZE
     return
@@ -275,16 +278,19 @@ module.exports = do ->
   # Check if given domain is in simplified, CSIS form
 
   is_simplified = (domain) ->
-    if domain.length <= PAIR_SIZE
-      if domain.length is PAIR_SIZE
-        ASSERT domain[FIRST_RANGE_LO] >= SUB, 'domains should not be sparse [0]'
-        ASSERT domain[FIRST_RANGE_HI] >= SUB, 'domains should not be sparse [1]'
+    if domain.length is PAIR_SIZE
+      ASSERT domain[FIRST_RANGE_LO] >= SUB
+      ASSERT domain[FIRST_RANGE_HI] <= SUP
+      ASSERT domain[FIRST_RANGE_LO] <= domain[FIRST_RANGE_HI]
       return true
+    if domain.length is 0
+      return true
+    ASSERT (domain.length % PAIR_SIZE) is 0
     phi = SUB
     for lo, index in domain by PAIR_SIZE
       hi = domain[index+1]
-      ASSERT lo >= SUB, 'domains should not be sparse [lo]', domain
-      ASSERT hi >= SUB, 'domains should not be sparse [hi]', domain
+      ASSERT lo >= SUB
+      ASSERT hi >= SUB
       ASSERT lo <= hi, 'ranges should be ascending', domain
       # we need to simplify if the lo of the next range goes before or touches the hi of the previous range
       # TODO: i think it used or intended to optimize this by continueing to process this from the current domain, rather than the start.
@@ -489,6 +495,7 @@ module.exports = do ->
   domain_plus = (domain1, domain2) ->
     ASSERT_DOMAIN domain1
     ASSERT_DOMAIN domain2
+    ASSERT domain1? and domain2?
 
     # Simplify the domains by closing gaps since when we add
     # the domains, the gaps will close according to the
@@ -511,6 +518,7 @@ module.exports = do ->
   domain_times = (domain1, domain2) ->
     ASSERT_DOMAIN domain1
     ASSERT_DOMAIN domain2
+    ASSERT domain1? and domain2?
 
     result = []
     for loi, index in domain1 by PAIR_SIZE
@@ -526,6 +534,7 @@ module.exports = do ->
   domain_minus = (domain1, domain2) ->
     ASSERT_DOMAIN domain1
     ASSERT_DOMAIN domain2
+    ASSERT domain1? and domain2?
 
     # Simplify the domains by closing gaps since when we add
     # the domains, the gaps will close according to the
@@ -552,6 +561,8 @@ module.exports = do ->
   domain_divby = (domain1, domain2) ->
     ASSERT_DOMAIN domain1
     ASSERT_DOMAIN domain2
+
+    ASSERT domain1? and domain2?
 
     result = []
 

--- a/src/propagator.coffee
+++ b/src/propagator.coffee
@@ -152,20 +152,6 @@ module.exports = do ->
         propagator_add_neq space, var_name_i, var_names[j]
     return
 
-  # Once you create an fdvar in a space with the given
-  # name, it is available for accessing as a direct member
-  # of the space. Since this can cause a name clash, it is
-  # recommended that you start the names of fdvars with an
-  # upper case letter. Since all the declared member names
-  # start with a lower case letter, a clash can certainly
-  # be avoided if you stick to that rule.
-  #
-  # If the domain is not specified, it is taken to be [SUB, SUP].
-  #
-  # Returns the space. All methods, unless otherwise noted,
-  # will return the current space so that other methods
-  # can be invoked in sequence.
-
   _propagator_add_plus_or_times = (space, target_op_name, inv_op_name, v1name, v2name, sumname) ->
     ASSERT space._class is 'space'
     retval = space

--- a/src/propagator.coffee
+++ b/src/propagator.coffee
@@ -64,11 +64,10 @@ module.exports = do ->
       else
         THROW 'add_reified: Unsupported operator \'' + opname + '\''
 
-    if bool_name
-      if fdvar_constrain(space.vars[bool_name], domain_create_bool()) is REJECTED
-        return REJECTED
-    else
+    if !bool_name
       bool_name = space_add_var space, 0, 1
+    else if fdvar_constrain(space.vars[bool_name], domain_create_bool()) is REJECTED
+      THROW 'boolean var should start with a domain containing zero, one, or both'
 
     ASSERT space.vars[left_var_name], 'var should exist'
     ASSERT space.vars[right_var_name], 'var should exist'

--- a/src/solver.coffee
+++ b/src/solver.coffee
@@ -20,6 +20,7 @@ module.exports = do ->
 
   {
     domain_create_bool
+    domain_from_list
   } = require './domain'
 
   {
@@ -546,6 +547,16 @@ module.exports = do ->
         console.log "      - FD solution count: #{count}"
 
       return
+
+    # exposes internal method space_add_var for subclass
+
+    space_add_var_range: (id, lo, hi) ->
+      return space_add_var @space, id, lo, hi
+
+    # exposes internal method domain_from_list for subclass
+
+    domain_from_list: (list) ->
+      return domain_from_list list
 
     # Visit the branch vars and collect var specific configuration overrides if
     # there are any and put them on the root space. This way we don't need to

--- a/tests/spec/distribution/markov.spec.coffee
+++ b/tests/spec/distribution/markov.spec.coffee
@@ -51,7 +51,7 @@ describe 'distribution/markov.spec', ->
     value_legend = [2, 8]
     prob_vector = [1, 1] # equal odds (irrelevant for this test)
     rng_func = -> 1 # not a valid normalized value
-    expect(-> distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_NORMALIZED).to.throw
+    expect(-> distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_NORMALIZED).to.throw()
 
   it 'should throw if normalized rng returns 1.1', ->
 
@@ -59,7 +59,7 @@ describe 'distribution/markov.spec', ->
     value_legend = [2, 8]
     prob_vector = [1, 1] # equal odds (irrelevant for this test)
     rng_func = -> 1.1 # not a valid normalized value
-    expect(-> distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_NORMALIZED).to.throw
+    expect(-> distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_NORMALIZED).to.throw()
 
   it 'should throw if normalized rng returns -1', ->
 
@@ -67,7 +67,7 @@ describe 'distribution/markov.spec', ->
     value_legend = [2, 8]
     prob_vector = [1, 1] # equal odds (irrelevant for this test)
     rng_func = -> -1 # not a valid normalized value
-    expect(-> distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_NORMALIZED).to.throw
+    expect(-> distribution_markov_sampleNextFromDomain domain, prob_vector, value_legend, rng_func, RNG_NORMALIZED).to.throw()
 
   it 'should return middle value in legend if rng is .5 with equal probs', ->
 

--- a/tests/spec/distribution/value.spec.coffee
+++ b/tests/spec/distribution/value.spec.coffee
@@ -79,16 +79,16 @@ describe 'distribution/value.spec', ->
 
       fdvar = fdvar_create 'A', spec_d_create_value 20
 
-      expect(-> distribution_value_by_min fdvar, 0).to.throw
-      expect(-> distribution_value_by_min fdvar, 1).to.throw
+      expect(-> distribution_value_by_min fdvar, 0).to.throw()
+      expect(-> distribution_value_by_min fdvar, 1).to.throw()
 
     it 'should reject a "rejected" var', ->
       # note: only rejects with ASSERTs
 
       fdvar = fdvar_create 'A', []
 
-      expect(-> distribution_value_by_min fdvar, 0).to.throw
-      expect(-> distribution_value_by_min fdvar, 1).to.throw
+      expect(-> distribution_value_by_min fdvar, 0).to.throw()
+      expect(-> distribution_value_by_min fdvar, 1).to.throw()
 
   describe 'distribution_value_by_max', ->
 
@@ -136,16 +136,16 @@ describe 'distribution/value.spec', ->
 
       fdvar = fdvar_create 'A', spec_d_create_value 20
 
-      expect(-> distribution_value_by_max fdvar, 0).to.throw
-      expect(-> distribution_value_by_max fdvar, 1).to.throw
+      expect(-> distribution_value_by_max fdvar, 0).to.throw()
+      expect(-> distribution_value_by_max fdvar, 1).to.throw()
 
     it 'should reject a "rejected" var', ->
       # note: only rejects with ASSERTs
 
       fdvar = fdvar_create 'A', []
 
-      expect(-> distribution_value_by_max fdvar, 0).to.throw
-      expect(-> distribution_value_by_max fdvar, 1).to.throw
+      expect(-> distribution_value_by_max fdvar, 0).to.throw()
+      expect(-> distribution_value_by_max fdvar, 1).to.throw()
 
   describe 'distribution_value_by_mid', ->
 
@@ -199,16 +199,16 @@ describe 'distribution/value.spec', ->
 
       fdvar = fdvar_create 'A', spec_d_create_value 20
 
-      expect(-> distribution_value_by_mid fdvar, 0).to.throw
-      expect(-> distribution_value_by_mid fdvar, 1).to.throw
+      expect(-> distribution_value_by_mid fdvar, 0).to.throw()
+      expect(-> distribution_value_by_mid fdvar, 1).to.throw()
 
     it 'should reject a "rejected" var', ->
       # note: only rejects with ASSERTs
 
       fdvar = fdvar_create 'A', []
 
-      expect(-> distribution_value_by_mid fdvar, 0).to.throw
-      expect(-> distribution_value_by_mid fdvar, 1).to.throw
+      expect(-> distribution_value_by_mid fdvar, 0).to.throw()
+      expect(-> distribution_value_by_mid fdvar, 1).to.throw()
 
   describe 'distribution_value_by_split_min', ->
 
@@ -271,16 +271,16 @@ describe 'distribution/value.spec', ->
 
       fdvar = fdvar_create 'A', spec_d_create_value 20
 
-      expect(-> distribution_value_by_split_min fdvar, 0).to.throw
-      expect(-> distribution_value_by_split_min fdvar, 1).to.throw
+      expect(-> distribution_value_by_split_min fdvar, 0).to.throw()
+      expect(-> distribution_value_by_split_min fdvar, 1).to.throw()
 
     it 'should reject a "rejected" var', ->
       # note: only rejects with ASSERTs
 
       fdvar = fdvar_create 'A', []
 
-      expect(-> distribution_value_by_split_min fdvar, 0).to.throw
-      expect(-> distribution_value_by_split_min fdvar, 1).to.throw
+      expect(-> distribution_value_by_split_min fdvar, 0).to.throw()
+      expect(-> distribution_value_by_split_min fdvar, 1).to.throw()
 
   describe 'distribution_value_by_split_min', ->
 
@@ -343,16 +343,16 @@ describe 'distribution/value.spec', ->
 
       fdvar = fdvar_create 'A', spec_d_create_value 20
 
-      expect(-> distribution_value_by_split_min fdvar, 0).to.throw
-      expect(-> distribution_value_by_split_min fdvar, 1).to.throw
+      expect(-> distribution_value_by_split_min fdvar, 0).to.throw()
+      expect(-> distribution_value_by_split_min fdvar, 1).to.throw()
 
     it 'should reject a "rejected" var', ->
       # note: only rejects with ASSERTs
 
       fdvar = fdvar_create 'A', []
 
-      expect(-> distribution_value_by_split_min fdvar, 0).to.throw
-      expect(-> distribution_value_by_split_min fdvar, 1).to.throw
+      expect(-> distribution_value_by_split_min fdvar, 0).to.throw()
+      expect(-> distribution_value_by_split_min fdvar, 1).to.throw()
 
   describe 'distribution_value_by_split_max', ->
 
@@ -415,13 +415,13 @@ describe 'distribution/value.spec', ->
 
       fdvar = fdvar_create 'A', spec_d_create_value 20
 
-      expect(-> distribution_value_by_split_max fdvar, 0).to.throw
-      expect(-> distribution_value_by_split_max fdvar, 1).to.throw
+      expect(-> distribution_value_by_split_max fdvar, 0).to.throw()
+      expect(-> distribution_value_by_split_max fdvar, 1).to.throw()
 
     it 'should reject a "rejected" var', ->
       # note: only rejects with ASSERTs
 
       fdvar = fdvar_create 'A', []
 
-      expect(-> distribution_value_by_split_max fdvar, 0).to.throw
-      expect(-> distribution_value_by_split_max fdvar, 1).to.throw
+      expect(-> distribution_value_by_split_max fdvar, 0).to.throw()
+      expect(-> distribution_value_by_split_max fdvar, 1).to.throw()

--- a/tests/spec/distribution/var.spec.coffee
+++ b/tests/spec/distribution/var.spec.coffee
@@ -365,7 +365,7 @@ describe 'distribution/var.spec', ->
             A: 2
             B: 2
 
-        expect(-> by_list v1, v2, {}, config).to.throw
+        expect(-> by_list v1, v2, {}, config).to.throw()
 
       it 'should return WORSE if the priority hash says A is lower than B', ->
 
@@ -441,7 +441,7 @@ describe 'distribution/var.spec', ->
             priority_hash:
               A: 0
 
-        expect(-> by_list v1, v2, fake_space, {}).to.throw
+        expect(-> by_list v1, v2, fake_space, {}).to.throw()
 
       it 'should throw if B gets value 0 from the hash', ->
 
@@ -449,9 +449,9 @@ describe 'distribution/var.spec', ->
         v2 = fdvar_create 'B', []
         config =
           priority_hash:
-            B: 2
+            B: 0
 
-        expect(-> by_list v1, v2, {}, config).to.throw
+        expect(-> by_list v1, v2, {}, config).to.throw()
 
       it 'should return SAME if neither A nor B is in the hash without fallback', ->
 
@@ -706,7 +706,7 @@ describe 'distribution/var.spec', ->
         # shuffle list the ugly way
         names.sort -> Math.random() - .5
 
-        expect(-> distribution_get_next_var solver.space, solver.space, names).not.to.throw
+        expect(-> distribution_get_next_var solver.space, solver.space, names).not.to.throw()
 
   describe 'list -> inverted list -> min', ->
 

--- a/tests/spec/domain.spec.coffee
+++ b/tests/spec/domain.spec.coffee
@@ -50,8 +50,8 @@ describe 'domain.spec', ->
       expect(domain_from_list [1,1,0,0]).to.eql spec_d_create_bool()
 
     it "negative elements should throw", ->
-      expect(-> domain_from_list [10,1,-1,0]).to.throw
-      expect(-> domain_from_list [10,1,-1,0,10,1,-1,0,10,1,-1,0]).to.throw
+      expect(-> domain_from_list [10,1,-1,0]).to.throw()
+      expect(-> domain_from_list [10,1,-1,0,10,1,-1,0,10,1,-1,0]).to.throw()
 
   describe "domain_to_list", ->
 
@@ -63,7 +63,7 @@ describe 'domain.spec', ->
 
     it 'should require a domain', ->
 
-      expect(-> domain_to_list()).to.throw
+      expect(-> domain_to_list()).to.throw()
 
     it "[[0,0]]", ->
 
@@ -72,10 +72,6 @@ describe 'domain.spec', ->
     it "[[0,1]]", ->
 
       expect(domain_to_list spec_d_create_bool()).to.eql [0,1]
-
-    it "negative elements to throw", ->
-
-      expect(-> domain_to_list spec_d_create_ranges([-1,1], [10,10])).to.throw
 
   describe "domain_remove_next_from_list", ->
 
@@ -87,7 +83,7 @@ describe 'domain.spec', ->
 
     it 'should require an array', ->
 
-      expect(-> domain_remove_next_from_list null, [0]).to.throw
+      expect(-> domain_remove_next_from_list null, [0]).to.throw()
 
     it 'should return a fresh domain', ->
 
@@ -138,8 +134,8 @@ describe 'domain.spec', ->
 
     it "should throw for negative values", ->
       dom = spec_d_create_ranges([0,4],[10,14],[20,24])
-      expect(-> domain_remove_next_from_list dom, [99,-1,12,11]).to.throw
-      expect(-> domain_remove_next_from_list dom, [99,-1]).to.throw
+      expect(-> domain_remove_next_from_list dom, [99,-1,12,11]).to.throw()
+      expect(-> domain_remove_next_from_list dom, [99,-1]).to.throw()
 
   describe "domain_get_value_of_first_contained_value_in_list ", ->
 
@@ -179,8 +175,8 @@ describe 'domain.spec', ->
 
     it "should throw for negative values", ->
       dom = spec_d_create_ranges([0,4],[10,14],[20,24])
-      expect(-> domain_get_value_of_first_contained_value_in_list(dom,[99,-1,12,11]) ).to.throw
-      expect(-> domain_get_value_of_first_contained_value_in_list(dom,[99,-1]) ).to.throw
+      expect(-> domain_get_value_of_first_contained_value_in_list(dom,[99,-1,12,11]) ).to.throw()
+      expect(-> domain_get_value_of_first_contained_value_in_list(dom,[99,-1]) ).to.throw()
 
   describe 'domain_contains_value', ->
 
@@ -257,7 +253,7 @@ describe 'domain.spec', ->
 
     it 'should require a domain', ->
 
-      expect(-> domain_is_value()).to.throw
+      expect(-> domain_is_value()).to.throw()
 
     it 'should return false if domain is empty', ->
 
@@ -265,7 +261,7 @@ describe 'domain.spec', ->
 
     it 'should throw for invalid domains', ->
 
-      expect(-> domain_is_value spec_d_create_value(undefined)).to.throw
+      expect(-> domain_is_value spec_d_create_value(undefined)).to.throw()
 
     it 'should be able to check without arg (but return false)', ->
 
@@ -297,17 +293,6 @@ describe 'domain.spec', ->
       expect(domain_is_value(spec_d_create_ranges([1, 1], [3, 3]), 3), 'first range 1 with second range 3').to.be.false
       expect(domain_is_value(spec_d_create_ranges([10, 20], [50, 50]), 50), 'two ranges').to.be.false
 
-    it 'should throw for invalid (non-csis) domains', ->
-
-      expect(-> domain_is_value(spec_d_create_ranges([50, 50], [10, 20]), 50)).to.throw
-      expect(-> domain_is_value(spec_d_create_ranges([50, 50], [60, 70]), 50)).to.throw
-      expect(-> domain_is_value(spec_d_create_ranges([50, 50], [54, 54]), 50)).to.throw
-
-    it 'should throw for bogus domains', ->
-
-      expect(-> domain_is_value([[50, 50], ['oops']])).to.throw
-      expect(-> domain_is_value([[50, 50], ['oops']])).to.throw
-
   describe 'domain_remove_value_inline', ->
 
     {domain_remove_value_inline} = Domain
@@ -318,7 +303,7 @@ describe 'domain.spec', ->
 
     it 'should require a domain', ->
 
-      expect(-> domain_remove_value_inline null, 15).to.throw
+      expect(-> domain_remove_value_inline null, 15).to.throw()
 
     it 'should accept an empty domain', ->
 
@@ -349,7 +334,7 @@ describe 'domain.spec', ->
 
     it 'should require a domain', ->
 
-      expect(-> is_simplified()).to.throw
+      expect(-> is_simplified()).to.throw()
 
     it 'should accept empty domain', ->
 
@@ -367,7 +352,7 @@ describe 'domain.spec', ->
 
       it 'should reject domain with inverted range', ->
 
-        expect(-> is_simplified spec_d_create_range(1, 0)).to.throw
+        expect(-> is_simplified spec_d_create_range(1, 0)).to.throw()
 
     describe 'multiple ranges in domain', ->
 
@@ -377,11 +362,11 @@ describe 'domain.spec', ->
 #        expect(is_simplified spec_d_create_ranges([5, 6], [7, 8], [9, 10])).to.be.true
 #        expect(is_simplified spec_d_create_ranges([5, 6], [7, 8], [9, 10], [100, 200])).to.be.true
 
-      it 'should reject if two ranges overlap despite ordering', ->
+      it 'should throw if two ranges overlap despite ordering', ->
 
-        expect(-> is_simplified spec_d_create_ranges([10, 15], [13, 19], [50, 60])).to.throw # start
-        expect(-> is_simplified spec_d_create_ranges([1, 3], [10, 15], [13, 19], [70, 75])).to.throw # middle
-        expect(-> is_simplified spec_d_create_ranges([1, 3], [10, 15], [16, 19], [18, 25])).to.throw #end
+        expect(is_simplified spec_d_create_ranges([10, 15], [13, 19], [50, 60])).to.be.false # start
+        expect(is_simplified spec_d_create_ranges([1, 3], [10, 15], [13, 19], [70, 75])).to.be.false # middle
+        expect(is_simplified spec_d_create_ranges([1, 3], [10, 15], [16, 19], [18, 25])).to.be.false #end
 
       it 'should reject if two ranges touch', ->
 
@@ -389,9 +374,9 @@ describe 'domain.spec', ->
 
       it 'should reject if at least one range is inverted', ->
 
-        expect(-> is_simplified spec_d_create_ranges([15, 10], [40, 50], [55, 60])).to.throw # start
-        expect(-> is_simplified spec_d_create_ranges([10, 15], [50, 40], [55, 60])).to.throw # middle
-        expect(-> is_simplified spec_d_create_ranges([10, 15], [40, 50], [65, 60])).to.throw # end
+        expect(-> is_simplified spec_d_create_ranges([15, 10], [40, 50], [55, 60])).to.throw() # start
+        expect(-> is_simplified spec_d_create_ranges([10, 15], [50, 40], [55, 60])).to.throw() # middle
+        expect(-> is_simplified spec_d_create_ranges([10, 15], [40, 50], [65, 60])).to.throw() # end
 
   describe 'merge_overlapping_inline', ->
 
@@ -497,7 +482,7 @@ describe 'domain.spec', ->
 
     it 'should throw without a domain', ->
 
-      expect(-> domain_simplify()).to.throw
+      expect(-> domain_simplify()).to.throw()
 
     # test both empty domains and the case where the domain actually requires an action
 
@@ -603,9 +588,9 @@ describe 'domain.spec', ->
 
       it 'should require two domains', ->
 
-        expect(-> domain_intersection).to.throw
-        expect(-> domain_intersection []).to.throw
-        expect(-> domain_intersection null, []).to.throw
+        expect(-> domain_intersection()).to.throw()
+        expect(-> domain_intersection []).to.throw()
+        expect(-> domain_intersection null, []).to.throw()
 
       it 'should handle empty domains', ->
 
@@ -752,7 +737,7 @@ describe 'domain.spec', ->
 
     it 'should require a domain', ->
 
-      expect(-> domain_complement()).to.throw
+      expect(-> domain_complement()).to.throw()
 
     it 'should accept an empty array', ->
 
@@ -809,9 +794,9 @@ describe 'domain.spec', ->
 #
 #    it 'should requires two domains', ->
 #
-#      expect(-> domain_close_gaps_inline()).to.throw
-#      expect(-> domain_close_gaps_inline []).to.throw
-#      expect(-> domain_close_gaps_inline undefined, []).to.throw
+#      expect(-> domain_close_gaps_inline()).to.throw()
+#      expect(-> domain_close_gaps_inline []).to.throw()
+#      expect(-> domain_close_gaps_inline undefined, []).to.throw()
 #
 #    it 'should accept empty domains', ->
 #
@@ -889,9 +874,9 @@ describe 'domain.spec', ->
 
     it 'should require domains', ->
 
-      expect(-> domain_plus).to.throw
-      expect(-> domain_plus []).to.throw
-      expect(-> domain_plus null, []).to.throw
+      expect(-> domain_plus()).to.throw()
+      expect(-> domain_plus []).to.throw()
+      expect(-> domain_plus null, []).to.throw()
 
     it 'should accept empty domains', ->
 
@@ -904,12 +889,6 @@ describe 'domain.spec', ->
       expect(domain_plus a, []).to.not.equal a
       a = []
       expect(domain_plus [], a).to.not.equal a
-
-    it 'should throw if empty domains are passed on', ->
-
-      a = spec_d_create_ranges([0, 1], [4, 5], [7, 8], [10, 12], [15, 17])
-      expect(-> domain_plus (a.slice 0), []).to.throw
-      expect(-> domain_plus [], (a.slice 0)).to.throw
 
     it 'should add two ranges', ->
 
@@ -937,9 +916,9 @@ describe 'domain.spec', ->
 
     it 'should require domains', ->
 
-      expect(-> domain_times).to.throw
-      expect(-> domain_times []).to.throw
-      expect(-> domain_times null, []).to.throw
+      expect(-> domain_times()).to.throw()
+      expect(-> domain_times []).to.throw()
+      expect(-> domain_times null, []).to.throw()
 
     it 'should accept empty domains', ->
 
@@ -986,9 +965,9 @@ describe 'domain.spec', ->
 
     it 'should require domains', ->
 
-      expect(-> domain_minus).to.throw
-      expect(-> domain_minus []).to.throw
-      expect(-> domain_minus null, []).to.throw
+      expect(-> domain_minus()).to.throw()
+      expect(-> domain_minus []).to.throw()
+      expect(-> domain_minus null, []).to.throw()
 
     it 'should accept empty domains', ->
 
@@ -1037,9 +1016,9 @@ describe 'domain.spec', ->
 
     it 'should require domains', ->
 
-      expect(-> domain_divby).to.throw
-      expect(-> domain_divby []).to.throw
-      expect(-> domain_divby null, []).to.throw
+      expect(-> domain_divby()).to.throw()
+      expect(-> domain_divby []).to.throw()
+      expect(-> domain_divby null, []).to.throw()
 
     it 'should accept empty domains', ->
 
@@ -1208,7 +1187,7 @@ describe 'domain.spec', ->
 
     it 'should throw for imblalanced ranges', ->
 
-      expect(-> domain_set_to_range_inline [], 27, 0).to.throw
+      expect(-> domain_set_to_range_inline [], 27, 0).to.throw()
 
     it 'should update the array inline', ->
 
@@ -1238,7 +1217,7 @@ describe 'domain.spec', ->
 
     it 'should throw for emtpy domains', ->
 
-      expect(-> domain_sort_by_range []).to.throw
+      expect(-> domain_sort_by_range []).to.throw()
 
     it 'should return nothing', ->
 
@@ -1327,7 +1306,7 @@ describe 'domain.spec', ->
 
     it 'should accept an empty domain', ->
 
-      expect(-> domain_remove_gte_inline [], 5).not.to.throw
+      expect(-> domain_remove_gte_inline [], 5).not.to.throw()
 
     it 'should return bool', ->
 
@@ -1399,7 +1378,7 @@ describe 'domain.spec', ->
 
     it 'should accept an empty domain', ->
 
-      expect(-> domain_remove_lte_inline [], 5).not.to.throw
+      expect(-> domain_remove_lte_inline [], 5).not.to.throw()
 
     it 'should return bool', ->
 

--- a/tests/spec/helpers.spec.coffee
+++ b/tests/spec/helpers.spec.coffee
@@ -34,4 +34,4 @@ describe "helpers.spec", ->
 
     it 'should throw if you pass on false', ->
 
-      expect(-> ASSERT false).to.throw
+      expect(-> ASSERT false).to.throw()

--- a/tests/spec/propagator.spec.coffee
+++ b/tests/spec/propagator.spec.coffee
@@ -39,6 +39,8 @@ describe "propagator.spec", ->
     propagator_add_times
     propagator_add_times_plus
     propagator_add_wsum
+
+    _propagator_add_plus_or_times
   } = FD.propagator
 
 
@@ -54,6 +56,29 @@ describe "propagator.spec", ->
       expect(propagator_add_markov space_create_root(), 'foo').to.be.undefined
 
   describe 'propagator_add_reified', ->
+
+    it 'should accept numbers for anonymous var A', ->
+
+      space = space_create_root()
+      space_add_var space, 'B'
+      space_add_var space, 'C'
+
+      expect(-> propagator_add_reified space, 'eq', 0, 'B', 'C').not.to.throw()
+
+    it 'should accept numbers for anonymous var B', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+      space_add_var space, 'C'
+
+      expect(-> propagator_add_reified space, 'eq', 'A', 0, 'C').not.to.throw()
+
+    it 'should throw if left and right vars are anonymous vars', ->
+
+      space = space_create_root()
+      space_add_var space, 'C'
+
+      expect(-> propagator_add_reified space, 'eq', 0, 0, 'C').to.throw()
 
     describe 'bool var domain', ->
 
@@ -102,3 +127,184 @@ describe "propagator.spec", ->
         propagator_add_reified space, 'eq', 'A', 'B', 'C'
 
         expect(space.vars.C.dom).to.eql spec_d_create_bool()
+
+      it 'should accept a number for boolvar', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+        space_add_var space, 'B'
+
+        expect(-> propagator_add_reified space, 'eq', 'A', 'B', 0).not.to.throw()
+
+      it 'should return the name of the anon boolvar', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+        space_add_var space, 'B'
+
+        expect(typeof propagator_add_reified space, 'eq', 'A', 'B', 0).to.eql 'string'
+
+      it 'should return the name of the named boolvar', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+        space_add_var space, 'B'
+        space_add_var space, 'C'
+
+        expect(propagator_add_reified space, 'eq', 'A', 'B', 'C').to.eql 'C'
+
+  describe 'propagator_add_eq', ->
+
+    describe 'numbers as anonymous vars', ->
+
+      it 'should accept a number for var1', ->
+
+        space = space_create_root()
+        space_add_var space, 'B'
+
+        expect(-> propagator_add_eq space, 0, 'B').not.to.throw()
+
+      it 'should accept a number for var2', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+
+        expect(-> propagator_add_eq space, 'A', 0).not.to.throw()
+
+      it 'should throw if both vars are anonymous numbers', ->
+
+        space = space_create_root()
+
+        expect(-> propagator_add_eq space, 0, 0).to.throw()
+
+  describe 'propagator_add_lt', ->
+
+    describe 'numbers as anonymous vars', ->
+
+      it 'should accept a number for var1', ->
+
+        space = space_create_root()
+        space_add_var space, 'B'
+
+        expect(-> propagator_add_lt space, 0, 'B').not.to.throw()
+
+      it 'should accept a number for var2', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+
+        expect(-> propagator_add_lt space, 'A', 0).not.to.throw()
+
+      it 'should throw if both vars are anonymous numbers', ->
+
+        space = space_create_root()
+
+        expect(-> propagator_add_lt space, 0, 0).to.throw()
+
+  describe 'propagator_add_lte', ->
+
+    describe 'numbers as anonymous vars', ->
+
+      it 'should accept a number for var1', ->
+
+        space = space_create_root()
+        space_add_var space, 'B'
+
+        expect(-> propagator_add_lte space, 0, 'B').not.to.throw()
+
+      it 'should accept a number for var2', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+
+        expect(-> propagator_add_lte space, 'A', 0).not.to.throw()
+
+      it 'should throw if both vars are anonymous numbers', ->
+
+        space = space_create_root()
+
+        expect(-> propagator_add_lte space, 0, 0).to.throw()
+
+  describe 'propagator_add_gt', ->
+
+    describe 'numbers as anonymous vars', ->
+
+      it 'should accept a number for var1', ->
+
+        space = space_create_root()
+        space_add_var space, 'B'
+
+        expect(-> propagator_add_gt space, 0, 'B').not.to.throw()
+
+      it 'should accept a number for var2', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+
+        expect(-> propagator_add_gt space, 'A', 0).not.to.throw()
+
+      it 'should throw if both vars are anonymous numbers', ->
+
+        space = space_create_root()
+
+        expect(-> propagator_add_gt space, 0, 0).to.throw()
+
+  describe 'propagator_add_gte', ->
+
+    describe 'numbers as anonymous vars', ->
+
+      it 'should accept a number for var1', ->
+
+        space = space_create_root()
+        space_add_var space, 'B'
+
+        expect(-> propagator_add_gte space, 0, 'B').not.to.throw()
+
+      it 'should accept a number for var2', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+
+        expect(-> propagator_add_gte space, 'A', 0).not.to.throw()
+
+      it 'should throw if both vars are anonymous numbers', ->
+
+        space = space_create_root()
+
+        expect(-> propagator_add_gte space, 0, 0).to.throw()
+
+  describe '_propagator_add_plus_or_times', ->
+
+    it 'should return the name of the anonymous result var', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+      space_add_var space, 'B'
+
+      expect(typeof _propagator_add_plus_or_times space, 'div', 'mul', 'A', 'B', 0).to.eql 'string'
+
+    it 'should return the name of the named result var', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+      space_add_var space, 'B'
+      space_add_var space, 'C'
+
+      expect(_propagator_add_plus_or_times space, 'div', 'mul', 'A', 'B', 'C').to.eql 'C'
+
+  describe 'propagator_add_scale', ->
+
+    it 'should return the name of the anonymous result var', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+
+      expect(typeof propagator_add_scale space, 5, 'A', 0).to.eql 'string'
+
+    it 'should return the name of the named result var', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+      space_add_var space, 'B'
+
+      expect(propagator_add_scale space, 5, 'A', 'B').to.eql 'B'

--- a/tests/spec/propagator.spec.coffee
+++ b/tests/spec/propagator.spec.coffee
@@ -308,3 +308,92 @@ describe "propagator.spec", ->
       space_add_var space, 'B'
 
       expect(propagator_add_scale space, 5, 'A', 'B').to.eql 'B'
+
+  describe 'propagator_add_sum', ->
+
+    it 'should return the name of the anonymous result var', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+      space_add_var space, 'B'
+      space_add_var space, 'C'
+
+      expect(typeof propagator_add_sum space, ['A', 'B', 'C']).to.eql 'string'
+
+    it 'should return the name of the named result var', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+      space_add_var space, 'B'
+      space_add_var space, 'C'
+      space_add_var space, 'D'
+
+      expect(propagator_add_sum space, ['A', 'B', 'C'], 'D').to.eql 'D'
+
+    it 'should allow anonymous numbers in the list of vars', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+      space_add_var space, 'C'
+      space_add_var space, 'D'
+
+      expect(propagator_add_sum space, ['A', 5, 'C'], 'D').to.eql 'D'
+
+    it 'should throw if you dont pass on any vars', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+
+      expect(-> propagator_add_sum space, [], 'A').to.throw()
+
+    it 'should throw if you dont pass on an array', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+
+      expect(-> propagator_add_sum space undefined, 'A').to.throw()
+      expect(-> propagator_add_sum space, 'X', 'A').to.throw()
+      expect(-> propagator_add_sum space, 5, 'A').to.throw()
+      expect(-> propagator_add_sum space, null, 'A').to.throw()
+
+  describe 'propagator_add_product', ->
+
+    it 'should return the name of the anonymous result var', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+      space_add_var space, 'B'
+      space_add_var space, 'C'
+
+      expect(typeof propagator_add_product space, ['A', 'B', 'C']).to.eql 'string'
+
+    it 'should return the name of the named result var', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+      space_add_var space, 'B'
+      space_add_var space, 'C'
+      space_add_var space, 'D'
+
+      expect(propagator_add_product space, ['A', 'B', 'C'], 'D').to.eql 'D'
+
+  describe 'propagator_add_wsum', ->
+
+    it 'should return the name of the anonymous result var', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+      space_add_var space, 'B'
+      space_add_var space, 'C'
+
+      expect(typeof propagator_add_wsum space, [1, 2, 3], ['A', 'B', 'C']).to.eql 'string'
+
+    it 'should return the name of the named result var', ->
+
+      space = space_create_root()
+      space_add_var space, 'A'
+      space_add_var space, 'B'
+      space_add_var space, 'C'
+      space_add_var space, 'D'
+
+      expect(propagator_add_wsum space, [1, 2, 3], ['A', 'B', 'C'], 'D').to.eql 'D'

--- a/tests/spec/propagator.spec.coffee
+++ b/tests/spec/propagator.spec.coffee
@@ -43,6 +43,7 @@ describe "propagator.spec", ->
 
 
   {
+    space_add_var
     space_create_root
   } = FD.space
 
@@ -51,3 +52,53 @@ describe "propagator.spec", ->
     it 'should not crash', ->
 
       expect(propagator_add_markov space_create_root(), 'foo').to.be.undefined
+
+  describe 'propagator_add_reified', ->
+
+    describe 'bool var domain', ->
+
+      it 'should throw if the boolvar has no zero or one', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+        space_add_var space, 'B'
+        space_add_var space, 'C', 2, 3
+
+        expect(-> propagator_add_reified space, 'eq', 'A', 'B', 'C').to.throw
+
+      it 'should be fine if the boolvar has no one', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+        space_add_var space, 'B'
+        space_add_var space, 'C', 0, 0
+
+        expect(propagator_add_reified space, 'eq', 'A', 'B', 'C').to.eql 'C'
+
+      it 'should be fine if the boolvar has no zero', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+        space_add_var space, 'B'
+        space_add_var space, 'C', 1, 5
+
+        expect(propagator_add_reified space, 'eq', 'A', 'B', 'C').to.eql 'C'
+
+      it 'should be fine if the boolvar has more than zero and one', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+        space_add_var space, 'B'
+        space_add_var space, 'C', 0, 3
+
+        expect(propagator_add_reified space, 'eq', 'A', 'B', 'C').to.eql 'C'
+
+      it 'should reduce the domain to bool if not already', ->
+
+        space = space_create_root()
+        space_add_var space, 'A'
+        space_add_var space, 'B'
+        space_add_var space, 'C', 0, 3
+        propagator_add_reified space, 'eq', 'A', 'B', 'C'
+
+        expect(space.vars.C.dom).to.eql spec_d_create_bool()

--- a/tests/spec/propagators/eq.spec.coffee
+++ b/tests/spec/propagators/eq.spec.coffee
@@ -41,10 +41,10 @@ describe "propagators/eq.spec", ->
 
   it 'should require two vars', ->
 
-    expect(-> propagator_eq_step_bare()).to.throw
+    expect(-> propagator_eq_step_bare()).to.throw()
     v = fdvar_create_wide 'x'
-    expect(-> propagator_eq_step_bare v).to.throw
-    expect(-> propagator_eq_step_bare undefined, v).to.throw
+    expect(-> propagator_eq_step_bare v).to.throw()
+    expect(-> propagator_eq_step_bare undefined, v).to.throw()
 
 #  it 'should reject for empty domains', ->
 #

--- a/tests/spec/propagators/lt.spec.coffee
+++ b/tests/spec/propagators/lt.spec.coffee
@@ -39,10 +39,10 @@ describe "propagators/lt.spec", ->
 
   it 'should require two vars', ->
 
-    expect(-> propagator_lt_step_bare()).to.throw
+    expect(-> propagator_lt_step_bare()).to.throw()
     v = fdvar_create_wide 'x'
-    expect(-> propagator_lt_step_bare v).to.throw
-    expect(-> propagator_lt_step_bare undefined, v).to.throw
+    expect(-> propagator_lt_step_bare v).to.throw()
+    expect(-> propagator_lt_step_bare undefined, v).to.throw()
 
 #  it 'should reject for empty domains', ->
 #

--- a/tests/spec/propagators/lte.spec.coffee
+++ b/tests/spec/propagators/lte.spec.coffee
@@ -39,10 +39,10 @@ describe "propagators/lte.spec", ->
 
   it 'should require two vars', ->
 
-    expect(-> propagator_lte_step_bare()).to.throw
+    expect(-> propagator_lte_step_bare()).to.throw()
     v = fdvar_create_wide 'x'
-    expect(-> propagator_lte_step_bare v).to.throw
-    expect(-> propagator_lte_step_bare undefined, v).to.throw
+    expect(-> propagator_lte_step_bare v).to.throw()
+    expect(-> propagator_lte_step_bare undefined, v).to.throw()
 
 #  it 'should reject for empty domains', ->
 #

--- a/tests/spec/propagators/neq.spec.coffee
+++ b/tests/spec/propagators/neq.spec.coffee
@@ -41,10 +41,10 @@ describe "propagators/neq.spec", ->
 
   it 'should require two vars', ->
 
-    expect(-> propagator_neq_step_bare()).to.throw
+    expect(-> propagator_neq_step_bare()).to.throw()
     v = fdvar_create_wide 'x'
-    expect(-> propagator_neq_step_bare v).to.throw
-    expect(-> propagator_neq_step_bare undefined, v).to.throw
+    expect(-> propagator_neq_step_bare v).to.throw()
+    expect(-> propagator_neq_step_bare undefined, v).to.throw()
 
 #  it 'should reject for empty domains', ->
 #

--- a/tests/spec/space.spec.coffee
+++ b/tests/spec/space.spec.coffee
@@ -407,7 +407,7 @@ describe "space.spec", ->
       it 'should throw if value is OOB', ->
 
         space = space_create_root()
-        expect(-> space_add_var space, FD.helpers.SUB - 100).to.throw
+        expect(-> space_add_var space, FD.helpers.SUB - 100).to.throw()
 
       it 'should create a new var', ->
 


### PR DESCRIPTION
Add support for plain numbers which are turned into anonymous solved variables (so you can do `solver.eq 'A', 5` instead of `solver.eq 'A', solver.num 5`)
Fixed a possible weird untrapped situation during solver setup
Prepared PathSolver for detachment by exposing internal functions on Solver. Detachment to happen later.
Fixed various tests that weren't testing anything (mainly `expect(foo).to.throw` -> `expect(foo).to.throw()`)
Various refactorings to bring consitency to propagators.

---

Remove old comment  005a1f9
Dont allow empty bool vars in propagator_add_reified    0f57765
Support numbers var names for anonymous vars, always return boolvar n… …    f150ff4
Mah bad. Missing parenthesis after `to.throw` made those tests a dud …    f5f964b
Prepare to detach the PathSolver from this repo ecb9959
Straighten return values of some propagators, add tests for changes  a6410ae
