### PR TITLE
Eliminate destructuring assignments because they compile in a `_slice…

### DIFF
--- a/src/domain.js
+++ b/src/domain.js
@@ -184,7 +184,8 @@ function domain_getValue(domain) {
   if (domain.length !== PAIR_SIZE) {
     return NO_SUCH_VALUE;
   }
-  let [lo, hi] = domain;
+  let lo = domain[LO_BOUND];
+  let hi = domain[HI_BOUND];
   if (lo === hi) {
     return lo;
   }
@@ -893,7 +894,9 @@ function domain_plus(domain1, domain2) {
   // Simplify the domains by closing gaps since when we add
   // the domains, the gaps will close according to the
   // smallest interval width in the other domain.
-  [domain1, domain2] = _domain_closeGaps2(domain1, domain2);
+  let domains = _domain_closeGaps2(domain1, domain2);
+  domain1 = domains[0];
+  domain2 = domains[1];
 
   let result = [];
   for (let index = 0, step = PAIR_SIZE; index < domain1.length; index += step) {
@@ -964,7 +967,9 @@ function domain_minus(domain1, domain2) {
   // Simplify the domains by closing gaps since when we add
   // the domains, the gaps will close according to the
   // smallest interval width in the other domain.
-  [domain1, domain2] = _domain_closeGaps2(domain1, domain2);
+  let domains = _domain_closeGaps2(domain1, domain2);
+  domain1 = domains[0];
+  domain2 = domains[1];
 
   let result = [];
   for (let i = 0; i < domain1.length; i += PAIR_SIZE) {

--- a/src/propagators/step_any.js
+++ b/src/propagators/step_any.js
@@ -55,7 +55,8 @@ function propagator_stepAny(propagator, space) {
  * @returns {$fd_changeState}
  */
 function _propagator_stepAny(space, opName, propVarIndexes, propagator) {
-  let [varIndex1, varIndex2] = propVarIndexes;
+  let varIndex1 = propVarIndexes[0];
+  let varIndex2 = propVarIndexes[1];
 
   ASSERT(varIndex2 >= 0 || opName === 'markov' || opName === 'callback', 'varIndex2 index should exist for most props', propagator);
 

--- a/src/solver.js
+++ b/src/solver.js
@@ -27,6 +27,8 @@ import {
 
 import {
   FORCE_ARRAY,
+  HI_BOUND,
+  LO_BOUND,
   PAIR_SIZE,
 
   domain_clone,
@@ -992,14 +994,15 @@ function solver_confirmDomainElement(n) {
 function solver_tryToFixLegacyDomain(domain) {
   let fixed = [];
   for (let i = 0; i < domain.length; i++) {
-    let a = domain[i];
-    if (!(a instanceof Array)) {
+    let rangeArr = domain[i];
+    if (!(rangeArr instanceof Array)) {
       return;
     }
-    if (a.length !== PAIR_SIZE) {
+    if (rangeArr.length !== PAIR_SIZE) {
       return;
     }
-    let [lo, hi] = a;
+    let lo = rangeArr[LO_BOUND];
+    let hi = rangeArr[HI_BOUND];
     if (lo > hi) {
       return;
     }


### PR DESCRIPTION
…dToArray` call

=============================== Coverage summary ================
Statements   : 96.74% ( 2967/3067 ), 15 ignored
Branches     : 93.07% ( 1370/1472 ), 36 ignored
Functions    : 97.87% ( 276/282 ), 7 ignored
# Lines        : 96.99% ( 2477/2554 )
