### PR TITLE
Optimize changed var tries

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -16,10 +16,9 @@ import {
   THROW,
 } from './helpers';
 import {
-  TRIE_16_BIT,
-  TRIE_DEFAULT_SIZE,
-  TRIE_KEY_NOT_FOUND,
   TRIE_EMPTY,
+  TRIE_KEY_NOT_FOUND,
+  TRIE_NODE_SIZE,
 
   trie_add,
   trie_create,
@@ -1047,7 +1046,13 @@ function config_initForSpace(config, space) {
   if (!config._var_names_trie) {
     config._var_names_trie = trie_create(config.all_var_names);
   }
-  config._changedVarsTrie = trie_create(TRIE_EMPTY, TRIE_DEFAULT_SIZE, TRIE_16_BIT); // values very likely to exceed 255 so start at 16bit. it grows automatically if we exceed that.
+  // we know the max number of var names used in this search so we
+  // know the number of indexes the changevars trie may need to hash
+  // worst case. set the size accordingly. after some benchmarking
+  // it turns out these tries use about 1.1 node per index so just
+  // reserve that many cells. this saves some memcopies when growing.
+  let cells = Math.ceil(config.all_var_names.length * TRIE_NODE_SIZE * 1.1);
+  config._changedVarsTrie = trie_create(TRIE_EMPTY, cells);
   config._propagationBatch = 0;
   config._propagationCycles = 0;
 

--- a/src/trie.js
+++ b/src/trie.js
@@ -9,14 +9,14 @@ import {
 
 // BODY_START
 
-let TRIE_ROOT_OFFSET = 0;
-let TRIE_BUCKET_COUNT = 10; // 10 digits
-let TRIE_NODE_SIZE = TRIE_BUCKET_COUNT + 1; // inc value
+const TRIE_ROOT_OFFSET = 0;
+const TRIE_BUCKET_COUNT = 10; // 10 digits
+const TRIE_NODE_SIZE = TRIE_BUCKET_COUNT + 1; // inc value
 
-let TRIE_INITIAL_SIZE = 16 * 1024;
-let TRIE_MINIMAL_GROWTH = 4 * 1024;
+const TRIE_INITIAL_SIZE = 16 * 1024;
+const TRIE_MINIMAL_GROWTH = 4 * 1024;
 
-let TRIE_KEY_NOT_FOUND = -1;
+const TRIE_KEY_NOT_FOUND = -1;
 
 // every trie node needs space for 10 jumps + 1 leaf value (must be capable of containing `size(Trie)-1`) so initially 11 bytes, later 12 bytes and then 22 bytes once the number of nodes exceeds 255
 
@@ -32,6 +32,7 @@ let TRIE_KEY_NOT_FOUND = -1;
  */
 function trie_create(valuesByIndex, initialLength, initialBitsize) {
   let size = (initialLength | 0) || TRIE_INITIAL_SIZE;
+  if (!size) THROW('fixme'); // blabla it's possible the constant is not yet initialized due to minification. dont initialize a trie in module global space
   let bits = (initialBitsize | 0) || trie_getValueBitsize(size);
   let buf = trie_createBuffer(size, bits);
 

--- a/src/trie.js
+++ b/src/trie.js
@@ -42,7 +42,7 @@ const TRIE_DEFAULT_BITS = undefined;
 function trie_create(valuesByIndex, initialLength, initialBitsize) {
   let size = (initialLength | 0) || TRIE_INITIAL_SIZE;
   if (!size) THROW('fixme'); // blabla it's possible the constant is not yet initialized due to minification. dont initialize a trie in module global space
-  let bits = (initialBitsize | 0) || trie_getValueBitsize(size);
+  let bits = Math.max(trie_getValueBitsize(size), (initialBitsize | 0)); // given bitsize might be lower than max address, ignore it in that case
   let buf = trie_createBuffer(size, bits);
 
   // have to use a wrapper because the buffer ref may change when it grows

--- a/src/trie.js
+++ b/src/trie.js
@@ -531,6 +531,7 @@ export {
   TRIE_INITIAL_SIZE,
   TRIE_KEY_NOT_FOUND,
   TRIE_MINIMAL_GROWTH,
+  TRIE_NODE_SIZE,
   TRIE_EMPTY,
 
   trie_add,
@@ -539,6 +540,7 @@ export {
   _trie_debug,
   trie_get,
   trie_getNum,
+  trie_getValueBitsize,
   trie_has,
   trie_hasNum,
 };

--- a/src/trie.js
+++ b/src/trie.js
@@ -18,6 +18,15 @@ const TRIE_MINIMAL_GROWTH = 4 * 1024;
 
 const TRIE_KEY_NOT_FOUND = -1;
 
+const TRIE_EMPTY = undefined;
+const TRIE_DEFAULT_SIZE = undefined;
+const TRIE_8_BIT = 8;
+const TRIE_16_BIT = 16;
+const TRIE_32_BIT = 32;
+const TRIE_64_BIT = 64;
+const TRIE_DEFAULT_BITS = undefined;
+
+
 // every trie node needs space for 10 jumps + 1 leaf value (must be capable of containing `size(Trie)-1`) so initially 11 bytes, later 12 bytes and then 22 bytes once the number of nodes exceeds 255
 
 /**
@@ -75,13 +84,13 @@ function trie_create(valuesByIndex, initialLength, initialBitsize) {
  */
 function trie_createBuffer(size, bits) {
   switch (bits) {
-    case 8:
+    case TRIE_8_BIT:
       return new Uint8Array(size);
     case 16:
       return new Uint16Array(size);
-    case 32:
+    case TRIE_32_BIT:
       return new Uint32Array(size);
-    case 64:
+    case TRIE_64_BIT:
       return new Float64Array(size); // let's hope not ;)
   }
   THROW('Unsupported bit size');
@@ -162,10 +171,10 @@ function trie_malloc(trie, size) {
  * @returns {number}
  */
 function trie_getValueBitsize(value) {
-  if (value < 0x100) return 8;
-  else if (value < 0x10000) return 16;
-  else if (value < 0x100000000) return 32;
-  else return 64;
+  if (value < 0x100) return TRIE_8_BIT;
+  else if (value < 0x10000) return TRIE_16_BIT;
+  else if (value < 0x100000000) return TRIE_32_BIT;
+  else return TRIE_64_BIT;
 }
 
 /**
@@ -513,7 +522,16 @@ function _trie_debug(trie, skipBuffer) {
 // BODY_STOP
 
 export {
+  TRIE_8_BIT,
+  TRIE_16_BIT,
+  TRIE_32_BIT,
+  TRIE_64_BIT,
+  TRIE_DEFAULT_BITS,
+  TRIE_DEFAULT_SIZE,
+  TRIE_INITIAL_SIZE,
   TRIE_KEY_NOT_FOUND,
+  TRIE_MINIMAL_GROWTH,
+  TRIE_EMPTY,
 
   trie_add,
   trie_addNum,

--- a/src/trie.js
+++ b/src/trie.js
@@ -478,6 +478,16 @@ function _trie_debug(trie, skipBuffer) {
     Uint8Array.prototype.slice = Uint16Array.prototype.slice = Uint32Array.prototype.slice = Float64Array.prototype.slice = Array.prototype.slice;
   }
 
+  function bytes(b) {
+    if (b < 1024) return b + ' b';
+    b /= 1024;
+    if (b < 1024) return ~~(b * 100) / 100 + ' kb';
+    b /= 1024;
+    if (b < 1024) return ~~(b * 100) / 100 + ' mb';
+    b /= 1024;
+    return ~~(b * 100) / 100 + ' gb';
+  }
+
   let pad = 20;
   let npad = 6;
   let s = '' +
@@ -491,7 +501,8 @@ function _trie_debug(trie, skipBuffer) {
     'Node len:'.padEnd(pad, ' ') + TRIE_NODE_SIZE + '\n' +
     'Node size:'.padEnd(pad, ' ') + TRIE_NODE_SIZE + '\n' +
     'Last Node:'.padEnd(pad, ' ') + lastNode + '\n' +
-    'Unused space:'.padEnd(pad, ' ') + (buf.length - (lastNode + TRIE_NODE_SIZE)) + ' cells, ' + ((buf.length - (lastNode + TRIE_NODE_SIZE)) * (trie.bits >> 3)) + ' bytes\n' +
+    'Used space:'.padEnd(pad, ' ') + (lastNode + TRIE_NODE_SIZE) + ' cells, ' + bytes((lastNode + TRIE_NODE_SIZE) * (trie.bits >> 3)) + '\n' +
+    'Unused space:'.padEnd(pad, ' ') + (buf.length - (lastNode + TRIE_NODE_SIZE)) + ' cells, ' + bytes((buf.length - (lastNode + TRIE_NODE_SIZE)) * (trie.bits >> 3)) + '\n' +
 
     // __REMOVE_BELOW_FOR_DIST__
     'Mallocs:'.padEnd(pad, ' ') + trie._mallocs + '\n' +

--- a/tests/specs/trie.spec.js
+++ b/tests/specs/trie.spec.js
@@ -341,4 +341,19 @@ describe('src/tries.spec', function() {
       });
     });
   });
+
+  it.skip('test', function() {
+    let trie = trie_create(undefined, 1, 8);
+
+    let arr1k = new Array(1000).fill(0);
+    arr1k.forEach((_, i) => trie_addNum(trie, i, 0));
+    arr1k.forEach((_, i) => trie_getNum(trie, i));
+    console.log(_trie_debug(trie, true));
+
+    new Array(10000).fill(0).forEach((_, i) => trie_addNum(trie, i, 0));
+    console.log(_trie_debug(trie, true));
+
+    new Array(25000).fill(0).forEach((_, i) => trie_addNum(trie, i, 0));
+    console.log(_trie_debug(trie, true));
+  });
 });

--- a/tests/specs/trie.spec.js
+++ b/tests/specs/trie.spec.js
@@ -27,7 +27,35 @@ describe('src/tries.spec', function() {
     expect(trie.buffer instanceof Uint16Array).to.eql(true);
   });
 
+  describe('size hint', function() {
+
+    it('should work with 8bits', function() {
+      let trie = trie_create(undefined, 50, 8);
+
+      expect(trie.buffer).to.be.an.instanceof(Uint8Array);
+    });
+
+    it('should work with 16bits', function() {
+      let trie = trie_create(undefined, 50, 16);
+
+      expect(trie.buffer).to.be.an.instanceof(Uint16Array);
+    });
+
+    it('should work with 32bits', function() {
+      let trie = trie_create(undefined, 50, 32);
+
+      expect(trie.buffer).to.be.an.instanceof(Uint32Array);
+    });
+
+    it('should work with 64bits', function() {
+      let trie = trie_create(undefined, 50, 64);
+
+      expect(trie.buffer).to.be.an.instanceof(Float64Array);
+    });
+  });
+
   describe('string keys', function() {
+
     it('should be able to add a key', function() {
       let trie = trie_create();
       let before = trie_add(trie, 'foo', 15);
@@ -110,6 +138,59 @@ describe('src/tries.spec', function() {
       }
 
       //console.log(_trie_debug(trie));
+    });
+
+    describe('value bitsize', function() {
+
+      it('should work incrementally', function() {
+        let trie = trie_create(undefined, 50, 8);
+
+        expect(trie.buffer).to.be.an.instanceof(Uint8Array);
+
+        trie_add(trie, '1', 1);
+        expect(trie.buffer).to.be.an.instanceof(Uint8Array);
+        expect(trie_get(trie, '1')).to.eql(1);
+
+        trie_add(trie, '1 << 10', 1 << 10);
+        expect(trie.buffer).to.be.an.instanceof(Uint16Array);
+        expect(trie_get(trie, '1 << 10')).to.eql(1 << 10);
+
+        trie_add(trie, '1 << 20', 1 << 20);
+        expect(trie.buffer).to.be.an.instanceof(Uint32Array);
+        expect(trie_get(trie, '1 << 20')).to.eql(1 << 20);
+
+        trie_add(trie, '0xA000000000', 0xA000000000);
+        expect(trie.buffer).to.be.an.instanceof(Float64Array);
+        expect(trie_get(trie, '0xA000000000')).to.eql(0xA000000000);
+      });
+
+      it('should grow from min to max bitsize', function() {
+        let trie = trie_create(undefined, 50, 8);
+
+        expect(trie.buffer).to.be.an.instanceof(Uint8Array);
+
+        trie_add(trie, '1', 1);
+        expect(trie.buffer).to.be.an.instanceof(Uint8Array);
+        expect(trie_get(trie, '1')).to.eql(1);
+
+        trie_add(trie, '0xA000000000', 0xA000000000);
+        expect(trie.buffer).to.be.an.instanceof(Float64Array);
+        expect(trie_get(trie, '0xA000000000')).to.eql(0xA000000000);
+      });
+
+      it('should grow from 16 to 32bit', function() {
+        let trie = trie_create(undefined, 50, 8);
+
+        expect(trie.buffer).to.be.an.instanceof(Uint8Array);
+
+        trie_add(trie, '1 << 10', 1 << 10);
+        expect(trie.buffer).to.be.an.instanceof(Uint16Array);
+        expect(trie_get(trie, '1 << 10')).to.eql(1 << 10);
+
+        trie_add(trie, '1 << 20', 1 << 20);
+        expect(trie.buffer).to.be.an.instanceof(Uint32Array);
+        expect(trie_get(trie, '1 << 20')).to.eql(1 << 20);
+      });
     });
   });
 
@@ -205,6 +286,59 @@ describe('src/tries.spec', function() {
       }
 
       if (false) console.log(_trie_debug(trie));
+    });
+
+    describe('value bitsize', function() {
+
+      it('should work incrementally', function() {
+        let trie = trie_create(undefined, 50, 8);
+
+        expect(trie.buffer).to.be.an.instanceof(Uint8Array);
+
+        trie_addNum(trie, 1, 1);
+        expect(trie.buffer).to.be.an.instanceof(Uint8Array);
+        expect(trie_getNum(trie, 1)).to.eql(1);
+
+        trie_addNum(trie, 1 << 10, 1 << 10);
+        expect(trie.buffer).to.be.an.instanceof(Uint16Array);
+        expect(trie_getNum(trie, 1 << 10)).to.eql(1 << 10);
+
+        trie_addNum(trie, 1 << 20, 1 << 20);
+        expect(trie.buffer).to.be.an.instanceof(Uint32Array);
+        expect(trie_getNum(trie, 1 << 20)).to.eql(1 << 20);
+
+        trie_addNum(trie, 0xA000000000, 0xA000000000);
+        expect(trie.buffer).to.be.an.instanceof(Float64Array);
+        expect(trie_getNum(trie, 0xA000000000)).to.eql(0xA000000000);
+      });
+
+      it('should grow from min to max bitsize', function() {
+        let trie = trie_create(undefined, 50, 8);
+
+        expect(trie.buffer).to.be.an.instanceof(Uint8Array);
+
+        trie_addNum(trie, 1, 1);
+        expect(trie.buffer).to.be.an.instanceof(Uint8Array);
+        expect(trie_getNum(trie, 1)).to.eql(1);
+
+        trie_addNum(trie, 0xA000000000, 0xA000000000);
+        expect(trie.buffer).to.be.an.instanceof(Float64Array);
+        expect(trie_getNum(trie, 0xA000000000)).to.eql(0xA000000000);
+      });
+
+      it('should grow from 16 to 32bit', function() {
+        let trie = trie_create(undefined, 50, 8);
+
+        expect(trie.buffer).to.be.an.instanceof(Uint8Array);
+
+        trie_addNum(trie, 1 << 10, 1 << 10);
+        expect(trie.buffer).to.be.an.instanceof(Uint16Array);
+        expect(trie_getNum(trie, 1 << 10)).to.eql(1 << 10);
+
+        trie_addNum(trie, 1 << 20, 1 << 20);
+        expect(trie.buffer).to.be.an.instanceof(Uint32Array);
+        expect(trie_getNum(trie, 1 << 20)).to.eql(1 << 20);
+      });
     });
   });
 });

--- a/tests/specs/trie.spec.js
+++ b/tests/specs/trie.spec.js
@@ -342,7 +342,27 @@ describe('src/tries.spec', function() {
     });
   });
 
-  it.skip('test', function() {
+  describe('key bitsize', function() {
+
+    it('should ignore bitsize if it is too small to address the whole space', function() {
+      let trie = trie_create(undefined, 300, 8); // note: the 0 was an important value for the regression
+
+      expect(trie.bits).to.eql(16);
+    });
+
+    it('should adjust bitsize even if there is enough "space"', function() {
+      // regression
+      let trie = trie_create(undefined, 0, 8); // note: the 0 was an important value for the regression
+      // add 300 keys to the table, so the key size overflows the 8 bit cell size
+      for (let i = 0; i < 300; ++i) {
+        let prevValue = trie_addNum(trie, i, 0);
+        expect(prevValue, 'key = ' + i + ' should not yet have a value').to.eql(-1);
+      }
+      expect(trie.count).to.eql(300);
+    });
+  });
+
+  it.skip('benchmark size', function() {
     let trie = trie_create(undefined, 1, 8);
 
     let arr1k = new Array(1000).fill(0);


### PR DESCRIPTION
Improve robustness of Tries in general. Better scaling, safer to use with variating bitsizes for both the buffer size and the value size.
Use one trie per search to track changed vars while propagating. The structure hardly changes so once it's built up we don't have to worry about it anymore. By caching it we prevent building the same-ish structure over and over again. It uses a fence to distinct between epochs/cycles (if the registered value for a key is below this fence the key is considered not to exist).
Saves a bit, not huge but significant.
