### PR TITLE
Front

### DIFF
--- a/src/asmdomain.js
+++ b/src/asmdomain.js
@@ -284,7 +284,7 @@ function AsmDomainJs(/*stdlib, foreign, heap*/) {
       case 0:
         //return 32;
         return -1; // note: we dont use bits 31 and 32 so we can check for empty domain here "for free"
-      case 1:
+      case 1: // does not exist within 32bits
         return 0;
       case 2:
         return 1;
@@ -296,7 +296,7 @@ function AsmDomainJs(/*stdlib, foreign, heap*/) {
         return 23;
       case 6:
         return 27;
-      case 7:
+      case 7: // does not exist within 32bits
         return 0;
       case 8:
         return 3;
@@ -310,7 +310,7 @@ function AsmDomainJs(/*stdlib, foreign, heap*/) {
         return 28;
       case 13:
         return 11;
-      case 14:
+      case 14: // does not exist within 32bits
         return 0;
       case 15:
         return 13;
@@ -320,7 +320,7 @@ function AsmDomainJs(/*stdlib, foreign, heap*/) {
         return 7;
       case 18:
         return 17;
-      case 19:
+      case 19: // does not exist within 32bits
         return 0;
       case 20:
         return 25;
@@ -339,7 +339,7 @@ function AsmDomainJs(/*stdlib, foreign, heap*/) {
         return 12;
       case 27:
         return 6;
-      case 28:
+      case 28: // does not exist within 32bits
         return 0;
       case 29:
         return 21;
@@ -355,11 +355,9 @@ function AsmDomainJs(/*stdlib, foreign, heap*/) {
         return 8;
       case 35:
         return 19;
-      case 36:
-        return 18;
     }
-
-    return -1; // I don't think this really happens, or should, but just in case it does...
+    // case 36:
+    return 18;
   }
 
   /**

--- a/src/asmdomain.js
+++ b/src/asmdomain.js
@@ -236,17 +236,14 @@ function AsmDomainJs(/*stdlib, foreign, heap*/) {
       case 2: return 1;
       case 3: return 1;
     }
-    if ((domain | 0) == 1) return 0;
-    if ((domain | 0) == 2) return 1;
-    if ((domain | 0) == 3) return 1;
 
     // there's no pretty way to do this
-    while ((i | 0) >= 0) {
-      if (domain & (1 << i)) return i | 0;
+    do {
+      if (domain & (1 << i)) break;
       i = (i - 1) | 0;
-    }
+    } while ((i | 0) >= 0);
 
-    return -1; // I don't think this really happens, or should, but just in case it does...
+    return i | 0; // note: the 31 case is unused in our system and assumed impossible here
   }
 
   /**

--- a/src/config.js
+++ b/src/config.js
@@ -617,7 +617,7 @@ function config_solvedAtCompileTime(config, constraintName, varIndexes, param) {
   } else if (constraintName === 'sum') {
     if (!varIndexes.length) return true;
     return _config_solvedAtCompileTimeSumProduct(config, constraintName, varIndexes, param);
-  } else if (constraintName === 'sum') {
+  } else if (constraintName === 'product') {
     return _config_solvedAtCompileTimeSumProduct(config, constraintName, varIndexes, param);
   }
   return false;
@@ -919,6 +919,8 @@ function _config_solvedAtCompileTimeReifierRight(config, opName, varIndexLeft, v
 }
 function _config_solvedAtCompileTimeSumProduct(config, constraintName, varIndexes, resultIndex) {
   if (varIndexes.length === 1) {
+    // both in the case of sum and product, if there is only one value in the set, the result must be that value
+    // so here we do an intersect that one value with the result because that's what must happen anyways
     let domain = domain_toStr(domain_strstr_intersection(config.initial_domains[resultIndex], config.initial_domains[varIndexes[0]]));
     config.initial_domains[resultIndex] = domain;
     config.initial_domains[varIndexes[0]] = domain;

--- a/src/config.js
+++ b/src/config.js
@@ -632,7 +632,7 @@ function _config_solvedAtCompileTimeLtLte(config, constraintName, varIndexes) {
 
   ASSERT_STRDOM(domainLeft);
   ASSERT_STRDOM(domainRight);
-  if (!domainLeft || !domainRight) THROW('E_NON_EMPTY_DOMAINS_EXPECTED'); // it's probably a bug to feed empty domains to config
+  ASSERT(domainLeft && domainRight, 'NON_EMPTY_DOMAINS_EXPECTED'); // empty domains should be caught by addvar/decl
 
   let v = domain_str_getValue(domainLeft);
   if (v !== NO_SUCH_VALUE) {
@@ -662,6 +662,10 @@ function _config_solvedAtCompileTimeGtGte(config, constraintName, varIndexes) {
 
   let domainLeft = initialDomains[varIndexLeft];
   let domainRight = initialDomains[varIndexRight];
+
+  ASSERT_STRDOM(domainLeft);
+  ASSERT_STRDOM(domainRight);
+  ASSERT(domainLeft && domainRight, 'NON_EMPTY_DOMAINS_EXPECTED'); // empty domains should be caught by addvar/decl
 
   let v = domain_str_getValue(domainLeft);
   if (v !== NO_SUCH_VALUE) {

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,9 @@ import {
   trie_has,
 } from './trie';
 import {
+  front_create,
+} from './front';
+import {
   propagator_addDistinct,
   propagator_addDiv,
   propagator_addEq,
@@ -83,6 +86,8 @@ function config_create() {
     _propagationBatch: 0,
     _propagationCycles: 0,
 
+    _front: undefined,
+
     varStratConfig: config_createVarStratConfig(),
     valueStratName: 'min',
     targetedVars: 'all',
@@ -131,6 +136,8 @@ function config_clone(config, newDomains) {
     _changedVarsTrie: undefined,
     _propagationBatch, // track _propagationCycles at start of last propagate() call
     _propagationCycles, // current step value
+
+    _front: undefined, // dont clone this, that's useless.
 
     varStratConfig,
     valueStratName,
@@ -1046,6 +1053,8 @@ function config_initForSpace(config, space) {
   if (!config._var_names_trie) {
     config._var_names_trie = trie_create(config.all_var_names);
   }
+  // always create a new front (we may assume this is a new search)
+  config._front = front_create();
   // we know the max number of var names used in this search so we
   // know the number of indexes the changevars trie may need to hash
   // worst case. set the size accordingly. after some benchmarking

--- a/src/config.js
+++ b/src/config.js
@@ -430,18 +430,13 @@ function config_populateVarPropHash(config) {
   config._varToPropagators = hash;
 }
 function _config_addVarConditionally(varIndex, initialDomains, hash, propagatorIndex) {
-  if (typeof varIndex === 'number') {
-    // dont bother adding props on unsolved vars because they can't affect
-    // anything anymore. seems to prevent about 10% in our case so worth it.
-    if (!domain_str_isSolved(initialDomains[varIndex])) {
-      if (!hash[varIndex]) hash[varIndex] = [propagatorIndex];
-      else if (hash[varIndex].indexOf(propagatorIndex) < 0) hash[varIndex].push(propagatorIndex);
-    }
-  } else {
-    ASSERT(varIndex instanceof Array);
-    for (let i = 0, len = varIndex.length; i < len; ++i) {
-      _config_addVarConditionally(varIndex[i], initialDomains, hash, propagatorIndex);
-    }
+  // (at some point this could be a strings, or array, or whatever)
+  ASSERT(typeof varIndex === 'number', 'must be number');
+  // dont bother adding props on unsolved vars because they can't affect
+  // anything anymore. seems to prevent about 10% in our case so worth it.
+  if (!domain_str_isSolved(initialDomains[varIndex])) {
+    if (!hash[varIndex]) hash[varIndex] = [propagatorIndex];
+    else if (hash[varIndex].indexOf(propagatorIndex) < 0) hash[varIndex].push(propagatorIndex);
   }
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -520,8 +520,8 @@ function config_addConstraint(config, name, varNames, param) {
     case 'gte': {
       ASSERT(name !== 'markov' || varNames.length === 1, 'MARKOV_PROP_USES_ONE_VAR');
 
-      // require at least one non-constant variable... except distinct can have zero vars
-      let hasNonConstant = (name !== 'distinct') && varNames.length === 0;
+      // require at least one non-constant variable...
+      let hasNonConstant = false;
       for (let i = 0, n = varNames.length; i < n; ++i) {
         if (typeof varNames[i] === 'number') {
           let varIndex = config_addVarAnonConstant(config, varNames[i]);
@@ -532,8 +532,7 @@ function config_addConstraint(config, name, varNames, param) {
         }
       }
 
-      if (!hasNonConstant) THROW('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
-      if (varNames.length === 0) varNameToReturn = param;
+      if (!hasNonConstant) THROW('E_MUST_GET_AT_LEAST_ONE_VAR_NAME_ONLY_GOT_CONSTANTS');
       break;
     }
 

--- a/src/distribution/var.js
+++ b/src/distribution/var.js
@@ -24,7 +24,7 @@ const WORSE = 3;
  * @param {$space} space
  * @returns {number}
  */
-function distribution_getNextVar(space) {
+function distribution_getNextVarIndex(space) {
   let unsolvedVarIndexes = space.unsolvedVarIndexes;
   let varStratConfig = space.config.varStratConfig;
   let isBetterVarFunc = distribution_getFunc(varStratConfig.type);
@@ -231,7 +231,7 @@ function distribution_varThrow(s) {
 
 // BODY_STOP
 
-export default distribution_getNextVar;
+export default distribution_getNextVarIndex;
 export {
   BETTER,
   SAME,

--- a/src/distribution/var.js
+++ b/src/distribution/var.js
@@ -11,6 +11,11 @@ import {
   domain_any_size,
 } from '../domain';
 
+import {
+  _front_getCell,
+  _front_getSizeOf,
+} from '../front';
+
 // BODY_START
 
 const BETTER = 1;
@@ -25,11 +30,11 @@ const WORSE = 3;
  * @returns {number}
  */
 function distribution_getNextVarIndex(space) {
-  let unsolvedVarIndexes = space.unsolvedVarIndexes;
+  let front = space.config._front;
   let varStratConfig = space.config.varStratConfig;
   let isBetterVarFunc = distribution_getFunc(varStratConfig.type);
 
-  return _distribution_varFindBest(space, unsolvedVarIndexes, isBetterVarFunc, varStratConfig);
+  return _distribution_varFindBest(space, front, isBetterVarFunc, varStratConfig);
 }
 
 /**
@@ -61,16 +66,19 @@ function distribution_getFunc(distName) {
  * Return the best varIndex according to a fitness function
  *
  * @param {$space} space
- * @param {number[]} indexes A subset of indexes that are properties on space.vardoms
- * @param {Function($space, string, string, Function)} [fitnessFunc] Given two var indexes returns true iif the first var is better than the second var
+ * @param {$front} unsolvedFront
+ * @param {Function($space, currentIndex, bestIndex, Function)} [fitnessFunc] Given two var indexes returns true iif the first var is better than the second var
  * @param {Object} varStratConfig
  * @returns {number} The varIndex of the next var or NO_SUCH_VALUE
  */
-function _distribution_varFindBest(space, indexes, fitnessFunc, varStratConfig) {
-  ASSERT(indexes.length, 'SHOULD_HAVE_VARS');
+function _distribution_varFindBest(space, unsolvedFront, fitnessFunc, varStratConfig) {
   let bestVarIndex = NO_SUCH_VALUE;
-  for (let i = 0; i < indexes.length; i++) {
-    let varIndex = indexes[i];
+
+  let buf = unsolvedFront.buffer;
+  let nodeIndex = space.frontNodeIndex;
+
+  for (let i = 0, len = _front_getSizeOf(buf, nodeIndex); i < len; i++) {
+    let varIndex = _front_getCell(buf, nodeIndex, i);
     ASSERT(typeof varIndex === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
     ASSERT(space.vardoms[varIndex] !== undefined, 'expecting each varIndex to have an domain', varIndex);
 

--- a/src/front.js
+++ b/src/front.js
@@ -1,0 +1,263 @@
+// This class represents the "search front", manually maintained in a buffer.
+// In depth first search the front can be represented in a linear array that
+// continuously grows and shrinks. Because it only needs to maintain the
+// previous branch from which was branched for every step of the way.
+// Grow when branching, shrink when backtracking.
+// The goal of this class is to reduce pressure on the GC. It replaces a
+// model where part of these branches were maintained in their own arrays.
+// The model is simply a buffer with nodes, each node starts with a cell
+// that represents its size and then that many cells. During construction
+// a node may already have values while its length is not updated.
+// The nodes can only be reconstructed by walking from front to back, like
+// a singly linked list. Assuming, of course, the node lengths are properly
+// set.
+
+import {
+  ASSERT,
+  THROW,
+} from './helpers';
+
+// BODY_START
+
+const FRONT_DEFAULT_SIZE = 100;
+const FRONT_FIRST_NODE_OFFSET = 0;
+
+/**
+ * @param {number} [size]
+ * @returns {$front}
+ */
+function front_create(size) {
+  ASSERT(FRONT_DEFAULT_SIZE > 0, 'build check');
+  let front = {
+    _class: '$front',
+    lastNodeIndex: 0,
+    buffer: new Uint16Array(size || FRONT_DEFAULT_SIZE),
+  };
+
+  ASSERT(!void (front._nodes = 0)); // total added nodes, not total nodes in model because we cant know this
+  ASSERT(!void (front._grows = '[' + (size || FRONT_DEFAULT_SIZE) + ']'));
+
+  return front;
+}
+
+/**
+ * Moves the node pointer forward. Ensures the buffer has
+ * at least as much space to fit the entire previous node
+ * but does not copy/clone it. It's length starts at zero..
+ *
+ * @param {$front} front
+ * @returns {number} the new nodeIndex
+ */
+function front_addNode(front) {
+  ASSERT(front._class === '$front');
+
+  ASSERT(!void (++front._nodes));
+  //console.log('front_addNode');
+  let lastOffset = front.lastNodeIndex;
+  let lastLen = front.buffer[lastOffset];
+  if (!lastLen && lastOffset !== FRONT_FIRST_NODE_OFFSET) THROW('E_LAST_NODE_EMPTY'); // search should end if a list is empty so a node after an empty lis is an error. exception: first space.
+  let newOffset = lastOffset + 1 + lastLen; // +1 = cell containing length
+  front.lastNodeIndex = newOffset;
+
+  let buf = front.buffer;
+  let bufLen = buf.length;
+  let requiredLen = newOffset + 1 + lastLen;
+  if (requiredLen >= bufLen) {
+    front_grow(front, Math.floor(Math.max(requiredLen, bufLen + 1, bufLen * 1.1)));
+  }
+  return newOffset;
+}
+
+/**
+ * Grow the buffer of the front to given size. Will simply
+ * replace the internal buffer with a new buffer and copy
+ * the old buffer into it.
+ *
+ * @param {$front} front
+ * @param {number} size
+ */
+function front_grow(front, size) {
+  ASSERT(front._class === '$front');
+  ASSERT(typeof size === 'number');
+  ASSERT(size > front.buffer.length, 'buffer should only grow in our model');
+
+  ASSERT(!void (front._grows += ' ' + size));
+  let oldBuf = front.buffer;
+  front.buffer = new Uint16Array(size);
+  //console.log('growing from '+bufLen+' to '+buf.length)
+  front.buffer.set(oldBuf);
+}
+
+/**
+ * Returns the size of given node. This size excludes the size of the cell
+ * that maintains the size, since the caller most likely doesn't care about
+ * that internal artifact.
+ *
+ * @param {$front} front
+ * @param {number} nodeIndex
+ */
+function front_getSizeOf(front, nodeIndex) {
+  ASSERT(front._class === '$front');
+  ASSERT(typeof nodeIndex === 'number');
+
+  return _front_getSizeOf(front.buffer, nodeIndex);
+}
+/**
+ * Same as front_getSizeOf except it expects the buffer immediately.
+ *
+ * @param {TypedArray} buffer
+ * @param {number} nodeIndex
+ */
+function _front_getSizeOf(buffer, nodeIndex) {
+  ASSERT(!buffer._class);
+  ASSERT(nodeIndex >= 0, 'node should be >=0 (was ' + nodeIndex + ')');
+  ASSERT(nodeIndex < buffer.length);
+  ASSERT(nodeIndex + buffer[nodeIndex] < buffer.length);
+
+  return buffer[nodeIndex];
+}
+
+/**
+ * Set the size of given node to length. This length should
+ * not include the cell size for the length value (so just the
+ * number of elements that the node contains)..
+ *
+ * @param {$front} front
+ * @param {number} nodeIndex
+ * @param {number} length
+ */
+function front_setSizeOf(front, nodeIndex, length) {
+  ASSERT(front._class === '$front');
+
+  return _front_setSizeOf(front.buffer, nodeIndex, length);
+}
+/**
+ * Same as front_setSizeOf except it expects the buffer immediately.
+ *
+ * @param {TypedArray} buffer
+ * @param {number} nodeIndex
+ */
+function _front_setSizeOf(buffer, nodeIndex, length) {
+  ASSERT(!buffer._class);
+  ASSERT(typeof nodeIndex === 'number');
+  ASSERT(typeof length === 'number');
+  ASSERT(nodeIndex + 1 + length <= buffer.length, 'NODE_SHOULD_END_INSIDE_BUFFER [' + nodeIndex + ',' + length + ',' + buffer.length + ']');
+
+  buffer[nodeIndex] = length;
+}
+
+/**
+ * Add a value to the front. Value is inserted at given
+ * cell offset wihch is relative to given node offset.
+ * Only for the first node this operation may exceed the
+ * size of the buffer. In that case the buffer is grown.
+ * That is also the reason there is no _front_addCell with
+ * buffer argument; too dangerous to make mistakes by
+ * caching the buffer.
+ * If the buffer is exceeded otherwise an error is thrown.
+ * (Because each node in the front should only shrink so
+ * there's no need for nodes to be bigger than their predecessor)
+ *
+ * @param {$front} front
+ * @param {number} nodeIndex
+ * @param {number} cellOffset
+ * @param {number} value
+ */
+function front_addCell(front, nodeIndex, cellOffset, value) {
+  ASSERT(front._class === '$front');
+  ASSERT(typeof nodeIndex === 'number');
+  ASSERT(typeof cellOffset === 'number');
+  ASSERT(typeof value === 'number');
+  // dont abstract this. when adding cells or nodes the buffer should not be cached!
+
+  let bufLen = front.buffer.length;
+  let cellIndex = nodeIndex + 1 + cellOffset;
+  // initial size of front may not be big enough to hold all indexes. other nodes should be.
+  if (nodeIndex === FRONT_FIRST_NODE_OFFSET && cellIndex >= bufLen) {
+    front_grow(front, Math.floor(Math.max(cellIndex + 1, bufLen * 1.1)));
+  }
+  ASSERT(cellIndex < front.buffer.length, 'cellIndex should be within buffer');
+  front.buffer[cellIndex] = value;
+}
+
+/**
+ * Return value of cell relative to given node.
+ *
+ * @param {$front} front
+ * @param {number} nodeIndex
+ * @param {number} cellOffset
+ * @returns {number}
+ */
+function front_getCell(front, nodeIndex, cellOffset) {
+  return _front_getCell(front.buffer, nodeIndex, cellOffset);
+}
+/**
+ * Same as front_getCell except it expects the buffer immediately.
+ *
+ * @param {TypedArray} buffer
+ * @param {number} nodeIndex
+ */
+function _front_getCell(buf, nodeIndex, cellOffset) {
+  ASSERT(typeof nodeIndex === 'number', 'node must be number');
+  ASSERT(typeof cellOffset === 'number', 'cell must be number');
+  ASSERT(nodeIndex >= 0 && nodeIndex <= buf.length, 'node must not be OOB');
+  ASSERT(cellOffset >= 0, 'cell must not be OOB');
+  ASSERT(nodeIndex + 1 + cellOffset < buf.length, 'target cell should be within bounds');
+
+  return buf[nodeIndex + 1 + cellOffset];
+}
+
+/**
+ * @param {$front} front
+ * @param {Object} [options]
+ * @property {boolean} options.buf If true will do a pretty and raw print of the buffer
+ * @property {boolean} options.bufPretty If true will do a pretty print of the buffer
+ * @property {boolean} options.bufRaw If true will do a raw print of the buffer
+ */
+function _front_debug(front, options = {}) {
+  console.log('##');
+  console.log('Unsolved Vars Front:');
+  console.log('Cells:', front.buffer.length);
+  if (front._nodes !== 'undefined') console.log('Nodes:', front._nodes, '(added at some point, not currently containing)');
+  if (front._grows !== 'undefined') console.log('Grows:', front._grows);
+  console.log('');
+  if (options.bufPretty || options.buf) {
+    let buf = front.buffer;
+    let next = 0;
+    let nodes = 0;
+    while (next <= front.lastNodeIndex) {
+      ++nodes;
+      let len = buf[next++];
+      let s = next + ' [' + len + ']:';
+      for (let i = 0; i < len; ++i) {
+        s += ' ' + buf[next + i];
+      }
+      next += len;
+      console.log(s);
+    }
+    console.log('Current node count:', nodes);
+  }
+  if (options.bufRaw || options.buf) {
+    console.log('Raw buffer (' + front.buffer.length + '): [' + [].join.call(front.buffer, ',') + ']');
+  }
+  console.log('##');
+}
+
+// BODY_STOP
+
+export {
+  FRONT_DEFAULT_SIZE,
+  FRONT_FIRST_NODE_OFFSET,
+
+  front_addCell,
+  front_addNode,
+  front_create,
+  _front_debug,
+  front_getCell,
+  _front_getCell,
+  front_getSizeOf,
+  _front_getSizeOf,
+  front_setSizeOf,
+  _front_setSizeOf,
+};
+

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -119,6 +119,8 @@ function GET_NAME(e) {
 // @returns {string[]}
 
 function GET_NAMES(es) {
+  if (typeof es === 'string') return es;
+
   let varNames = [];
   for (let i = 0; i < es.length; i++) {
     let varName = es[i];

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -109,7 +109,7 @@ function ASSERT_ANYDOM(domain) {
 
 function GET_NAME(e) {
   // e can be the empty string (TOFIX: let's not allow this...)
-  if (e.id != null) {
+  if (e.id !== undefined && e.id !== null) {
     return e.id;
   }
   return e;

--- a/src/propagator.js
+++ b/src/propagator.js
@@ -60,24 +60,24 @@ import domain_any_minus from './doms/domain_minus';
  * @param {string} [arg2='']
  * @param {string} [arg3='']
  * @param {string} [arg4='']
- * @param {string} [arg5]
- * @param {string} [arg6]
+ * @param {string} [arg5='']
+ * @param {string} [arg6='']
  * @returns {$propagator}
  */
-function propagator_create(name, stepFunc, index1, index2 = -1, index3 = -1, arg1 = '', arg2 = '', arg3 = '', arg4 = '', arg5, arg6) {
+function propagator_create(name, stepFunc, index1, index2, index3, arg1, arg2, arg3, arg4, arg5, arg6) {
   return {
     _class: '$propagator',
     name: name,
     stepper: stepFunc,
-    index1: index1,
-    index2: index2,
-    index3: index3,
-    arg1: arg1,
-    arg2: arg2,
-    arg3: arg3,
-    arg4: arg4,
-    arg5: arg5,
-    arg6: arg6,
+    index1: index1 === undefined ? -1 : index1,
+    index2: index2 === undefined ? -1 : index2,
+    index3: index3 === undefined ? -1 : index3,
+    arg1: arg1 === undefined ? '' : arg1,
+    arg2: arg2 === undefined ? '' : arg2,
+    arg3: arg3 === undefined ? '' : arg3,
+    arg4: arg4 === undefined ? '' : arg4,
+    arg5: arg5 === undefined ? '' : arg5,
+    arg6: arg6 === undefined ? '' : arg6,
   };
 }
 

--- a/src/search.js
+++ b/src/search.js
@@ -10,7 +10,7 @@ import {
 import {
   domain_any_isSolved,
 } from './domain';
-import distribution_getNextVar from './distribution/var';
+import distribution_getNextVarIndex from './distribution/var';
 import distribute_getNextDomainForVar from './distribution/value';
 
 // BODY_START
@@ -111,7 +111,7 @@ function search_depthFirstLoop(space, stack, state, createNextSpaceNode) {
  * @returns {$space|undefined} a clone with small modification or nothing if this is an unsolved leaf node
  */
 function search_defaultSpaceFactory(space) {
-  let varIndex = distribution_getNextVar(space);
+  let varIndex = distribution_getNextVarIndex(space);
 
   if (varIndex !== NO_SUCH_VALUE) {
     ASSERT(typeof varIndex === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');

--- a/src/search.js
+++ b/src/search.js
@@ -72,7 +72,12 @@ function search_depthFirst(state) {
  * @returns {boolean}
  */
 function search_depthFirstLoop(space, stack, state, createNextSpaceNode) {
+  // we backtrack, update the last node in the data model with the previous space
+  // I don't like doing it this way but what else?
+  space.config._front.lastNodeIndex = space.frontNodeIndex;
+
   let rejected = space_propagate(space);
+
   if (rejected) {
     _search_onReject(state, space, stack);
     return false;

--- a/tests/specs/config.spec.js
+++ b/tests/specs/config.spec.js
@@ -580,4 +580,25 @@ describe('src/config.spec', function() {
       expect(clone.initial_domains).to.eql(newVars);
     });
   });
+
+  it('should reject a known var', function() {
+    let config = config_create();
+    config_addVarRange(config, 'again', 0, 10);
+    expect(_ => config_addVarRange(config, 'again', 0, 10)).to.throw('Do not declare the same varName twice');
+  });
+
+  it('should reject number as var', function() {
+    let config = config_create();
+    expect(_ => config_addVarRange(config, 200, 0, 10)).to.throw('A_VARNAME_SHOULD_BE_STRING_OR_TRUE');
+  });
+
+  it('should reject zero as var', function() {
+    let config = config_create();
+    expect(_ => config_addVarRange(config, 0, 0, 10)).to.throw('A_VARNAME_SHOULD_BE_STRING_OR_TRUE');
+  });
+
+  it('should reject stringified zero as var', function() {
+    let config = config_create();
+    expect(_ => config_addVarRange(config, '0', 0, 10)).to.throw('DONT_USE_NUMBERS_AS_VAR_NAMES');
+  });
 });

--- a/tests/specs/config.spec.js
+++ b/tests/specs/config.spec.js
@@ -165,6 +165,19 @@ describe('src/config.spec', function() {
         expect(config.all_var_names.length).to.equal(1);
         expect(config.initial_domains[0]).to.eql(fixt_strdom_range(lo, hi));
       });
+
+      it('should make a constant if lo=hi', function() {
+        let config = config_create();
+
+        let lo = 58778;
+        let hi = 58778;
+
+        let varIndex = config_addVarAnonRange(config, lo, hi);
+
+        expect(config.all_var_names.length).to.equal(1);
+        expect(config.initial_domains[0]).to.eql(fixt_strdom_range(lo, hi));
+        expect(config.constant_cache[lo]).to.eql(varIndex);
+      });
     });
 
     describe('with numbers', function() {
@@ -179,6 +192,19 @@ describe('src/config.spec', function() {
 
         expect(config.all_var_names.length).to.equal(1);
         expect(config.initial_domains[0]).to.eql(fixt_strdom_range(lo, hi, true));
+      });
+
+      it('should make a constant if lo=hi', function() {
+        let config = config_create();
+
+        let lo = 28;
+        let hi = 28;
+
+        let varIndex = config_addVarAnonRange(config, lo, hi);
+
+        expect(config.all_var_names.length).to.equal(1);
+        expect(config.initial_domains[0]).to.eql(fixt_strdom_range(lo, hi));
+        expect(config.constant_cache[lo]).to.eql(varIndex);
       });
     });
   });

--- a/tests/specs/config.spec.js
+++ b/tests/specs/config.spec.js
@@ -11,6 +11,7 @@ import {
   SUP,
 } from '../../src/helpers';
 import {
+  config_addConstraint,
   //config_addPropagator,
   config_addVarAnonConstant,
   config_addVarAnonNothing,
@@ -31,6 +32,18 @@ import {
 } from '../../src/space';
 
 describe('src/config.spec', function() {
+
+  describe('config_addConstraint', function() {
+
+    it('should exist', function() {
+      expect(config_addConstraint).to.be.a('function');
+    });
+
+    it('should throw for unknown names', function() {
+      let config = config_create();
+      expect(_ => config_addConstraint(config, 'crap', [])).to.throw('UNKNOWN_PROPAGATOR');
+    });
+  });
 
   describe('config_create', function() {
 

--- a/tests/specs/constraint.spec.js
+++ b/tests/specs/constraint.spec.js
@@ -7,7 +7,6 @@ import {
 import {
   SUB,
   SUP,
-  EMPTY,
 } from '../../src/helpers';
 import Solver from '../../src/solver';
 
@@ -20,7 +19,7 @@ describe('src/constraint.spec', function() {
       let solver = new Solver();
       solver.decl('A', 100);
       solver.decl('B', 100);
-      let solution = solver.solve({});
+      let solution = solver.solve();
 
       expect(solution).to.eql([{A: 100, B: 100}]);
     });
@@ -626,9 +625,9 @@ describe('src/constraint.spec', function() {
         let solver = new Solver();
         solver.decl('A', 100);
         solver.decl('B', 101);
-        solver.decl('C', EMPTY); // TODO: fix this test. if EMPTY is `undefined` this test still passes.
+        solver.decl('C', fixt_arrdom_range(0, 0, true)); // it should not even clamp to zero...
         solver.min('A', 'B', 'C');
-        let solution = solver.solve({});
+        let solution = solver.solve();
 
         expect(solution).to.eql([]);
       });

--- a/tests/specs/distribution/var.spec.js
+++ b/tests/specs/distribution/var.spec.js
@@ -6,7 +6,7 @@ import {
   fixt_arrdom_nums,
 } from '../../fixtures/domain.fixt';
 
-import distribution_getNextVar, {
+import distribution_getNextVarIndex, {
   BETTER,
   SAME,
   WORSE,
@@ -33,7 +33,7 @@ describe('distribution/var.spec', function() {
 
   describe('distribution_var_by_throw', function() {
     it('should throw', function() {
-      expect(_ => distribution_getNextVar({config: {varStratConfig: {type: 'throw'}}})).to.throw('not expecting to pick this distributor');
+      expect(_ => distribution_getNextVarIndex({config: {varStratConfig: {type: 'throw'}}})).to.throw('not expecting to pick this distributor');
     });
   });
 
@@ -62,9 +62,9 @@ describe('distribution/var.spec', function() {
       let B = solver._space.config.all_var_names.indexOf('B');
 
       solver._space.unsolvedVarIndexes = [A, B];
-      let varName = distribution_getNextVar(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varName, stack).to.equal(solver._space.config.all_var_names.indexOf(out));
+      expect(varIndex, stack).to.equal(solver._space.config.all_var_names.indexOf(out));
     });
   }
 
@@ -252,8 +252,8 @@ describe('distribution/var.spec', function() {
         let B = solver._space.config.all_var_names.indexOf('B');
 
         solver._space.unsolvedVarIndexes = [A, B];
-        let varName = distribution_getNextVar(solver._space);
-        expect(varName).to.eql(A);
+        let varIndex = distribution_getNextVarIndex(solver._space);
+        expect(varIndex).to.eql(A);
       });
 
       it('should count actual elements in the domain B', function() {
@@ -273,8 +273,8 @@ describe('distribution/var.spec', function() {
         let B = solver._space.config.all_var_names.indexOf('B');
 
         solver._space.unsolvedVarIndexes = [A, B];
-        let varName = distribution_getNextVar(solver._space);
-        expect(varName).to.eql(B);
+        let varIndex = distribution_getNextVarIndex(solver._space);
+        expect(varIndex).to.eql(B);
       });
     });
   });
@@ -449,9 +449,9 @@ describe('distribution/var.spec', function() {
         let D = solver._space.config.all_var_names.indexOf('D');
 
         solver._space.unsolvedVarIndexes = [A, B, C, D];
-        let varName = distribution_getNextVar(solver._space);
+        let varIndex = distribution_getNextVarIndex(solver._space);
 
-        expect(varName).to.eql(B);
+        expect(varIndex).to.eql(B);
       });
 
       it('should get markov vars back to front', function() {
@@ -493,9 +493,9 @@ describe('distribution/var.spec', function() {
         let D = solver._space.config.all_var_names.indexOf('D');
 
         solver._space.unsolvedVarIndexes = [A, B, C, D];
-        let varName = distribution_getNextVar(solver._space);
+        let varIndex = distribution_getNextVarIndex(solver._space);
 
-        expect(varName).to.eql(C);
+        expect(varIndex).to.eql(C);
       });
     });
   });
@@ -842,9 +842,9 @@ describe('distribution/var.spec', function() {
         let B = solver._space.config.all_var_names.indexOf('B');
 
         solver._space.unsolvedVarIndexes = [A, B];
-        let varName = distribution_getNextVar(solver._space);
+        let varIndex = distribution_getNextVarIndex(solver._space);
 
-        expect(varName).to.eql(A);
+        expect(varIndex).to.eql(A);
       });
 
       it('should solve vars in the explicit order of the list B', function() {
@@ -863,9 +863,9 @@ describe('distribution/var.spec', function() {
         let B = solver._space.config.all_var_names.indexOf('B');
 
         solver._space.unsolvedVarIndexes = [A, B];
-        let varName = distribution_getNextVar(solver._space);
+        let varIndex = distribution_getNextVarIndex(solver._space);
 
-        expect(varName).to.eql(B);
+        expect(varIndex).to.eql(B);
       });
 
       it('should not crash if a var is not on the list or when list is empty', function() {
@@ -882,9 +882,9 @@ describe('distribution/var.spec', function() {
         let A = solver._space.config.all_var_names.indexOf('A');
 
         solver._space.unsolvedVarIndexes = [A];
-        let varName = distribution_getNextVar(solver._space);
+        let varIndex = distribution_getNextVarIndex(solver._space);
 
-        expect(varName).to.eql(A);
+        expect(varIndex).to.eql(A);
       });
 
       it('should assume unlisted vars come after listed vars', function() {
@@ -905,20 +905,20 @@ describe('distribution/var.spec', function() {
         let C = solver._space.config.all_var_names.indexOf('C');
 
         solver._space.unsolvedVarIndexes = [A, B, C];
-        let varName = distribution_getNextVar(solver._space);
-        expect(varName, 'A and C should go before B').to.eql(A);
+        let varIndex = distribution_getNextVarIndex(solver._space);
+        expect(varIndex, 'A and C should go before B').to.eql(A);
 
         solver._space.unsolvedVarIndexes = [A, B];
-        varName = distribution_getNextVar(solver._space);
-        expect(varName, 'A should go before B').to.eql(A);
+        varIndex = distribution_getNextVarIndex(solver._space);
+        expect(varIndex, 'A should go before B').to.eql(A);
 
         solver._space.unsolvedVarIndexes = [B, C];
-        varName = distribution_getNextVar(solver._space);
-        expect(varName, 'C should go before B').to.eql(C);
+        varIndex = distribution_getNextVarIndex(solver._space);
+        expect(varIndex, 'C should go before B').to.eql(C);
 
         solver._space.unsolvedVarIndexes = [B];
-        varName = distribution_getNextVar(solver._space);
-        expect(varName, 'B is only one left').to.eql(B);
+        varIndex = distribution_getNextVarIndex(solver._space);
+        expect(varIndex, 'B is only one left').to.eql(B);
       });
 
       it('should work with list as fallback dist', function() {
@@ -942,20 +942,20 @@ describe('distribution/var.spec', function() {
         let C = solver._space.config.all_var_names.indexOf('C');
 
         solver._space.unsolvedVarIndexes = [A, B, C];
-        let varName = distribution_getNextVar(solver._space);
-        expect(varName, 'A and C should go before B').to.eql(A);
+        let varIndex = distribution_getNextVarIndex(solver._space);
+        expect(varIndex, 'A and C should go before B').to.eql(A);
 
         solver._space.unsolvedVarIndexes = [A, B];
-        varName = distribution_getNextVar(solver._space);
-        expect(varName, 'A should go before B').to.eql(A);
+        varIndex = distribution_getNextVarIndex(solver._space);
+        expect(varIndex, 'A should go before B').to.eql(A);
 
         solver._space.unsolvedVarIndexes = [B, C];
-        varName = distribution_getNextVar(solver._space);
-        expect(varName, 'C should go before B').to.eql(C);
+        varIndex = distribution_getNextVarIndex(solver._space);
+        expect(varIndex, 'C should go before B').to.eql(C);
 
         solver._space.unsolvedVarIndexes = [B];
-        varName = distribution_getNextVar(solver._space);
-        expect(varName, 'B is only one left').to.eql(B);
+        varIndex = distribution_getNextVarIndex(solver._space);
+        expect(varIndex, 'B is only one left').to.eql(B);
       });
     });
   });
@@ -1030,49 +1030,49 @@ describe('distribution/var.spec', function() {
 
     it('base test: should get highest priority on the list; A_list', function() {
       solver._space.unsolvedVarIndexes = [A_list, B_list, C_markov, D_markov, E_pleb, F_pleb];
-      let varName = distribution_getNextVar(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varName).to.equal(B_list);
+      expect(varIndex).to.equal(B_list);
     });
 
     it('missing first item from list', function() {
       solver._space.unsolvedVarIndexes = [A_list, C_markov, D_markov, E_pleb, F_pleb];
-      let varName = distribution_getNextVar(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varName).to.equal(A_list);
+      expect(varIndex).to.equal(A_list);
     });
 
     it('nothing on list, fallback to markov, get last markov', function() {
       solver._space.unsolvedVarIndexes = [C_markov, D_markov, E_pleb, F_pleb];
-      let varName = distribution_getNextVar(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varName).to.equal(D_markov);
+      expect(varIndex).to.equal(D_markov);
     });
 
     it('nothing on list, fallback to markov, get only markov', function() {
       solver._space.unsolvedVarIndexes = [C_markov, E_pleb, F_pleb];
-      let varName = distribution_getNextVar(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varName).to.equal(C_markov);
+      expect(varIndex).to.equal(C_markov);
     });
 
     it('nothing on list, no markov vars, pick smallest by size', function() {
       solver._space.unsolvedVarIndexes = [E_pleb, F_pleb];
-      let varName = distribution_getNextVar(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varName).to.equal(F_pleb);
+      expect(varIndex).to.equal(F_pleb);
     });
 
     it('nothing on list, no markov vars, pick only var left', function() {
       solver._space.unsolvedVarIndexes = [E_pleb];
-      let varName = distribution_getNextVar(solver._space, [E_pleb]);
+      let varIndex = distribution_getNextVarIndex(solver._space, [E_pleb]);
 
-      expect(varName).to.equal(E_pleb);
+      expect(varIndex).to.equal(E_pleb);
     });
 
     it('should throw for getting the next var without passing on names', function() {
       solver._space.unsolvedVarIndexes = [];
-      expect(_ => distribution_getNextVar(solver._space)).to.throw('SHOULD_HAVE_VARS');
+      expect(_ => distribution_getNextVarIndex(solver._space)).to.throw('SHOULD_HAVE_VARS');
     });
 
     it('dont crash on randomized inclusion and order', function() {
@@ -1084,7 +1084,7 @@ describe('distribution/var.spec', function() {
         names.sort(() => Math.random() - 0.5);
 
         solver._space.unsolvedVarIndexes = names;
-        expect(() => distribution_getNextVar(solver._space)).not.to.throw();
+        expect(() => distribution_getNextVarIndex(solver._space)).not.to.throw();
       }
     });
   });
@@ -1151,37 +1151,37 @@ describe('distribution/var.spec', function() {
 
     it('should prioritize list over rest A', function() {
       solver._space.unsolvedVarIndexes = [D, C, A, E, F];
-      let varName = distribution_getNextVar(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varName).to.equal(A);
+      expect(varIndex).to.equal(A);
     });
 
     it('should prioritize list over rest B', function() {
       solver._space.unsolvedVarIndexes = [D, C, B, E, F];
-      let varName = distribution_getNextVar(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varName).to.equal(B);
+      expect(varIndex).to.equal(B);
     });
 
     it('should prioritize un-blacklisted over rest E', function() {
       solver._space.unsolvedVarIndexes = [D, E, C];
-      let varName = distribution_getNextVar(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varName).to.equal(E);
+      expect(varIndex).to.equal(E);
     });
 
     it('should prioritize un-blacklisted over rest F', function() {
       solver._space.unsolvedVarIndexes = [D, F, C];
-      let varName = distribution_getNextVar(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varName).to.equal(F);
+      expect(varIndex).to.equal(F);
     });
 
     it('should prioritize C over D in blacklist', function() {
       solver._space.unsolvedVarIndexes = [D, C];
-      let varName = distribution_getNextVar(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varName).to.equal(C);
+      expect(varIndex).to.equal(C);
     });
   });
 });

--- a/tests/specs/distribution/var.spec.js
+++ b/tests/specs/distribution/var.spec.js
@@ -41,7 +41,7 @@ describe('distribution/var.spec', function() {
     let stack = new Error('from').stack; // mocha wont tell us which line called itAvsB :(
     if (stack && stack.slice) stack = stack.slice(0, stack.indexOf('._compile')) + ' ...'; // dont need the whole thing
 
-    it(`${desc}; type: ${type}, rangeA: ${range_a}, rangeB: ${range_b}, out: ${out}`, function() {
+    it(`itAvsB: ${desc}; type: ${type}, rangeA: ${range_a}, rangeB: ${range_b}, out: ${out}`, function() {
       let solver = new Solver();
       solver.addVar({
         id: 'A',
@@ -56,12 +56,10 @@ describe('distribution/var.spec', function() {
           varStrategy: {
             type: type,
           },
+          targeted_var_names: ['A', 'B'], // otherwise nothing happens
         },
       });
-      let A = solver._space.config.all_var_names.indexOf('A');
-      let B = solver._space.config.all_var_names.indexOf('B');
 
-      solver._space.unsolvedVarIndexes = [A, B];
       let varIndex = distribution_getNextVarIndex(solver._space);
 
       expect(varIndex, stack).to.equal(solver._space.config.all_var_names.indexOf(out));
@@ -247,13 +245,17 @@ describe('distribution/var.spec', function() {
           id: 'B',
           domain: fixt_arrdom_ranges([0, 50], [60, 90]), // 82 elements
         });
-        solver.prepare({distribute: {varStrategy: {type: 'size'}}});
-        let A = solver._space.config.all_var_names.indexOf('A');
-        let B = solver._space.config.all_var_names.indexOf('B');
+        solver.prepare({
+          distribute: {
+            varStrategy: {
+              type: 'size',
+            },
+            targeted_var_names: ['A', 'B'], // else nothing happens
+          },
+        });
 
-        solver._space.unsolvedVarIndexes = [A, B];
-        let varIndex = distribution_getNextVarIndex(solver._space);
-        expect(varIndex).to.eql(A);
+        let varName = distribution_getNextVarIndex(solver._space);
+        expect(varName).to.eql(solver._space.config.all_var_names.indexOf('A'));
       });
 
       it('should count actual elements in the domain B', function() {
@@ -268,13 +270,17 @@ describe('distribution/var.spec', function() {
           id: 'B',
           domain: fixt_arrdom_ranges([0, 10], [30, 40], [50, 60], [670, 700]), // 64 elements
         });
-        solver.prepare({distribute: {varStrategy: {type: 'size'}}});
-        let A = solver._space.config.all_var_names.indexOf('A');
-        let B = solver._space.config.all_var_names.indexOf('B');
+        solver.prepare({
+          distribute: {
+            varStrategy: {
+              type: 'size',
+            },
+            targeted_var_names: ['A', 'B'], // else nothing happens
+          },
+        });
 
-        solver._space.unsolvedVarIndexes = [A, B];
-        let varIndex = distribution_getNextVarIndex(solver._space);
-        expect(varIndex).to.eql(B);
+        let varName = distribution_getNextVarIndex(solver._space);
+        expect(varName).to.eql(solver._space.config.all_var_names.indexOf('B'));
       });
     });
   });
@@ -443,15 +449,12 @@ describe('distribution/var.spec', function() {
             varStrategy: {type: 'markov'},
           },
         });
-        let A = solver._space.config.all_var_names.indexOf('A');
-        let B = solver._space.config.all_var_names.indexOf('B');
-        let C = solver._space.config.all_var_names.indexOf('C');
-        let D = solver._space.config.all_var_names.indexOf('D');
+  //console.log('\n')
+  //_front_debug(solver._space.config._front);
 
-        solver._space.unsolvedVarIndexes = [A, B, C, D];
         let varIndex = distribution_getNextVarIndex(solver._space);
 
-        expect(varIndex).to.eql(B);
+        expect(varIndex).to.eql(solver._space.config.all_var_names.indexOf('B'));
       });
 
       it('should get markov vars back to front', function() {
@@ -487,15 +490,10 @@ describe('distribution/var.spec', function() {
             varStrategy: {type: 'markov'},
           },
         });
-        let A = solver._space.config.all_var_names.indexOf('A');
-        let B = solver._space.config.all_var_names.indexOf('B');
-        let C = solver._space.config.all_var_names.indexOf('C');
-        let D = solver._space.config.all_var_names.indexOf('D');
 
-        solver._space.unsolvedVarIndexes = [A, B, C, D];
         let varIndex = distribution_getNextVarIndex(solver._space);
 
-        expect(varIndex).to.eql(C);
+        expect(varIndex).to.eql(solver._space.config.all_var_names.indexOf('C'));
       });
     });
   });
@@ -836,15 +834,13 @@ describe('distribution/var.spec', function() {
               type: 'list',
               priorityList: ['A', 'B'],
             },
+            targeted_var_names: ['A', 'B'], // else nothing happens
           },
         });
-        let A = solver._space.config.all_var_names.indexOf('A');
-        let B = solver._space.config.all_var_names.indexOf('B');
 
-        solver._space.unsolvedVarIndexes = [A, B];
-        let varIndex = distribution_getNextVarIndex(solver._space);
+        let varName = distribution_getNextVarIndex(solver._space);
 
-        expect(varIndex).to.eql(A);
+        expect(varName).to.eql(solver._space.config.all_var_names.indexOf('A'));
       });
 
       it('should solve vars in the explicit order of the list B', function() {
@@ -857,15 +853,13 @@ describe('distribution/var.spec', function() {
               type: 'list',
               priorityList: ['B', 'A'],
             },
+            targeted_var_names: ['A', 'B'], // else nothing happens
           },
         });
-        let A = solver._space.config.all_var_names.indexOf('A');
-        let B = solver._space.config.all_var_names.indexOf('B');
 
-        solver._space.unsolvedVarIndexes = [A, B];
-        let varIndex = distribution_getNextVarIndex(solver._space);
+        let varName = distribution_getNextVarIndex(solver._space);
 
-        expect(varIndex).to.eql(B);
+        expect(varName).to.eql(solver._space.config.all_var_names.indexOf('B'));
       });
 
       it('should not crash if a var is not on the list or when list is empty', function() {
@@ -877,17 +871,16 @@ describe('distribution/var.spec', function() {
               type: 'list',
               priorityList: [],
             },
+            targeted_var_names: ['A'], // else nothing happens
           },
         });
-        let A = solver._space.config.all_var_names.indexOf('A');
 
-        solver._space.unsolvedVarIndexes = [A];
-        let varIndex = distribution_getNextVarIndex(solver._space);
+        let varName = distribution_getNextVarIndex(solver._space);
 
-        expect(varIndex).to.eql(A);
+        expect(varName).to.eql(solver._space.config.all_var_names.indexOf('A'));
       });
 
-      it('should assume unlisted vars come after listed vars', function() {
+      function unlistedTest(desc, targetNames, expectingName) {
         let solver = new Solver();
         solver.addVar({id: 'A'});
         solver.addVar({id: 'B'});
@@ -898,30 +891,22 @@ describe('distribution/var.spec', function() {
               type: 'list',
               priorityList: ['A', 'C'],
             },
+            targeted_var_names: targetNames, // else nothing happens
           },
         });
-        let A = solver._space.config.all_var_names.indexOf('A');
-        let B = solver._space.config.all_var_names.indexOf('B');
-        let C = solver._space.config.all_var_names.indexOf('C');
 
-        solver._space.unsolvedVarIndexes = [A, B, C];
-        let varIndex = distribution_getNextVarIndex(solver._space);
-        expect(varIndex, 'A and C should go before B').to.eql(A);
+        let varName = distribution_getNextVarIndex(solver._space);
+        expect(varName, desc).to.eql(solver._space.config.all_var_names.indexOf(expectingName));
+      }
 
-        solver._space.unsolvedVarIndexes = [A, B];
-        varIndex = distribution_getNextVarIndex(solver._space);
-        expect(varIndex, 'A should go before B').to.eql(A);
-
-        solver._space.unsolvedVarIndexes = [B, C];
-        varIndex = distribution_getNextVarIndex(solver._space);
-        expect(varIndex, 'C should go before B').to.eql(C);
-
-        solver._space.unsolvedVarIndexes = [B];
-        varIndex = distribution_getNextVarIndex(solver._space);
-        expect(varIndex, 'B is only one left').to.eql(B);
+      it('should assume unlisted vars come after listed vars', function() {
+        unlistedTest('A and C should go before B', ['A', 'B', 'C'], 'A');
+        unlistedTest('A should go before B', ['A', 'B'], 'A');
+        unlistedTest('C should go before B', ['B', 'C'], 'C');
+        unlistedTest('B is only one left', ['B'], 'B');
       });
 
-      it('should work with list as fallback dist', function() {
+      function fallbackTest(desc, targetNames, expectedName) {
         let solver = new Solver();
         solver.addVar({id: 'A'});
         solver.addVar({id: 'B'});
@@ -935,27 +920,19 @@ describe('distribution/var.spec', function() {
                 priorityList: ['A', 'C'],
               },
             },
+            targeted_var_names: targetNames, // else nothing happens
           },
         });
-        let A = solver._space.config.all_var_names.indexOf('A');
-        let B = solver._space.config.all_var_names.indexOf('B');
-        let C = solver._space.config.all_var_names.indexOf('C');
 
-        solver._space.unsolvedVarIndexes = [A, B, C];
-        let varIndex = distribution_getNextVarIndex(solver._space);
-        expect(varIndex, 'A and C should go before B').to.eql(A);
+        let varName = distribution_getNextVarIndex(solver._space);
+        expect(varName, desc).to.eql(solver._space.config.all_var_names.indexOf(expectedName));
+      }
 
-        solver._space.unsolvedVarIndexes = [A, B];
-        varIndex = distribution_getNextVarIndex(solver._space);
-        expect(varIndex, 'A should go before B').to.eql(A);
-
-        solver._space.unsolvedVarIndexes = [B, C];
-        varIndex = distribution_getNextVarIndex(solver._space);
-        expect(varIndex, 'C should go before B').to.eql(C);
-
-        solver._space.unsolvedVarIndexes = [B];
-        varIndex = distribution_getNextVarIndex(solver._space);
-        expect(varIndex, 'B is only one left').to.eql(B);
+      it('should work with list as fallback dist', function() {
+        fallbackTest('A and C should go before B', ['A', 'B', 'C'], 'A');
+        fallbackTest('A should go before B', ['A', 'B'], 'A');
+        fallbackTest('C should go before B', ['B', 'C'], 'C');
+        fallbackTest('B is only one left', ['B'], 'B');
       });
     });
   });
@@ -963,15 +940,9 @@ describe('distribution/var.spec', function() {
   describe('fallback list -> markov -> size', function() {
     // each test will ask for a var and supply a more limited list of vars
 
-    let solver;
-    let A_list;
-    let B_list;
-    let C_markov;
-    let D_markov;
-    let E_pleb;
-    let F_pleb;
 
-    before(function() {
+    function test(targetNames, resultName) {
+      let solver;
       solver = new Solver();
       solver.addVar({
         id: 'A_list',
@@ -1005,6 +976,7 @@ describe('distribution/var.spec', function() {
         id: 'F_pleb',
         domain: [0, 75],
       });
+
       solver.prepare({
         distribute: {
           varStrategy: {
@@ -1017,89 +989,58 @@ describe('distribution/var.spec', function() {
               },
             },
           },
+          targeted_var_names: targetNames, // else nothing happens
         },
       });
 
-      A_list = solver._space.config.all_var_names.indexOf('A_list');
-      B_list = solver._space.config.all_var_names.indexOf('B_list');
-      C_markov = solver._space.config.all_var_names.indexOf('C_markov');
-      D_markov = solver._space.config.all_var_names.indexOf('D_markov');
-      E_pleb = solver._space.config.all_var_names.indexOf('E_pleb');
-      F_pleb = solver._space.config.all_var_names.indexOf('F_pleb');
-    });
-
-    it('base test: should get highest priority on the list; A_list', function() {
-      solver._space.unsolvedVarIndexes = [A_list, B_list, C_markov, D_markov, E_pleb, F_pleb];
       let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varIndex).to.equal(B_list);
+      if (resultName !== undefined) {
+        expect(varIndex).to.equal(solver._space.config.all_var_names.indexOf(resultName));
+      }
+    }
+
+    it('base test: should get highest priority on the list; A_list', function() {
+      test(['A_list', 'B_list', 'C_markov', 'D_markov', 'E_pleb', 'F_pleb'], 'B_list');
     });
 
     it('missing first item from list', function() {
-      solver._space.unsolvedVarIndexes = [A_list, C_markov, D_markov, E_pleb, F_pleb];
-      let varIndex = distribution_getNextVarIndex(solver._space);
-
-      expect(varIndex).to.equal(A_list);
+      test(['A_list', 'C_markov', 'D_markov', 'E_pleb', 'F_pleb'], 'A_list');
     });
 
     it('nothing on list, fallback to markov, get last markov', function() {
-      solver._space.unsolvedVarIndexes = [C_markov, D_markov, E_pleb, F_pleb];
-      let varIndex = distribution_getNextVarIndex(solver._space);
-
-      expect(varIndex).to.equal(D_markov);
+      test(['C_markov', 'D_markov', 'E_pleb', 'F_pleb'], 'D_markov');
     });
 
     it('nothing on list, fallback to markov, get only markov', function() {
-      solver._space.unsolvedVarIndexes = [C_markov, E_pleb, F_pleb];
-      let varIndex = distribution_getNextVarIndex(solver._space);
-
-      expect(varIndex).to.equal(C_markov);
+      test(['C_markov', 'E_pleb', 'F_pleb'], 'C_markov');
     });
 
     it('nothing on list, no markov vars, pick smallest by size', function() {
-      solver._space.unsolvedVarIndexes = [E_pleb, F_pleb];
-      let varIndex = distribution_getNextVarIndex(solver._space);
-
-      expect(varIndex).to.equal(F_pleb);
+      test(['E_pleb', 'F_pleb'], 'F_pleb');
     });
 
     it('nothing on list, no markov vars, pick only var left', function() {
-      solver._space.unsolvedVarIndexes = [E_pleb];
-      let varIndex = distribution_getNextVarIndex(solver._space, [E_pleb]);
-
-      expect(varIndex).to.equal(E_pleb);
-    });
-
-    it('should throw for getting the next var without passing on names', function() {
-      solver._space.unsolvedVarIndexes = [];
-      expect(_ => distribution_getNextVarIndex(solver._space)).to.throw('SHOULD_HAVE_VARS');
+      test(['E_pleb'], 'E_pleb');
     });
 
     it('dont crash on randomized inclusion and order', function() {
-      let all = [A_list, B_list, C_markov, D_markov, E_pleb, F_pleb];
+      let all = ['A_list', 'B_list', 'C_markov', 'D_markov', 'E_pleb', 'F_pleb'];
       for (let i = 0; i < 20; ++i) {
         // randomly remove elements from the list
         let names = all.filter(() => Math.random() > 0.3);
         // shuffle list the ugly way
         names.sort(() => Math.random() - 0.5);
 
-        solver._space.unsolvedVarIndexes = names;
-        expect(() => distribution_getNextVarIndex(solver._space)).not.to.throw();
+        test(names);
       }
     });
   });
 
   describe('list -> inverted list -> min', function() {
-    let solver;
-    let A;
-    let B;
-    let C;
-    let D;
-    let E;
-    let F;
 
-    before(function() {
-      solver = new Solver();
+    function test(targetNames, expectName) {
+      let solver = new Solver();
       solver.addVar({
         id: 'A',
         domain: [0, 10],
@@ -1138,50 +1079,33 @@ describe('distribution/var.spec', function() {
               },
             },
           },
+          targeted_var_names: targetNames, // else nothing happens
         },
       });
 
-      A = solver._space.config.all_var_names.indexOf('A');
-      B = solver._space.config.all_var_names.indexOf('B');
-      C = solver._space.config.all_var_names.indexOf('C');
-      D = solver._space.config.all_var_names.indexOf('D');
-      E = solver._space.config.all_var_names.indexOf('E');
-      F = solver._space.config.all_var_names.indexOf('F');
-    });
-
-    it('should prioritize list over rest A', function() {
-      solver._space.unsolvedVarIndexes = [D, C, A, E, F];
       let varIndex = distribution_getNextVarIndex(solver._space);
 
-      expect(varIndex).to.equal(A);
+      expect(varIndex).to.equal(solver._space.config.all_var_names.indexOf(expectName));
+    }
+
+    it('should prioritize list over rest A', function() {
+      test(['D', 'C', 'A', 'E', 'F'], 'A');
     });
 
     it('should prioritize list over rest B', function() {
-      solver._space.unsolvedVarIndexes = [D, C, B, E, F];
-      let varIndex = distribution_getNextVarIndex(solver._space);
-
-      expect(varIndex).to.equal(B);
+      test(['D', 'C', 'B', 'E', 'F'], 'B');
     });
 
     it('should prioritize un-blacklisted over rest E', function() {
-      solver._space.unsolvedVarIndexes = [D, E, C];
-      let varIndex = distribution_getNextVarIndex(solver._space);
-
-      expect(varIndex).to.equal(E);
+      test(['D', 'E', 'C'], 'E');
     });
 
     it('should prioritize un-blacklisted over rest F', function() {
-      solver._space.unsolvedVarIndexes = [D, F, C];
-      let varIndex = distribution_getNextVarIndex(solver._space);
-
-      expect(varIndex).to.equal(F);
+      test(['D', 'F', 'C'], 'F');
     });
 
     it('should prioritize C over D in blacklist', function() {
-      solver._space.unsolvedVarIndexes = [D, C];
-      let varIndex = distribution_getNextVarIndex(solver._space);
-
-      expect(varIndex).to.equal(C);
+      test(['D', 'C'], 'C');
     });
   });
 });

--- a/tests/specs/domain.spec.js
+++ b/tests/specs/domain.spec.js
@@ -2175,6 +2175,14 @@ describe('src/domain.spec', function() {
       gteTest(fixt_numdom_nums(5), 5, EMPTY);
       gteTest(fixt_numdom_nums(0, 1, 2), 5, fixt_numdom_nums(0, 1, 2));
       gteTest(fixt_numdom_nums(6, 7, 8), 5, EMPTY);
+
+      it('should improve code coverage', function() {
+        let numdom = fixt_numdom_range(0, 30);
+        for (let i = 0; i <= 50; ++i) {
+          let v = domain_any_removeGte(numdom, i);
+          expect(v).to.be.a('number');
+        }
+      });
     });
   });
 
@@ -2261,6 +2269,14 @@ describe('src/domain.spec', function() {
       lteTest(fixt_numdom_nums(5), 5, EMPTY);
       lteTest(fixt_numdom_nums(6, 7, 8), 5, fixt_numdom_nums(6, 7, 8));
       lteTest(fixt_numdom_nums(0, 1, 2, 3, 4), 5, EMPTY);
+
+      it('should improve code coverage', function() {
+        let numdom = fixt_numdom_range(0, 30);
+        for (let i = 0; i <= 50; ++i) {
+          let v = domain_any_removeLte(numdom, i);
+          expect(v).to.be.a('number');
+        }
+      });
     });
   });
 

--- a/tests/specs/exports/export.cases.spec.js
+++ b/tests/specs/exports/export.cases.spec.js
@@ -4,6 +4,10 @@ import Solver from '../../../src/solver';
 import {
   config_clone,
 } from '../../../src/config';
+import {
+  space_getUnsolvedVarCount,
+  _space_getUnsolvedVarNamesFresh,
+} from '../../../src/space';
 
 import case20160611 from './2016-06-11';
 import case20160613 from './2016-06-13';
@@ -735,7 +739,7 @@ describe('exports/export.cases.spec', function() {
         let solution = solver.solve();
 
         expect(solution).to.eql([{A: [19, 20], B: [20, 21]}]); // return all valid values that still satisfy all constraints (->none)
-        expect(solver._space.unsolvedVarIndexes).to.eql([]); // should not target A or B because they are unconstrained
+        expect(space_getUnsolvedVarCount(solver._space)).to.eql(0); // should not target A or B because they are unconstrained
       });
       it('constrained AB should appear in spaces unsolved vars list', function() {
         let solver = new Solver();
@@ -745,7 +749,7 @@ describe('exports/export.cases.spec', function() {
         let solution = solver.solve({});
 
         expect(solution).to.eql([{A: 19, B: 21}, {A: 19, B: 22}, {A: 20, B: 21}, {A: 20, B: 22}]); // now it must solve. note: result will be different when we optimize neq to "solve" properly
-        expect(solver._space.unsolvedVarIndexes).to.eql([0, 1]); // should A and B because they are under neq
+        expect(_space_getUnsolvedVarNamesFresh(solver._space).sort()).to.eql(['A', 'B']); // should A and B because they are under neq
       });
     });
   });

--- a/tests/specs/front.spec.js
+++ b/tests/specs/front.spec.js
@@ -1,0 +1,341 @@
+import expect from '../fixtures/mocha_proxy.fixt';
+
+import {
+  FRONT_FIRST_NODE_OFFSET,
+  FRONT_DEFAULT_SIZE,
+
+  front_addCell,
+  front_addNode,
+  front_create,
+  _front_debug,
+  front_getCell,
+  front_getSizeOf,
+  front_setSizeOf,
+} from '../../src/front';
+
+describe('src/front.spec', function() {
+
+  describe('front_addNode', function() {
+
+    it('should exist', function() {
+      expect(front_addNode).to.be.a('function');
+    });
+
+    it('should throw for adding a node to an empty node', function() {
+      let front = front_create(30);
+      let nodeIndex = front.lastNodeIndex;
+      expect(nodeIndex).to.eql(FRONT_FIRST_NODE_OFFSET);
+      front_setSizeOf(front, nodeIndex, 15);
+      nodeIndex = front_addNode(front);
+      front_setSizeOf(front, nodeIndex, 0);
+
+      expect(_ => front_addNode(front)).to.throw('E_LAST_NODE_EMPTY');
+    });
+
+    it('should not throw for adding a second node when the first node is empty', function() {
+      let front = front_create();
+      let nodeIndex = front.lastNodeIndex;
+      expect(nodeIndex).to.eql(FRONT_FIRST_NODE_OFFSET);
+
+      expect(front_getSizeOf(front, nodeIndex)).to.eql(0);
+      front_addNode(front);
+      expect(true).to.eql(true);
+    });
+
+    it('should add node immediately after first node on a fresh front with some elements', function() {
+      let front = front_create();
+      let nodeIndex = front.lastNodeIndex;
+      expect(nodeIndex).to.eql(FRONT_FIRST_NODE_OFFSET);
+
+      // we could skip the add cells and just set the len but let's be nice
+      front_addCell(front, nodeIndex, 0, 0xfff);
+      front_addCell(front, nodeIndex, 1, 0xfff);
+      front_addCell(front, nodeIndex, 2, 0xfff);
+      front_addCell(front, nodeIndex, 3, 0xfff);
+      front_addCell(front, nodeIndex, 4, 0xfff);
+      front_setSizeOf(front, nodeIndex, 5);
+      expect(front_getSizeOf(front, nodeIndex)).to.eql(5);
+
+      front_addNode(front);
+      expect(front.lastNodeIndex).to.eql(nodeIndex + 1 + 5);
+    });
+
+    it('should add node immediately after another non-first node', function() {
+      let front = front_create();
+      let nodeIndex = front.lastNodeIndex;
+      expect(nodeIndex).to.eql(FRONT_FIRST_NODE_OFFSET);
+
+      // we could skip the add cells and just set the len but let's be nice
+      front_addCell(front, nodeIndex, 0, 0xfff);
+      front_addCell(front, nodeIndex, 1, 0xfff);
+      front_addCell(front, nodeIndex, 2, 0xfff);
+      front_addCell(front, nodeIndex, 3, 0xfff);
+      front_addCell(front, nodeIndex, 4, 0xfff);
+      front_setSizeOf(front, nodeIndex, 5);
+      expect(front_getSizeOf(front, nodeIndex)).to.eql(5);
+
+      // we could skip the add cells and just set the len but let's be nice
+      nodeIndex = front_addNode(front);
+      front_addCell(front, nodeIndex, 0, 0xfff);
+      front_addCell(front, nodeIndex, 1, 0xfff);
+      front_addCell(front, nodeIndex, 2, 0xfff);
+      front_addCell(front, nodeIndex, 3, 0xfff);
+      front_setSizeOf(front, nodeIndex, 4);
+      expect(front_getSizeOf(front, nodeIndex)).to.eql(4);
+
+      front_addNode(front);
+      expect(front.lastNodeIndex).to.eql(nodeIndex + 1 + 4);
+    });
+
+    it('should throw for adding a node after an empty node because the search ends when the list is empty', function() {
+      let front = front_create();
+      let nodeIndex = front.lastNodeIndex;
+      expect(nodeIndex).to.eql(FRONT_FIRST_NODE_OFFSET);
+
+      // we could skip the add cells and just set the len but let's be nice
+      front_addCell(front, nodeIndex, 0, 0xfff);
+      front_addCell(front, nodeIndex, 1, 0xfff);
+      front_addCell(front, nodeIndex, 2, 0xfff);
+      front_addCell(front, nodeIndex, 3, 0xfff);
+      front_addCell(front, nodeIndex, 4, 0xfff);
+      front_setSizeOf(front, nodeIndex, 5);
+      expect(front_getSizeOf(front, nodeIndex)).to.eql(5);
+
+      // we could skip the add cells and just set the len but let's be nice
+      nodeIndex = front_addNode(front);
+      front_setSizeOf(front, nodeIndex, 0);
+      expect(front_getSizeOf(front, nodeIndex)).to.eql(0);
+
+      expect(_ => front_addNode(front)).to.throw('E_LAST_NODE_EMPTY');
+    });
+
+    it('should grow if it has less space left than prev node size', function() {
+      let front = front_create(20);
+      expect(front.buffer.length).to.equal(20);
+
+      front_setSizeOf(front, front.lastNodeIndex, 15);
+      front_addNode(front);
+
+      expect(front.buffer.length).to.be.gt(20);
+    });
+
+    it('should grow to at least have enough space to fit previous node', function() {
+      let front = front_create(200);
+      expect(front.buffer.length).to.equal(200);
+
+      front_setSizeOf(front, front.lastNodeIndex, 190);
+      front_addNode(front);
+
+      _front_debug(front);
+
+      expect(front.buffer.length).to.be.gte(382); // each node is length+1, so 2x190+2=382
+    });
+
+    it('should accept a length fills the buffer precisely', function() {
+      let front = front_create(10);
+      expect(front.buffer.length).to.equal(10);
+
+      front_setSizeOf(front, front.lastNodeIndex, 4);
+      front_addNode(front); // should start at 5, room for 1 + 4 cells = max cell index 9 (=10th cell)
+      front_setSizeOf(front, front.lastNodeIndex, 4);
+
+      _front_debug(front, {showBuf: true});
+
+      expect(front.buffer.length).to.be.gte(10); // each node is length+1, so 2x190+2=382
+    });
+
+    it('should be able to set len 0 on first node when buffer is len 1', function() {
+      let front = front_create(1); // only fits one size cell
+      expect(front.buffer.length).to.equal(1);
+      front_setSizeOf(front, front.lastNodeIndex, 0);
+      expect(front.buffer.length).to.equal(1);
+    });
+
+    it('should be able to grow exactly during an addNode request', function() {
+      let front = front_create(10);
+      expect(front.buffer.length).to.equal(10);
+
+      front_setSizeOf(front, front.lastNodeIndex, 6);
+      // fill with 10~15
+      for (let i = 0; i < 6; ++i) {
+        front_addCell(front, front.lastNodeIndex, i, 10 + i);
+      }
+      // the next node should start at 5 (6th cell), room for 1 + 4 cells = max cell index 9 (=10th cell)
+      front_addNode(front);
+      // fill with 20~25
+      for (let i = 0; i < 6; ++i) {
+        front_addCell(front, front.lastNodeIndex, i, 20 + i);
+      }
+      // len 6 + 1 length cell = 7 cells so next node starts at 7 (=8th cell)
+      expect(front.lastNodeIndex).to.eql(7);
+      // while it should *1.1, it will increase that to fit the max size of the new node if it's bigger, like in this case (11 vs 14)
+      expect(front.buffer.length).to.equal(14);
+      front_setSizeOf(front, front.lastNodeIndex, 6); // should fill the buffer exactly
+
+      expect(front.buffer.length).to.be.gte(11);
+    });
+
+    it('should grow when adding cell to first node that would exceed buffer', function() {
+      let front = front_create(2);
+      front_addCell(front, FRONT_FIRST_NODE_OFFSET, 0, 10);
+      front_addCell(front, FRONT_FIRST_NODE_OFFSET, 1, 11);
+
+      expect(front.buffer.length).to.eql(3); // only added one cell to the start
+    });
+
+    it('should grow when adding a few cells to first node that would exceed buffer', function() {
+      let front = front_create(2);
+      front_addCell(front, FRONT_FIRST_NODE_OFFSET, 0, 10);
+      _front_debug(front, {buf: true});
+      front_addCell(front, FRONT_FIRST_NODE_OFFSET, 1, 11);
+      front_addCell(front, FRONT_FIRST_NODE_OFFSET, 2, 12);
+      front_addCell(front, FRONT_FIRST_NODE_OFFSET, 3, 13);
+
+
+      expect(front.buffer.length).to.eql(5); // four cells + size cell = 5 cells
+    });
+  });
+
+  describe('front_addCell', function() {
+
+    it('should exist', function() {
+      expect(front_addCell).to.be.a('function');
+    });
+  });
+
+  describe('front_getCell', function() {
+
+    it('should exist', function() {
+      expect(front_getCell).to.be.a('function');
+    });
+
+    it('should return a set cell', function() {
+      let front = front_create();
+      front_addCell(front, front.lastNodeIndex, 0, 10);
+
+      expect(front_getCell(front, front.lastNodeIndex, 0)).to.eql(10);
+    });
+
+    it('should throw for exceeding bounds', function() {
+      let front = front_create(50);
+      // note; 50 is the 51st cell
+      expect(_ => front_getCell(front, front.lastNodeIndex, 50)).to.throw('target cell should be within bounds');
+      expect(_ => front_getCell(front, front.lastNodeIndex, -1)).to.throw('cell must not be OOB');
+      expect(_ => front_getCell(front, 51, 1)).to.throw('node must not be OOB');
+      expect(_ => front_getCell(front, -1, 1)).to.throw('node must not be OOB');
+    });
+
+    it('should throw for bad cell index', function() {
+      let front = front_create(50);
+      // note; 50 is the 51st cell
+      expect(_ => front_getCell(front, front.lastNodeIndex, undefined)).to.throw('cell must be number');
+      expect(_ => front_getCell(front, front.lastNodeIndex, {})).to.throw('cell must be number');
+    });
+  });
+
+  describe('front_create', function() {
+
+    it('should exist', function() {
+      expect(front_create).to.be.a('function');
+    });
+
+    it('should create a front with default size', function() {
+      let front = front_create();
+
+      expect(front._class).to.eql('$front');
+      expect(front.buffer.length).to.eql(FRONT_DEFAULT_SIZE);
+    });
+
+    it('should create a front with explicit size', function() {
+      let front = front_create(50);
+
+      expect(front._class).to.eql('$front');
+      expect(front.buffer.length).to.eql(50);
+    });
+  });
+
+  describe('_front_debug', function() {
+
+    it('should exist', function() {
+      expect(_front_debug).to.be.a('function');
+    });
+
+    it('should not crash on an empty front', function() {
+      let front = front_create();
+      _front_debug(front);
+      expect(true).to.eql(true);
+    });
+
+    it('should not crash on a front with some nodes', function() {
+      let front = front_create();
+      let nodeIndex = front.lastNodeIndex;
+
+      // we could skip the add cells and just set the len but let's be nice
+      front_addCell(front, nodeIndex, 0, 0xfff);
+      front_addCell(front, nodeIndex, 1, 0xfff);
+      front_addCell(front, nodeIndex, 2, 0xfff);
+      front_addCell(front, nodeIndex, 3, 0xfff);
+      front_addCell(front, nodeIndex, 4, 0xfff);
+      front_setSizeOf(front, nodeIndex, 5);
+
+      // we could skip the add cells and just set the len but let's be nice
+      nodeIndex = front_addNode(front);
+      front_addCell(front, nodeIndex, 0, 0xfff);
+      front_addCell(front, nodeIndex, 1, 0xfff);
+      front_addCell(front, nodeIndex, 2, 0xfff);
+      front_addCell(front, nodeIndex, 3, 0xfff);
+      front_setSizeOf(front, nodeIndex, 4);
+
+      _front_debug(front);
+      expect(true).to.eql(true);
+    });
+  });
+
+  describe('front_getSizeOf', function() {
+
+    it('should exist', function() {
+      expect(front_getSizeOf).to.be.a('function');
+    });
+
+    it('should report zero for a fresh node', function() {
+      let front = front_create();
+
+      expect(front_getSizeOf(front, front.lastNodeIndex)).to.eql(0);
+    });
+
+    it('should report zero for a node even when cells are added', function() {
+      let front = front_create();
+      front_addCell(front, front.lastNodeIndex, 0, 20);
+      front_addCell(front, front.lastNodeIndex, 1, 20);
+
+      expect(front_getSizeOf(front, front.lastNodeIndex)).to.eql(0);
+    });
+
+    it('should only care about what setSizeOf did', function() {
+      let front = front_create(20);
+      front_setSizeOf(front, front.lastNodeIndex, 15);
+
+      expect(front_getSizeOf(front, front.lastNodeIndex)).to.eql(15);
+    });
+  });
+
+  describe('front_setSizeOf', function() {
+
+    it('should exist', function() {
+      expect(front_setSizeOf).to.be.a('function');
+    });
+
+    it('should not need actual elements to be set', function() {
+      let front = front_create(50);
+      front_setSizeOf(front, front.lastNodeIndex, 20);
+
+      expect(front_getSizeOf(front, front.lastNodeIndex)).to.eql(20);
+    });
+
+    it('should throw if setting length beyond buffer', function() {
+      let front = front_create(50);
+
+      expect(_ => front_setSizeOf(front, front.lastNodeIndex, 51)).to.throw('NODE_SHOULD_END_INSIDE_BUFFER');
+    });
+  });
+});

--- a/tests/specs/solver.spec.js
+++ b/tests/specs/solver.spec.js
@@ -347,6 +347,13 @@ describe('solver.spec', function() {
           solver3.decl('B', 100);
           expect(solver3[method]('A', 'B', 3)).to.be.a('string');
         });
+
+        it('should throw for bad result name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
+        });
       }
 
       alias('plus');
@@ -386,6 +393,13 @@ describe('solver.spec', function() {
           solver3.decl('A', 100);
           solver3.decl('B', 100);
           expect(solver3[method]('A', 'B', 3)).to.be.a('string');
+        });
+
+        it('should throw for bad result name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
         });
       }
 
@@ -428,6 +442,13 @@ describe('solver.spec', function() {
           solver3.decl('B', 100);
           expect(solver3[method]('A', 'B', 3)).to.be.a('string');
         });
+
+        it('should throw for bad result name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
+        });
       }
 
       alias('times');
@@ -469,6 +490,13 @@ describe('solver.spec', function() {
           solver3.decl('B', 100);
           expect(solver3[method]('A', 'B', 3)).to.be.a('string');
         });
+
+        it('should throw for bad result name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
+        });
       }
 
       alias('div');
@@ -508,6 +536,13 @@ describe('solver.spec', function() {
           solver3.decl('A', 100);
           solver3.decl('B', 100);
           expect(solver3[method](['A', 'B'], 3)).to.be.a('string');
+        });
+
+        it('should throw for bad result name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          expect(_ => solver3[method](['A', 'B'], {})).to.throw('expecting result var name to be absent or a number or string:');
         });
       }
 
@@ -587,6 +622,13 @@ describe('solver.spec', function() {
           solver3.decl('A', 100);
           solver3.decl('B', 100);
           expect(solver3[method](['A', 'B'], 3)).to.be.a('string');
+        });
+
+        it('should throw for bad result name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          expect(_ => solver3[method](['A', 'B'], {})).to.throw('expecting result var name to be absent or a number or string:');
         });
       }
 
@@ -781,6 +823,13 @@ describe('solver.spec', function() {
             solver.decl('A', 100);
             solver.decl('B', 1);
             expect(solver[method]('A', 'B', 1)).to.be.a('string');
+          });
+
+          it('should throw for bad result name', function() {
+            let solver3 = new Solver();
+            solver3.decl('A', 100);
+            solver3.decl('B', 100);
+            expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
           });
         });
       }

--- a/tests/specs/solver.spec.js
+++ b/tests/specs/solver.spec.js
@@ -354,6 +354,28 @@ describe('solver.spec', function() {
           solver3.decl('B', 100);
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
         });
+
+        it('should have at leat one string var name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          solver3.decl('C', 100);
+
+          expect(solver3[method]('A', 'B')).to.be.a('string');
+          expect(solver3[method](1, 'B')).to.be.a('string');
+          expect(solver3[method]('A', 1)).to.be.a('string');
+          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method]('A', 'B', 'C')).to.be.a('string');
+          expect(solver3[method](1, 'B', 'C')).to.be.a('string');
+          expect(solver3[method]('A', 2, 'C')).to.be.a('string');
+          expect(_ => solver3[method](1, 2, 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method]('A', 'B', 3)).to.be.a('string');
+          expect(solver3[method](1, 'B', 3)).to.be.a('string');
+          expect(solver3[method]('A', 2, 3)).to.be.a('string');
+          expect(_ => solver3[method](1, 2, 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+        });
       }
 
       alias('plus');
@@ -400,6 +422,28 @@ describe('solver.spec', function() {
           solver3.decl('A', 100);
           solver3.decl('B', 100);
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
+        });
+
+        it('should have at leat one string var name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          solver3.decl('C', 100);
+
+          expect(solver3[method]('A', 'B')).to.be.a('string');
+          expect(solver3[method](1, 'B')).to.be.a('string');
+          expect(solver3[method]('A', 1)).to.be.a('string');
+          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method]('A', 'B', 'C')).to.be.a('string');
+          expect(solver3[method](1, 'B', 'C')).to.be.a('string');
+          expect(solver3[method]('A', 2, 'C')).to.be.a('string');
+          expect(_ => solver3[method](1, 2, 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method]('A', 'B', 3)).to.be.a('string');
+          expect(solver3[method](1, 'B', 3)).to.be.a('string');
+          expect(solver3[method]('A', 2, 3)).to.be.a('string');
+          expect(_ => solver3[method](1, 2, 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
         });
       }
 
@@ -449,6 +493,28 @@ describe('solver.spec', function() {
           solver3.decl('B', 100);
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
         });
+
+        it('should have at leat one string var name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          solver3.decl('C', 100);
+
+          expect(solver3[method]('A', 'B')).to.be.a('string');
+          expect(solver3[method](1, 'B')).to.be.a('string');
+          expect(solver3[method]('A', 1)).to.be.a('string');
+          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method]('A', 'B', 'C')).to.be.a('string');
+          expect(solver3[method](1, 'B', 'C')).to.be.a('string');
+          expect(solver3[method]('A', 2, 'C')).to.be.a('string');
+          expect(_ => solver3[method](1, 2, 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method]('A', 'B', 3)).to.be.a('string');
+          expect(solver3[method](1, 'B', 3)).to.be.a('string');
+          expect(solver3[method]('A', 2, 3)).to.be.a('string');
+          expect(_ => solver3[method](1, 2, 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+        });
       }
 
       alias('times');
@@ -497,6 +563,28 @@ describe('solver.spec', function() {
           solver3.decl('B', 100);
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
         });
+
+        it('should have at leat one string var name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          solver3.decl('C', 100);
+
+          expect(solver3[method]('A', 'B')).to.be.a('string');
+          expect(solver3[method](1, 'B')).to.be.a('string');
+          expect(solver3[method]('A', 1)).to.be.a('string');
+          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method]('A', 'B', 'C')).to.be.a('string');
+          expect(solver3[method](1, 'B', 'C')).to.be.a('string');
+          expect(solver3[method]('A', 2, 'C')).to.be.a('string');
+          expect(_ => solver3[method](1, 2, 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method]('A', 'B', 3)).to.be.a('string');
+          expect(solver3[method](1, 'B', 3)).to.be.a('string');
+          expect(solver3[method]('A', 2, 3)).to.be.a('string');
+          expect(_ => solver3[method](1, 2, 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+        });
       }
 
       alias('div');
@@ -543,6 +631,28 @@ describe('solver.spec', function() {
           solver3.decl('A', 100);
           solver3.decl('B', 100);
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('expecting result var name to be absent or a number or string:');
+        });
+
+        it('should have at leat one string var name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          solver3.decl('C', 100);
+
+          expect(solver3[method]('A', 'B')).to.be.a('string');
+          expect(_ => solver3[method](1, 'B')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME'); // special case
+          expect(solver3[method]('A', 1)).to.be.a('string');
+          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method](['A', 'B'], 'C')).to.be.a('string');
+          expect(solver3[method]([1, 'B'], 'C')).to.be.a('string');
+          expect(solver3[method](['A', 2], 'C')).to.be.a('string');
+          expect(_ => solver3[method]([1, 2], 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method](['A', 'B'], 3)).to.be.a('string');
+          expect(solver3[method]([1, 'B'], 3)).to.be.a('string');
+          expect(solver3[method](['A', 2], 3)).to.be.a('string');
+          expect(_ => solver3[method]([1, 2], 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
         });
       }
 
@@ -629,6 +739,28 @@ describe('solver.spec', function() {
           solver3.decl('A', 100);
           solver3.decl('B', 100);
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('expecting result var name to be absent or a number or string:');
+        });
+
+        it('should have at least one string var name', function() {
+          let solver3 = new Solver();
+          solver3.decl('A', 100);
+          solver3.decl('B', 100);
+          solver3.decl('C', 100);
+
+          expect(solver3[method]('A', 'B')).to.be.a('string');
+          expect(_ => solver3[method](1, 'B')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method]('A', 1)).to.be.a('string');
+          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method](['A', 'B'], 'C')).to.be.a('string');
+          expect(solver3[method]([1, 'B'], 'C')).to.be.a('string');
+          expect(solver3[method](['A', 2], 'C')).to.be.a('string');
+          expect(_ => solver3[method]([1, 2], 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+          expect(solver3[method](['A', 'B'], 3)).to.be.a('string');
+          expect(solver3[method]([1, 'B'], 3)).to.be.a('string');
+          expect(solver3[method](['A', 2], 3)).to.be.a('string');
+          expect(_ => solver3[method]([1, 2], 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
         });
       }
 
@@ -830,6 +962,28 @@ describe('solver.spec', function() {
             solver3.decl('A', 100);
             solver3.decl('B', 100);
             expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
+          });
+
+          it('should have at leat one string var name', function() {
+            let solver3 = new Solver();
+            solver3.decl('A', 100);
+            solver3.decl('B', 100);
+            solver3.decl('C', 100);
+
+            expect(solver3[method]('A', 'B')).to.be.a('string');
+            expect(solver3[method](1, 'B')).to.be.a('string');
+            expect(solver3[method]('A', 1)).to.be.a('string');
+            expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+            expect(solver3[method]('A', 'B', 'C')).to.be.a('string');
+            expect(solver3[method](1, 'B', 'C')).to.be.a('string');
+            expect(solver3[method]('A', 2, 'C')).to.be.a('string');
+            expect(_ => solver3[method](1, 2, 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+
+            expect(solver3[method]('A', 'B', 3)).to.be.a('string');
+            expect(solver3[method](1, 'B', 3)).to.be.a('string');
+            expect(solver3[method]('A', 2, 3)).to.be.a('string');
+            expect(_ => solver3[method](1, 2, 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
           });
         });
       }

--- a/tests/specs/trie.spec.js
+++ b/tests/specs/trie.spec.js
@@ -370,10 +370,69 @@ describe('src/tries.spec', function() {
     arr1k.forEach((_, i) => trie_getNum(trie, i));
     console.log(_trie_debug(trie, true));
 
+    /*
+    Key count:          1000
+    Node count:         1013 (1.013 nodes per key)
+    Buffer cell length: 12289
+    Buffer byte length: 24578
+    Bit size:           16
+    Node len:           11
+    Node size:          11
+    Last Node:          11132
+    Used space:         11143 cells, 21.76 kb
+    Unused space:       1146 cells, 2.23 kb
+    Mallocs:            1 4097 8193 12289
+    trie_adds:          1000
+    Avg key distance:   3.893
+    trie_hass:          0
+    trie_gets:          1000
+    Avg get distance:   3893 -> 3.893
+    */
+
     new Array(10000).fill(0).forEach((_, i) => trie_addNum(trie, i, 0));
     console.log(_trie_debug(trie, true));
 
+    /*
+    Key count:          10000
+    Node count:         10113 (1.0113 nodes per key)
+    Buffer cell length: 116857
+    Buffer byte length: 467428
+    Bit size:           32
+    Node len:           11
+    Node size:          11
+    Last Node:          111232
+    Used space:         111243 cells, 434.54 kb
+    Unused space:       5614 cells, 21.92 kb
+    Mallocs:            1 4097 8193 12289 16385 20481 24577 28673 32769 36865 40961 45057 49562 54518 59969 65965 72561 79817 87798 96577 106234 116857
+    trie_adds:          11000
+    Avg key distance:   4.798818181818182
+    trie_hass:          0
+    trie_gets:          1000
+    Avg get distance:   3893 -> 3.893
+    */
+
+
     new Array(25000).fill(0).forEach((_, i) => trie_addNum(trie, i, 0));
     console.log(_trie_debug(trie, true));
+
+    /*
+    Key count:          25000
+    Node count:         26112 (1.04448 nodes per key)
+    Buffer cell length: 303088
+    Buffer byte length: 1212352
+    Bit size:           32
+    Node len:           11
+    Node size:          11
+    Last Node:          287221
+    Used space:         287232 cells, 1.09 mb
+    Unused space:       15856 cells, 61.93 kb
+    Mallocs:            1 4097 8193 12289 16385 20481 24577 28673 32769 36865 40961 45057 49562 54518 59969 65965 72561 79817 87798 96577 106234 116857 128542 141396 155535 171088 188196 207015 227716 250487 275535 303088
+    trie_adds:          36000
+    Avg key distance:   5.324472222222222
+    trie_hass:          0
+    trie_gets:          1000
+    Avg get distance:   3893 -> 3.893
+    */
+
   });
 });


### PR DESCRIPTION
The main change is to implement a "front", a linear search structure that tracks the unsolved vars per search node (-> space).

The structure replaces the unsolvedVarIndexes arrays on each space. The goal is to reduce GC pressure because it no longer has to construct and deconstruct arrays for every step or backtrack of the search. Since we have more precise knowledge and assumptions about that data we can safely put ti in a Buffer. Of course at the cost of legibility.
