### PR TITLE
109 list fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Use `grunt dist` (after `npm install`) to compile everything. Intermediate build
 - Disallow vars from being redeclared to prevent possible bugs. Before a var would be clobbered if you declared the same var name twice.
 - Added `Solver#callback` which is used to read the current state and reject a search branch at an arbitrary point
 - Fixed a bug in the value list distributor where `-1` would be picked if no value in the list occurs in the domain. It should notice the negative number as an error and reject but instead it did not scrub the value at all.
+- Added a fallback distributor option, `fallback_dist_name`, for value list distributors. To be used when none of the values in the list occur in the current domain. This way you can use the list as a priority list instead of just a mask. This option is opt-in.
 
 1.3.1:
 - (Internal) removed scale_div and scale_mul as they were unused and will be replaced by something else soon

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Use `grunt dist` (after `npm install`) to compile everything. Intermediate build
 - Dropped support for the `search_defaults` option of `Solver#solve`, you can set the string to the `distribute` option of that call if you need it
 - Disallow vars from being redeclared to prevent possible bugs. Before a var would be clobbered if you declared the same var name twice.
 - Added `Solver#callback` which is used to read the current state and reject a search branch at an arbitrary point
+- Fixed a bug in the value list distributor where `-1` would be picked if no value in the list occurs in the domain. It should notice the negative number as an error and reject but instead it did not scrub the value at all.
 
 1.3.1:
 - (Internal) removed scale_div and scale_mul as they were unused and will be replaced by something else soon

--- a/src/distribution/value.coffee
+++ b/src/distribution/value.coffee
@@ -118,6 +118,8 @@ module.exports = do ->
     ASSERT config_var_dist_options[fdvar.id].list, 'there should be a distribution list available for every var', fdvar
     fdvar_dist_options = config_var_dist_options[fdvar.id]
     list_source = fdvar_dist_options.list
+    fallback_dist_name = fdvar_dist_options.fallback_dist_name
+    ASSERT fallback_dist_name isnt 'list', 'prevent recursion loops'
 
     if typeof list_source is 'function'
       # Note: callback should return the actual list
@@ -130,11 +132,16 @@ module.exports = do ->
       when FIRST_CHOICE
         v = domain_get_value_of_first_contained_value_in_list fdvar.dom, list
         if v is NO_SUCH_VALUE
+          if fallback_dist_name
+            return _distribute_get_next_domain_for_var fallback_dist_name, space, fdvar, choice_index
           return undefined # no choice
         return domain_create_value v
 
       when SECOND_CHOICE
-        return domain_remove_next_from_list fdvar.dom, list
+        d = domain_remove_next_from_list fdvar.dom, list
+        if not d and fallback_dist_name
+          return _distribute_get_next_domain_for_var fallback_dist_name, space, fdvar, choice_index
+        return d
 
     ASSERT typeof choice_index is 'number', 'should be a number'
     ASSERT choice_index is 2, 'should not keep calling this func after the last choice'

--- a/src/distribution/value.coffee
+++ b/src/distribution/value.coffee
@@ -4,6 +4,8 @@
 module.exports = do ->
 
   {
+    NO_SUCH_VALUE
+
     ASSERT
     THROW
   } = require '../helpers'
@@ -114,7 +116,8 @@ module.exports = do ->
     ASSERT config_var_dist_options, 'space should have config.var_dist_options'
     ASSERT config_var_dist_options[fdvar.id], 'there should be distribution options available for every var', fdvar
     ASSERT config_var_dist_options[fdvar.id].list, 'there should be a distribution list available for every var', fdvar
-    list_source = config_var_dist_options[fdvar.id].list
+    fdvar_dist_options = config_var_dist_options[fdvar.id]
+    list_source = fdvar_dist_options.list
 
     if typeof list_source is 'function'
       # Note: callback should return the actual list
@@ -125,7 +128,10 @@ module.exports = do ->
     switch choice_index
 
       when FIRST_CHOICE
-        return domain_create_value domain_get_value_of_first_contained_value_in_list fdvar.dom, list
+        v = domain_get_value_of_first_contained_value_in_list fdvar.dom, list
+        if v is NO_SUCH_VALUE
+          return undefined # no choice
+        return domain_create_value v
 
       when SECOND_CHOICE
         return domain_remove_next_from_list fdvar.dom, list

--- a/src/domain.coffee
+++ b/src/domain.coffee
@@ -955,6 +955,8 @@ module.exports = do ->
     return [SUP, SUP]
 
   domain_create_value = (value) ->
+    ASSERT value >= SUB, 'domain_create_value: value should be within valid range'
+    ASSERT value <= SUP, 'domain_create_value: value should be within valid range'
     return [value, value]
 
   domain_create_range = (lo, hi) ->

--- a/tests/spec/solver.list.spec.coffee
+++ b/tests/spec/solver.list.spec.coffee
@@ -174,3 +174,37 @@ describe 'solver.list.spec', ->
         {V1: 1, V2: 4, STATE: 5}
         {V1: 1, V2: 2, STATE: 5}
       ]
+
+  describe 'list values trump domain values', ->
+
+    it 'should ignore values in the domain that are not in the list', ->
+
+      solver = new Solver {}
+      solver.addVar
+        id: 'V1'
+        domain: spec_d_create_range 0, 5
+        distributeOptions:
+          distributor_name: 'list'
+          list: [0, 3, 4]
+      solver['>'] 'V1', 0
+      solutions = solver.solve()
+
+      expect(solutions.length, 'all solutions').to.equal 2 # list.length
+      expect(strip_anon_vars_a solutions).to.eql [
+        {V1: 3}
+        {V1: 4}
+      ]
+
+    it 'should not solve when the list contains no values in the domain', ->
+
+      solver = new Solver {}
+      solver.addVar
+        id: 'V1'
+        domain: spec_d_create_range 0, 10
+        distributeOptions:
+          distributor_name: 'list'
+          list: [0, 15]
+      solver['>'] 'V1', 0
+      solutions = solver.solve()
+
+      expect(solutions.length, 'all solutions').to.equal 0

--- a/tests/spec/solver.list.spec.coffee
+++ b/tests/spec/solver.list.spec.coffee
@@ -208,3 +208,66 @@ describe 'solver.list.spec', ->
       solutions = solver.solve()
 
       expect(solutions.length, 'all solutions').to.equal 0
+
+    it 'should use the fallback when the list contains no values in the domain', ->
+
+      solver = new Solver {}
+      solver.addVar
+        id: 'V1'
+        domain: spec_d_create_range 0, 5
+        distributeOptions:
+          distributor_name: 'list'
+          list: [0, 15]
+          fallback_dist_name: 'max'
+      solver['>'] 'V1', 0
+      solutions = solver.solve()
+
+      expect(solutions.length, 'all solutions').to.equal 5
+
+      expect(strip_anon_vars_a solutions).to.eql [
+        {V1: 5}
+        {V1: 4}
+        {V1: 3}
+        {V1: 2}
+        {V1: 1}
+      ]
+
+    it 'should prioritize the list before applying the fallback', ->
+
+      solver = new Solver {}
+      solver.addVar
+        id: 'V1'
+        domain: spec_d_create_range 0, 5
+        distributeOptions:
+          distributor_name: 'list'
+          list: [3, 0, 1, 5]
+          fallback_dist_name: 'max'
+      solver['>'] 'V1', 0
+      solutions = solver.solve()
+
+      expect(solutions.length, 'all solutions').to.equal 5
+
+      expect(strip_anon_vars_a solutions).to.eql [
+        {V1: 3}
+        {V1: 1}
+        {V1: 5}
+        {V1: 4}
+        {V1: 2}
+      ]
+
+    it 'should still be able to reject if fallback fails too', ->
+
+      solver = new Solver {}
+      solver.addVar
+        id: 'V1'
+        domain: spec_d_create_range 0, 5
+        distributeOptions:
+          distributor_name: 'list'
+          list: [3, 0, 1, 15, 5]
+          fallback_dist_name: 'max'
+      solver['>'] 'V1', 6
+      solutions = solver.solve()
+
+      # original domain contains 0~5 but constraint requires >6
+      # list contains 15 but since domain doesnt thats irrelevant
+      expect(solutions.length, 'all solutions').to.equal 0


### PR DESCRIPTION
Fixes a bug in list distributors
Supports `fallback_dist_name` for list distributors, which turns it into a priority list and if no value is found then apply a regular distributor (like `'min'` or `'max'`)

Tests added. 

Fixes https://github.com/the-grid/designsystems-stories/issues/109

Usage example:

```
      solver = new Solver {}
      solver.addVar
        id: 'V1'
        domain: spec_d_create_range 0, 5
        distributeOptions:
          distributor_name: 'list'
          list: [3, 0, 1, 5]
          fallback_dist_name: 'max'
      solver['>'] 'V1', 0
      solutions = solver.solve()

      expect(solutions.length, 'all solutions').to.equal 5

      expect(strip_anon_vars_a solutions).to.eql [
        {V1: 3}
        {V1: 1}
        {V1: 5}
        {V1: 4}
        {V1: 2}
      ]
```
