### PR TITLE
Detach config from space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Dropped the `callback` propagator, to return later. It was all kinds of messed up, anyways. This propagator was the only anomaly in the code and now we can run with more assumptions.
 - Dropped support for custom `search` function option. May return later.
 - Dropped support for `initial_vars` in the `Solver` constructor options
+- Dropped support for `next_choice`. I don't think it was really exposed, but either way internally it doesn't exist anymore. Everything uses the same space factory now, until we need this functionality back.
 
 ## v2.3.4:
 

--- a/src/distribution/value.js
+++ b/src/distribution/value.js
@@ -48,7 +48,6 @@ const MATH_RANDOM = Math.random;
 function distribute_getNextDomainForVar(space, config, varIndex, choiceIndex) {
   ASSERT(space._class === '$space', 'SPACE_SHOULD_BE_SPACE');
   ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
-  ASSERT(space.config === config);
   ASSERT(typeof varIndex === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
   ASSERT(domain_any_isUndetermined(space.vardoms[varIndex]), 'CALLSITE_SHOULD_PREVENT_DETERMINED'); // TODO: test
 
@@ -68,7 +67,6 @@ function distribute_getNextDomainForVar(space, config, varIndex, choiceIndex) {
 function _distribute_getNextDomainForVar(stratName, space, config, varIndex, choiceIndex) {
   ASSERT(space._class === '$space', 'EXPECTING_SPACE');
   ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
-  ASSERT(space.config === config);
 
   switch (stratName) {
     case 'max':

--- a/src/propagators/div.js
+++ b/src/propagators/div.js
@@ -13,12 +13,13 @@ import {
 
 /**
  * @param {$space} space
+ * @param {$config} config
  * @param {number} varIndex1
  * @param {number} varIndex2
  * @param {number} varIndex3
  * @returns {$fd_changeState}
  */
-function propagator_divStep(space, varIndex1, varIndex2, varIndex3) {
+function propagator_divStep(space, config, varIndex1, varIndex2, varIndex3) {
   ASSERT(varIndex1 >= 0 && varIndex2 >= 0 && varIndex3 >= 0, 'expecting three vars', varIndex1, varIndex2, varIndex3);
   let domain1 = space.vardoms[varIndex1];
   let domain2 = space.vardoms[varIndex2];

--- a/src/propagators/eq.js
+++ b/src/propagators/eq.js
@@ -21,12 +21,13 @@ import {
  * can potentially skip a lot of values early.
  *
  * @param {$space} space
+ * @param {$config} config
  * @param {number} varIndex1
  * @param {number} varIndex2
  * @returns {$fd_changeState}
  */
-function propagator_eqStepBare(space, varIndex1, varIndex2) {
-  ASSERT(space && space._class === '$space', 'SHOULD_GET_SPACE');
+function propagator_eqStepBare(space, config, varIndex1, varIndex2) {
+  ASSERT(space._class === '$space', 'SHOULD_GET_SPACE');
   ASSERT(typeof varIndex1 === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
   ASSERT(typeof varIndex2 === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
 

--- a/src/propagators/lt.js
+++ b/src/propagators/lt.js
@@ -14,11 +14,12 @@ import {
 
 /**
  * @param {$space} space
+ * @param {$config} config
  * @param {number} varIndex1
  * @param {number} varIndex2
  */
-function propagator_ltStepBare(space, varIndex1, varIndex2) {
-  ASSERT(space && space._class === '$space', 'SHOULD_GET_SPACE');
+function propagator_ltStepBare(space, config, varIndex1, varIndex2) {
+  ASSERT(space._class === '$space', 'SHOULD_GET_SPACE');
   ASSERT(typeof varIndex1 === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
   ASSERT(typeof varIndex2 === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
 
@@ -68,8 +69,8 @@ function propagator_ltStepBare(space, varIndex1, varIndex2) {
   }
 }
 
-function propagator_gtStepBare(space, varIndex1, varIndex2) {
-  return propagator_ltStepBare(space, varIndex2, varIndex1);
+function propagator_gtStepBare(space, config, varIndex1, varIndex2) {
+  return propagator_ltStepBare(space, config, varIndex2, varIndex1);
 }
 
 /**

--- a/src/propagators/lte.js
+++ b/src/propagators/lte.js
@@ -14,12 +14,13 @@ import {
 
 /**
  * @param {$space} space
+ * @param {$config} config
  * @param {number} varIndex1
  * @param {number} varIndex2
  * @returns {$fd_changeState}
  */
-function propagator_lteStepBare(space, varIndex1, varIndex2) {
-  ASSERT(space && space._class === '$space', 'SHOULD_GET_SPACE');
+function propagator_lteStepBare(space, config, varIndex1, varIndex2) {
+  ASSERT(space._class === '$space', 'SHOULD_GET_SPACE');
   ASSERT(typeof varIndex1 === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
   ASSERT(typeof varIndex2 === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
 
@@ -48,8 +49,8 @@ function propagator_lteStepBare(space, varIndex1, varIndex2) {
   }
 }
 
-function propagator_gteStepBare(space, varIndex1, varIndex2) {
-  return propagator_lteStepBare(space, varIndex2, varIndex1);
+function propagator_gteStepBare(space, config, varIndex1, varIndex2) {
+  return propagator_lteStepBare(space, config, varIndex2, varIndex1);
 }
 
 /**

--- a/src/propagators/markov.js
+++ b/src/propagators/markov.js
@@ -28,9 +28,10 @@ import {
  * there can be one markov propagator that checks all markov vars.
  *
  * @param {$space} space
+ * @param {$config} config
  * @param {number} varIndex
  */
-function propagator_markovStepBare(space, varIndex) {
+function propagator_markovStepBare(space, config, varIndex) {
   // THIS IS VERY EXPENSIVE IF expandVectorsWith IS ENABLED
 
   ASSERT(typeof varIndex === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
@@ -44,7 +45,7 @@ function propagator_markovStepBare(space, varIndex) {
 
   let value = domain_any_min(domain); // note: solved so lo=hi=value
 
-  let configVarDistOptions = space.config.var_dist_options;
+  let configVarDistOptions = config.var_dist_options;
   let distributionOptions = configVarDistOptions[space.config.all_var_names[varIndex]];
 
   ASSERT(distributionOptions, 'var should have a config', varIndex, distributionOptions || JSON.stringify(configVarDistOptions));

--- a/src/propagators/markov.js
+++ b/src/propagators/markov.js
@@ -46,7 +46,7 @@ function propagator_markovStepBare(space, config, varIndex) {
   let value = domain_any_min(domain); // note: solved so lo=hi=value
 
   let configVarDistOptions = config.var_dist_options;
-  let distributionOptions = configVarDistOptions[space.config.all_var_names[varIndex]];
+  let distributionOptions = configVarDistOptions[config.all_var_names[varIndex]];
 
   ASSERT(distributionOptions, 'var should have a config', varIndex, distributionOptions || JSON.stringify(configVarDistOptions));
   ASSERT(distributionOptions.valtype === 'markov', 'var should be a markov var', distributionOptions.valtype);

--- a/src/propagators/min.js
+++ b/src/propagators/min.js
@@ -13,11 +13,12 @@ import domain_any_minus from '../doms/domain_minus';
  * Min as in minus. Only updates the result domain.
  *
  * @param {$space} space
+ * @param {$config} config
  * @param {number} varIndex1
  * @param {number} varIndex2
  * @param {number} varIndex3
  */
-function propagator_minStep(space, varIndex1, varIndex2, varIndex3) {
+function propagator_minStep(space, config, varIndex1, varIndex2, varIndex3) {
   ASSERT(varIndex1 >= 0 && varIndex2 >= 0 && varIndex3 >= 0, 'expecting three vars', varIndex1, varIndex2, varIndex3);
   let domain1 = space.vardoms[varIndex1];
   let domain2 = space.vardoms[varIndex2];

--- a/src/propagators/mul.js
+++ b/src/propagators/mul.js
@@ -11,11 +11,12 @@ import {
 
 /**
  * @param {$space} space
+ * @param {$config} config
  * @param {number} varIndex1
  * @param {number} varIndex2
  * @param {number} varIndex3
  */
-function propagator_mulStep(space, varIndex1, varIndex2, varIndex3) {
+function propagator_mulStep(space, config, varIndex1, varIndex2, varIndex3) {
   ASSERT(varIndex1 >= 0 && varIndex2 >= 0 && varIndex3 >= 0, 'expecting three vars', varIndex1, varIndex2, varIndex3);
   let domain1 = space.vardoms[varIndex1];
   let domain2 = space.vardoms[varIndex2];

--- a/src/propagators/neq.js
+++ b/src/propagators/neq.js
@@ -16,11 +16,12 @@ import {
 
 /**
  * @param {$space} space
+ * @param {$config} config
  * @param {number} varIndex1
  * @param {number} varIndex2
  * @returns {$fd_changeState}
  */
-function propagator_neqStepBare(space, varIndex1, varIndex2) {
+function propagator_neqStepBare(space, config, varIndex1, varIndex2) {
   ASSERT(space && space._class === '$space', 'SHOULD_GET_SPACE');
   ASSERT(typeof varIndex1 === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
   ASSERT(typeof varIndex2 === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');

--- a/src/propagators/reified.js
+++ b/src/propagators/reified.js
@@ -18,6 +18,7 @@ import {
  * condition between two variables currently holds or not.
  *
  * @param {$space} space
+ * @param {$config} config
  * @param {number} leftVarIndex
  * @param {number} rightVarIndex
  * @param {number} resultVarIndex
@@ -28,7 +29,7 @@ import {
  * @param {Function} opRejectChecker
  * @param {Function} nopRejectChecker
  */
-function propagator_reifiedStepBare(space, leftVarIndex, rightVarIndex, resultVarIndex, opFunc, nopFunc, opName, invOpName, opRejectChecker, nopRejectChecker) {
+function propagator_reifiedStepBare(space, config, leftVarIndex, rightVarIndex, resultVarIndex, opFunc, nopFunc, opName, invOpName, opRejectChecker, nopRejectChecker) {
   ASSERT(space._class === '$space', 'SPACE_SHOULD_BE_SPACE');
   ASSERT(typeof leftVarIndex === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
   ASSERT(typeof rightVarIndex === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');
@@ -41,9 +42,9 @@ function propagator_reifiedStepBare(space, leftVarIndex, rightVarIndex, resultVa
   ASSERT(domResult === ZERO || domResult === ONE || domResult === BOOL, 'RESULT_DOM_SHOULD_BE_BOOL_BOUND [was' + domResult + ']');
 
   if (domResult === ZERO) {
-    nopFunc(space, leftVarIndex, rightVarIndex);
+    nopFunc(space, config, leftVarIndex, rightVarIndex);
   } else if (domResult === ONE) {
-    opFunc(space, leftVarIndex, rightVarIndex);
+    opFunc(space, config, leftVarIndex, rightVarIndex);
   } else {
     ASSERT(domResult === BOOL, 'failsafe assertion');
 
@@ -66,11 +67,11 @@ function propagator_reifiedStepBare(space, leftVarIndex, rightVarIndex, resultVa
         vardoms[resultVarIndex] = EMPTY;
       } else {
         vardoms[resultVarIndex] = ONE;
-        opFunc(space, leftVarIndex, rightVarIndex);
+        opFunc(space, config, leftVarIndex, rightVarIndex);
       }
     } else if (opRejects) {
       vardoms[resultVarIndex] = ZERO;
-      nopFunc(space, leftVarIndex, rightVarIndex);
+      nopFunc(space, config, leftVarIndex, rightVarIndex);
     }
   }
 }

--- a/src/propagators/ring.js
+++ b/src/propagators/ring.js
@@ -15,13 +15,14 @@ import domain_any_minus from '../doms/domain_minus';
 
 /**
  * @param {$space} space
+ * @param {$config} config
  * @param {number} varIndex1
  * @param {number} varIndex2
  * @param {number} varIndex3
  * @param {string} opName
  * @param {Function} opFunc
  */
-function propagator_ringStepBare(space, varIndex1, varIndex2, varIndex3, opName, opFunc) {
+function propagator_ringStepBare(space, config, varIndex1, varIndex2, varIndex3, opName, opFunc) {
   ASSERT(varIndex1 >= 0 && varIndex2 >= 0 && varIndex3 >= 0, 'expecting three vars', varIndex1, varIndex2, varIndex3);
   ASSERT(typeof opName === 'string', 'OP_SHOULD_BE_STRING');
   let domain1 = space.vardoms[varIndex1];

--- a/src/search.js
+++ b/src/search.js
@@ -122,7 +122,7 @@ function search_createNextSpace(space, config) {
       let choice = space.next_distribution_choice++;
       let nextDomain = distribute_getNextDomainForVar(space, config, varIndex, choice);
       if (nextDomain) {
-        let clone = space_createClone(space, config);
+        let clone = space_createClone(space);
         clone.updatedVarIndex = varIndex;
         clone.vardoms[varIndex] = nextDomain;
         return clone;

--- a/src/search.js
+++ b/src/search.js
@@ -119,7 +119,7 @@ function search_createNextSpace(space) {
       let choice = space.next_distribution_choice++;
       let nextDomain = distribute_getNextDomainForVar(space, varIndex, choice);
       if (nextDomain) {
-        let clone = space_createClone(space);
+        let clone = space_createClone(space, space.config);
         clone.updatedVarIndex = varIndex;
         clone.vardoms[varIndex] = nextDomain;
         return clone;

--- a/src/search.js
+++ b/src/search.js
@@ -117,7 +117,7 @@ function search_createNextSpace(space) {
     let domain = space.vardoms[varIndex];
     if (!domain_any_isSolved(domain)) {
       let choice = space.next_distribution_choice++;
-      let nextDomain = distribute_getNextDomainForVar(space, varIndex, choice);
+      let nextDomain = distribute_getNextDomainForVar(space, space.config, varIndex, choice);
       if (nextDomain) {
         let clone = space_createClone(space, space.config);
         clone.updatedVarIndex = varIndex;

--- a/src/search.js
+++ b/src/search.js
@@ -68,7 +68,7 @@ function search_depthFirstLoop(space, stack, state) {
   // I don't like doing it this way but what else?
   space.config._front.lastNodeIndex = space.frontNodeIndex;
 
-  let rejected = space_propagate(space);
+  let rejected = space_propagate(space, space.config);
 
   if (rejected) {
     _search_onReject(state, space, stack);

--- a/src/search.js
+++ b/src/search.js
@@ -108,7 +108,7 @@ function search_depthFirstLoop(space, stack, state) {
  * @returns {$space|undefined} a clone with small modification or nothing if this is an unsolved leaf node
  */
 function search_createNextSpace(space) {
-  let varIndex = distribution_getNextVarIndex(space);
+  let varIndex = distribution_getNextVarIndex(space, space.config);
 
   if (varIndex !== NO_SUCH_VALUE) {
     ASSERT(typeof varIndex === 'number', 'VAR_INDEX_SHOULD_BE_NUMBER');

--- a/src/search.js
+++ b/src/search.js
@@ -75,7 +75,7 @@ function search_depthFirstLoop(space, stack, state) {
     return false;
   }
 
-  let solved = space_updateUnsolvedVarList(space);
+  let solved = space_updateUnsolvedVarList(space, space.config);
   if (solved) {
     _search_onSolve(state, space, stack);
     return true;

--- a/src/solver.js
+++ b/src/solver.js
@@ -798,7 +798,7 @@ function solver_getSolutions(solvedSpaces, solutions, log) {
     console.time('      - FD Solution Construction Time');
   }
   for (let i = 0; i < solvedSpaces.length; ++i) {
-    let solution = space_solution(solvedSpaces[i]);
+    let solution = space_solution(solvedSpaces[i], solvedSpaces[i].config);
     solutions.push(solution);
     if (log >= LOG_SOLVES) {
       console.log('      - FD solution() ::::::::::::::::::::::::::::');

--- a/src/solver.js
+++ b/src/solver.js
@@ -539,7 +539,7 @@ class Solver {
     if (alreadyRejected) {
       solvedSpaces = [];
     } else {
-      solvedSpaces = solver_runLoop(state, max);
+      solvedSpaces = solver_runLoop(state, this.config, max);
     }
 
     if (log >= LOG_STATS) {
@@ -766,13 +766,14 @@ function getInspector() {
  * probably only need one solution. Won't return more solutions than max.
  *
  * @param {Object} state
+ * @param {$config} config
  * @param {number} max Stop after finding this many solutions
  * @returns {$space[]} All solved spaces that were found (until max or end was reached)
  */
-function solver_runLoop(state, max) {
+function solver_runLoop(state, config, max) {
   let list = [];
   while (state.more && list.length < max) {
-    search_depthFirst(state);
+    search_depthFirst(state, config);
     if (state.status !== 'end') {
       list.push(state.space);
     }

--- a/src/solver.js
+++ b/src/solver.js
@@ -547,7 +547,7 @@ class Solver {
       console.log(`      - FD Solutions: ${solvedSpaces.length}`);
     }
 
-    if (!squash) solver_getSolutions(solvedSpaces, this.solutions, log);
+    if (!squash) solver_getSolutions(solvedSpaces, this.config, this.solutions, log);
   }
 
   /**
@@ -793,13 +793,13 @@ function solver_varDistOptions(name, bvar, config) {
   }
 }
 
-function solver_getSolutions(solvedSpaces, solutions, log) {
+function solver_getSolutions(solvedSpaces, config, solutions, log) {
   ASSERT(solutions instanceof Array);
   if (log >= LOG_STATS) {
     console.time('      - FD Solution Construction Time');
   }
   for (let i = 0; i < solvedSpaces.length; ++i) {
-    let solution = space_solution(solvedSpaces[i], solvedSpaces[i].config);
+    let solution = space_solution(solvedSpaces[i], config);
     solutions.push(solution);
     if (log >= LOG_SOLVES) {
       console.log('      - FD solution() ::::::::::::::::::::::::::::');

--- a/src/solver.js
+++ b/src/solver.js
@@ -622,7 +622,7 @@ class Solver {
   branch_from_current_solution() {
     // get the _solved_ space, convert to config,
     // use new config as base for new solver
-    let solvedConfig = space_toConfig(this.state.space);
+    let solvedConfig = space_toConfig(this.state.space, this.config);
     return new Solver({config: solvedConfig});
   }
 

--- a/src/solver.js
+++ b/src/solver.js
@@ -519,9 +519,9 @@ class Solver {
     ASSERT(state);
 
     if (log >= LOG_STATS) {
-      console.log(`      - FD Var Count: ${state.space.config.all_var_names.length}`);
-      console.log(`      - FD Constraint Count: ${state.space.config.all_constraints.length}`);
-      console.log(`      - FD Propagator Count: ${state.space.config._propagators.length}`);
+      console.log(`      - FD Var Count: ${this.config.all_var_names.length}`);
+      console.log(`      - FD Constraint Count: ${this.config.all_constraints.length}`);
+      console.log(`      - FD Propagator Count: ${this.config._propagators.length}`);
       console.log('      - FD Solving...');
       console.time('      - FD Solving Time');
     }

--- a/src/space.js
+++ b/src/space.js
@@ -181,10 +181,15 @@ function space_initFromConfig(space, config) {
  * This is only used for testing, prevents leaking internals into tests
  *
  * @param {$space} space
+ * @param {$config} config
  * @returns {number}
  */
-function space_getUnsolvedVarCount(space) {
-  return front_getSizeOf(space.config._front, space.frontNodeIndex);
+function space_getUnsolvedVarCount(space, config) {
+  ASSERT(space._class === '$space', 'EXPECTING_SPACE');
+  ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
+  ASSERT(space.config === config);
+
+  return front_getSizeOf(config._front, space.frontNodeIndex);
 }
 /**
  * Return the index of the nth unsolved var in given node

--- a/src/space.js
+++ b/src/space.js
@@ -296,7 +296,7 @@ function space_propagate(space, config) {
   let returnValue = false;
   while (changedVars.length) {
     let newChangedVars = [];
-    let rejected = space_propagateChanges(space, propagators, minimal, changedVars, newChangedVars, changedTrie, ++cycles);
+    let rejected = space_propagateChanges(space, config, propagators, minimal, changedVars, newChangedVars, changedTrie, ++cycles);
     if (rejected) {
       returnValue = true;
       break;
@@ -379,8 +379,12 @@ function space_recordChange(varIndex, changedTrie, changedVars, cycleIndex) {
     }
   }
 }
-function space_propagateChanges(space, allPropagators, minimal, targetVars, changedVars, changedTrie, cycleIndex) {
-  let varToPropagators = space.config._varToPropagators;
+function space_propagateChanges(space, config, allPropagators, minimal, targetVars, changedVars, changedTrie, cycleIndex) {
+  ASSERT(space._class === '$space', 'EXPECTING_SPACE');
+  ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
+  ASSERT(space.config === config);
+
+  let varToPropagators = config._varToPropagators;
   for (let i = 0, vlen = targetVars.length; i < vlen; i++) {
     let propagatorIndexes = varToPropagators[targetVars[i]];
     // note: the first loop of propagate() should require all propagators affected, even if

--- a/src/space.js
+++ b/src/space.js
@@ -17,7 +17,6 @@ import {
 import {
   front_addNode,
   front_addCell,
-  front_getCell,
   _front_getCell,
   front_getSizeOf,
   _front_getSizeOf,
@@ -192,43 +191,23 @@ function space_getUnsolvedVarCount(space, config) {
   return front_getSizeOf(config._front, space.frontNodeIndex);
 }
 /**
- * Return the index of the nth unsolved var in given node
- * You are responsible for making sure that node is still relevant
- * This is only used for testing, prevents leaking internals into tests
- *
- * @param {$space} space
- * @param {number} nodeIndex The node (offset of the list) to access
- * @param {number} cellIndex The cell offset relative to the node to return
- * @returns {number}
- */
-function space_getUnsolvedVarAt(space, nodeIndex, cellIndex) {
-  return front_getCell(space.config._front, nodeIndex, cellIndex);
-}
-/**
- * Return the index of the nth unsolved var in the node of this space
- * Only reliable if this space is the current active one
- * This is only used for testing, prevents leaking internals into tests
- *
- * @param {$space} space
- * @param {number} cellIndex The cell offset relative to the space's node to return
- * @returns {number}
- */
-function space_getUnsolvedIndex(space, cellIndex) {
-  return front_getCell(space.config._front, space.frontNodeIndex, cellIndex);
-}
-/**
  * Only use this for testing or debugging as it creates a fresh array
  * for the result. We don't use the names internally, anyways.
  *
  * @param {$space} space
+ * @param {$config} config
  * @returns {string[]} var names of all unsolved vars of given space
  */
-function _space_getUnsolvedVarNamesFresh(space) {
+function _space_getUnsolvedVarNamesFresh(space, config) {
+  ASSERT(space._class === '$space', 'EXPECTING_SPACE');
+  ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
+  ASSERT(space.config === config);
+
   let nodeIndex = space.frontNodeIndex;
   // fugly! :)
-  let buf = space.config._front.buffer;
+  let buf = config._front.buffer;
   let sub = [].slice.call(buf, nodeIndex + 1, nodeIndex + 1 + buf[nodeIndex]); // or .subArray() or something like that... or even toArray?
-  return sub.map(index => space.config.all_var_names[index]);
+  return sub.map(index => config.all_var_names[index]);
 }
 
 /**
@@ -537,8 +516,6 @@ export {
   space_createRoot,
   space_getDomainArr,
   space_getUnsolvedVarCount,
-  space_getUnsolvedVarAt,
-  space_getUnsolvedIndex,
   _space_getUnsolvedVarNamesFresh,
   space_getVarSolveState,
   space_initFromConfig,

--- a/src/space.js
+++ b/src/space.js
@@ -68,7 +68,7 @@ function space_createFromConfig(config) {
   ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
 
   let space = space_createRoot(config);
-  space_initFromConfig(space);
+  space_initFromConfig(space, config);
   return space;
 }
 
@@ -163,11 +163,12 @@ function space_createNew(config, vardoms, frontNodeIndex, _depth, _child, _path)
 
 /**
  * @param {$space} space
+ * @param {$config} config
  */
-function space_initFromConfig(space) {
-  let config = space.config;
-  ASSERT(config, 'should have a config');
-  ASSERT(config._class === '$config', 'should be a config');
+function space_initFromConfig(space, config) {
+  ASSERT(space._class === '$space', 'EXPECTING_SPACE');
+  ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
+  ASSERT(space.config === config);
 
   config_initForSpace(config, space);
   initializeUnsolvedVars(space, config);

--- a/src/space.js
+++ b/src/space.js
@@ -288,7 +288,7 @@ function space_propagate(space, config) {
     }
   }
 
-  if (space_abortSearch(space)) {
+  if (space_abortSearch(space, config)) {
     config._propagationCycles = cycles;
     return true;
   }
@@ -302,7 +302,7 @@ function space_propagate(space, config) {
       break;
     }
 
-    if (space_abortSearch(space)) {
+    if (space_abortSearch(space, config)) {
       returnValue = true;
       break;
     }
@@ -406,10 +406,14 @@ function space_propagateChanges(space, config, allPropagators, minimal, targetVa
 
 /**
  * @param {$space} space
+ * @param {$config} config
  * @returns {boolean}
  */
-function space_abortSearch(space) {
-  ASSERT(space._class === '$space', 'SPACE_SHOULD_BE_SPACE');
+function space_abortSearch(space, config) {
+  ASSERT(space._class === '$space', 'EXPECTING_SPACE');
+  ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
+  ASSERT(space.config === config);
+
   let callback = space.config.timeout_callback;
   if (callback) {
     return callback(space);

--- a/src/space.js
+++ b/src/space.js
@@ -76,10 +76,13 @@ function space_createFromConfig(config) {
  * Create a space node that is a child of given space node
  *
  * @param {$space} space
+ * @param {$config} config
  * @returns {$space}
  */
-function space_createClone(space) {
+function space_createClone(space, config) {
   ASSERT(space._class === '$space', 'SPACE_SHOULD_BE_SPACE');
+  ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
+  ASSERT(space.config === config);
 
   let vardomsCopy = space.vardoms.slice(0);
   let frontNodeIndex = space.frontNodeIndex;
@@ -93,7 +96,7 @@ function space_createClone(space) {
   ASSERT(!void (_child = space._child_count++));
   ASSERT(!void (_path = space._path));
 
-  return space_createNew(space.config, vardomsCopy, frontNodeIndex, _depth, _child, _path);
+  return space_createNew(config, vardomsCopy, frontNodeIndex, _depth, _child, _path);
 }
 
 /**

--- a/src/space.js
+++ b/src/space.js
@@ -104,20 +104,23 @@ function space_createClone(space, config) {
  * Basically clones its config but updates the `initial_domains` with fresh state
  *
  * @param {$space} space
+ * @param {$config} config
  * @returns {$space}
  */
-function space_toConfig(space) {
+function space_toConfig(space, config) {
   ASSERT(space._class === '$space', 'SPACE_SHOULD_BE_SPACE');
+  ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
+  ASSERT(space.config === config);
 
   let vardoms = space.vardoms;
   let newDomains = [];
-  let names = space.config.all_var_names;
+  let names = config.all_var_names;
   for (let i = 0, n = names.length; i < n; i++) {
     let domain = vardoms[i];
     newDomains[i] = domain_any_clone(domain, FORCE_STRING);
   }
 
-  return config_clone(space.config, newDomains);
+  return config_clone(config, newDomains);
 }
 
 /**

--- a/src/space.js
+++ b/src/space.js
@@ -238,7 +238,7 @@ function initializeUnsolvedVars(space, config) {
       }
     }
   } else {
-    let varNamesTrie = space.config._var_names_trie;
+    let varNamesTrie = config._var_names_trie;
     for (let i = 0, n = targetVarNames.length; i < n; ++i) {
       let varName = targetVarNames[i];
       let varIndex = trie_get(varNamesTrie, varName);
@@ -414,7 +414,7 @@ function space_abortSearch(space, config) {
   ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
   ASSERT(space.config === config);
 
-  let callback = space.config.timeout_callback;
+  let callback = config.timeout_callback;
   if (callback) {
     return callback(space);
   }
@@ -443,7 +443,7 @@ function space_updateUnsolvedVarList(space, config) {
 
   let vardoms = space.vardoms;
 
-  let unsolvedFront = space.config._front;
+  let unsolvedFront = config._front;
   let lastNodeIndex = unsolvedFront.lastNodeIndex;
   let nodeIndex = front_addNode(unsolvedFront);
   space.frontNodeIndex = nodeIndex;
@@ -512,8 +512,12 @@ function space_getDomainArr(space, varIndex) {
   return domain_toArr(space.vardoms[varIndex]);
 }
 
-
-function _space_debug(space, printPath) {
+/**
+ * @param {$space} space
+ * @param {$config} [config]
+ * @param {boolean} [printPath]
+ */
+function _space_debug(space, config, printPath) {
   console.log('\n## Space:');
   //__REMOVE_BELOW_FOR_ASSERTS__
   console.log('# Meta:');
@@ -524,7 +528,7 @@ function _space_debug(space, printPath) {
   if (printPath) console.log('path:', space._path);
   //__REMOVE_ABOVE_FOR_ASSERTS__
   console.log('# Domains:');
-  console.log(space.vardoms.map(domain_toArr).map((d, i) => (d + '').padEnd(15, ' ') + (space.config.all_var_names[i] === String(i) ? '' : ' (' + space.config.all_var_names[i] + ')')).join('\n'));
+  console.log(space.vardoms.map(domain_toArr).map((d, i) => (d + '').padEnd(15, ' ') + ((!config || config.all_var_names[i] === String(i)) ? '' : ' (' + config.all_var_names[i] + ')')).join('\n'));
   console.log('##\n');
 }
 

--- a/src/space.js
+++ b/src/space.js
@@ -469,11 +469,15 @@ function space_updateUnsolvedVarList(space, config) {
  * be already in a solved state for this to work.
  *
  * @param {$space} space
+ * @param {$config} config
  * @returns {Object}
  */
-function space_solution(space) {
-  ASSERT(space._class === '$space', 'SPACE_SHOULD_BE_SPACE');
-  let allVarNames = space.config.all_var_names;
+function space_solution(space, config) {
+  ASSERT(space._class === '$space', 'EXPECTING_SPACE');
+  ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
+  ASSERT(space.config === config);
+
+  let allVarNames = config.all_var_names;
   let result = {};
   for (let varIndex = 0, n = allVarNames.length; varIndex < n; varIndex++) {
     let varName = allVarNames[varIndex];

--- a/src/space.js
+++ b/src/space.js
@@ -351,7 +351,7 @@ function space_propagateStep(space, propagator, changedVars, changedTrie, cycleI
 
   let stepper = propagator.stepper;
   ASSERT(typeof stepper === 'function', 'stepper should be a func');
-  // TODO: if we can get a "solved" state here we can prevent an "is_solved" check later...
+  // TODO: if we can get a "solved" state here we can prevent an isSolved check later...
   stepper(space, index1, index2, index3, propagator.arg1, propagator.arg2, propagator.arg3, propagator.arg4, propagator.arg5, propagator.arg6);
 
   if (domain1 !== vardoms[index1]) {
@@ -427,11 +427,6 @@ function space_abortSearch(space) {
  * ranges for all variables under which all conditions
  * are met and there would be no further need to enumerate
  * those solutions.
- *
- * For weaker tests, use the solve_for_variables function
- * to create an appropriate "is_solved" tester and
- * set the "state.is_solved" field at search time to
- * that function.
  *
  * @param {$space} space
  * @returns {boolean}

--- a/src/space.js
+++ b/src/space.js
@@ -433,10 +433,14 @@ function space_abortSearch(space, config) {
  * those solutions.
  *
  * @param {$space} space
+ * @param {$config} config
  * @returns {boolean}
  */
-function space_updateUnsolvedVarList(space) {
-  ASSERT(space._class === '$space', 'SPACE_SHOULD_BE_SPACE');
+function space_updateUnsolvedVarList(space, config) {
+  ASSERT(space._class === '$space', 'EXPECTING_SPACE');
+  ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
+  ASSERT(space.config === config);
+
   let vardoms = space.vardoms;
 
   let unsolvedFront = space.config._front;

--- a/src/space.js
+++ b/src/space.js
@@ -281,7 +281,7 @@ function space_propagate(space, config) {
     changedVars.push(space.updatedVarIndex);
   } else {
     // very first cycle of first epoch of the search. all propagators must be visited at least once now.
-    let rejected = space_propagateAll(space, propagators, changedVars, changedTrie, ++cycles);
+    let rejected = space_propagateAll(space, config, propagators, changedVars, changedTrie, ++cycles);
     if (rejected) {
       config._propagationCycles = cycles;
       return true;
@@ -315,24 +315,24 @@ function space_propagate(space, config) {
   return returnValue;
 }
 
-function space_propagateAll(space, propagators, changedVars, changedTrie, cycleIndex) {
+function space_propagateAll(space, config, propagators, changedVars, changedTrie, cycleIndex) {
   for (let i = 0, n = propagators.length; i < n; i++) {
     let propagator = propagators[i];
-    let rejected = space_propagateStep(space, propagator, changedVars, changedTrie, cycleIndex);
+    let rejected = space_propagateStep(space, config, propagator, changedVars, changedTrie, cycleIndex);
     if (rejected) return true;
   }
   return false;
 }
-function space_propagateByIndexes(space, propagators, propagatorIndexes, changedVars, changedTrie, cycleIndex) {
+function space_propagateByIndexes(space, config, propagators, propagatorIndexes, changedVars, changedTrie, cycleIndex) {
   for (let i = 0, n = propagatorIndexes.length; i < n; i++) {
     let propagatorIndex = propagatorIndexes[i];
     let propagator = propagators[propagatorIndex];
-    let rejected = space_propagateStep(space, propagator, changedVars, changedTrie, cycleIndex);
+    let rejected = space_propagateStep(space, config, propagator, changedVars, changedTrie, cycleIndex);
     if (rejected) return true;
   }
   return false;
 }
-function space_propagateStep(space, propagator, changedVars, changedTrie, cycleIndex) {
+function space_propagateStep(space, config, propagator, changedVars, changedTrie, cycleIndex) {
   ASSERT(propagator._class === '$propagator', 'EXPECTING_PROPAGATOR');
 
   let vardoms = space.vardoms;
@@ -348,7 +348,7 @@ function space_propagateStep(space, propagator, changedVars, changedTrie, cycleI
   let stepper = propagator.stepper;
   ASSERT(typeof stepper === 'function', 'stepper should be a func');
   // TODO: if we can get a "solved" state here we can prevent an isSolved check later...
-  stepper(space, index1, index2, index3, propagator.arg1, propagator.arg2, propagator.arg3, propagator.arg4, propagator.arg5, propagator.arg6);
+  stepper(space, config, index1, index2, index3, propagator.arg1, propagator.arg2, propagator.arg3, propagator.arg4, propagator.arg5, propagator.arg6);
 
   if (domain1 !== vardoms[index1]) {
     if (vardoms[index1] === EMPTY) return true; // fail
@@ -397,7 +397,7 @@ function space_propagateChanges(space, config, allPropagators, minimal, targetVa
     // ultimately a list of propagators should perform better but the indexOf negates that perf
     // (this doesn't affect a whole lot of vars... most of them touch multiple propas)
     if (propagatorIndexes && propagatorIndexes.length >= minimal) {
-      let result = space_propagateByIndexes(space, allPropagators, propagatorIndexes, changedVars, changedTrie, cycleIndex);
+      let result = space_propagateByIndexes(space, config, allPropagators, propagatorIndexes, changedVars, changedTrie, cycleIndex);
       if (result) return true; // rejected
     }
   }

--- a/src/space.js
+++ b/src/space.js
@@ -218,6 +218,8 @@ function _space_getUnsolvedVarNamesFresh(space, config) {
  * @param {$config} config (=space.config)
  */
 function initializeUnsolvedVars(space, config) {
+  ASSERT(space._class === '$space', 'EXPECTING_SPACE');
+  ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
   ASSERT(space.config === config);
 
   let targetVarNames = config.targetedVars;
@@ -255,11 +257,14 @@ function initializeUnsolvedVars(space, config) {
  * Returns true if any propagator rejects.
  *
  * @param {$space} space
+ * @param {$config} config (=space.config)
  * @returns {boolean} when true, a propagator rejects and the (current path to a) solution is invalid
  */
-function space_propagate(space) {
-  ASSERT(space._class === '$space', 'SPACE_SHOULD_BE_SPACE');
-  let config = space.config;
+function space_propagate(space, config) {
+  ASSERT(space._class === '$space', 'EXPECTING_SPACE');
+  ASSERT(config._class === '$config', 'EXPECTING_CONFIG');
+  ASSERT(space.config === config);
+
   let propagators = config._propagators;
 
   // "cycle" is one step, "epoch" all steps until stable (but not solved per se)

--- a/tests/perf/curator/config.js
+++ b/tests/perf/curator/config.js
@@ -9,13 +9,13 @@
  - press start
  - wait until the spinner spins again (can take a while...), reduce the max to make this go faster
 
- @ console.log('starting now...');
- @ var exports = {};
- @ var module = {exports: {}};
- + http://localhost/path/to/finitedomain/dist/browser.js
- - http://localhost/path/to/finitedomain/tests/perf/gridsolver/config.js
- - http://localhost/path/to/finitedomain/tests/perf/perf.js
- @ perf(config, 1);
+@ console.log('starting now...');
+@ var exports = {};
+@ var module = {exports: {}};
++ http://localhost/path/to/finitedomain/dist/browser.js
+- http://localhost/path/to/finitedomain/tests/perf/curator/config.js
+- http://localhost/path/to/finitedomain/tests/perf/perf.js
+@ perf(config, 1);
 
  */
 

--- a/tests/perf/curator/perf.html
+++ b/tests/perf/curator/perf.html
@@ -6,6 +6,17 @@
   Note that multiple solutions doesn't mean running from scratch. Solutions beyond the first build on the first solution.<br>
   Run <code>grunt distperf</code> for a perf build. You can also run <code>grunt distbug</code> for debugging.<br>
 
+  <a href="https://github.com/qfox/heatfiler">Heatfiler</a> instructions (assumes heatfiler runs on same domain as finitedomain files, just clone it):
+  <pre>
+@ console.log('starting now...');
+@ var exports = {};
+@ var module = {exports: {}};
++ http://localhost/path/to/finitedomain/dist/browser.js
+- http://localhost/path/to/finitedomain/tests/perf/curator/config.js
+- http://localhost/path/to/finitedomain/tests/perf/perf.js
+@ perf(config, 1);
+  </pre>
+
   <script>var exports= {};</script>
   <script>var module = {exports: {}};</script>
   <script src="config.js"></script>

--- a/tests/perf/perf.js
+++ b/tests/perf/perf.js
@@ -35,4 +35,4 @@ var perf = module.exports = function perf(config, max, _waited) {
   solver.solve({log: 1, max: max, vars: solver.config.all_var_names});
   if (typeof location === 'object' && location.href.indexOf('perf=0') < 0) console.profileEnd && console.profileEnd('gridsolving');
   console.timeEnd('test runtime');
-}
+};

--- a/tests/specs/config.spec.js
+++ b/tests/specs/config.spec.js
@@ -60,7 +60,7 @@ describe('src/config.spec', function() {
 
     it('should require config and space', function() {
       let config = config_create();
-      let space = space_createRoot(config);
+      let space = space_createRoot();
 
       expect(_ => config_generateVars({}, space)).to.throw('EXPECTING_CONFIG');
       expect(_ => config_generateVars(config, {})).to.throw('SPACE_SHOULD_BE_SPACE');
@@ -69,7 +69,7 @@ describe('src/config.spec', function() {
     it('should create a constant', function() {
       let config = config_create();
       let name = config_addVarAnonConstant(config, 10);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
 
       config_generateVars(config, space);
 
@@ -79,7 +79,7 @@ describe('src/config.spec', function() {
     it('should create a full width var', function() {
       let config = config_create();
       let name = config_addVarAnonNothing(config);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
 
       config_generateVars(config, space);
 
@@ -89,7 +89,7 @@ describe('src/config.spec', function() {
     it('should clone a domained var', function() {
       let config = config_create();
       let name = config_addVarAnonRange(config, 32, 55);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
 
       config_generateVars(config, space);
 

--- a/tests/specs/distribution/value.spec.js
+++ b/tests/specs/distribution/value.spec.js
@@ -47,7 +47,7 @@ describe('distribution/value.spec', function() {
 
   it('should throw for unknown name', function() {
     let config = config_create();
-    let space = space_createRoot(config);
+    let space = space_createRoot();
     expect(_ => _distribute_getNextDomainForVar('error', space, config)).to.throw('unknown next var func');
   });
 
@@ -55,7 +55,7 @@ describe('distribution/value.spec', function() {
 
     it('should throw', function() {
       let config = config_create();
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       expect(_ => _distribute_getNextDomainForVar('throw', space, config)).to.throw('not expecting to pick this distributor');
     });
   });
@@ -65,7 +65,7 @@ describe('distribution/value.spec', function() {
     it('should work', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 0, 0);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
 
@@ -86,7 +86,7 @@ describe('distribution/value.spec', function() {
       it('should pick lo for FIRST_CHOICE ', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -97,7 +97,7 @@ describe('distribution/value.spec', function() {
       it('should pick hi for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -108,7 +108,7 @@ describe('distribution/value.spec', function() {
       it('should return NO_CHOICE for THIRD_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -119,7 +119,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for FIRST_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 111], [113, 120]));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -129,7 +129,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 111], [113, 120]));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         let A = config.all_var_names.indexOf('A');
@@ -139,7 +139,7 @@ describe('distribution/value.spec', function() {
       it('should reject a "solved" var', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 110);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -152,7 +152,7 @@ describe('distribution/value.spec', function() {
       it('should reject a "rejected" var', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
@@ -169,7 +169,7 @@ describe('distribution/value.spec', function() {
       it('should pick lo for FIRST_CHOICE ', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 1, 2);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -180,7 +180,7 @@ describe('distribution/value.spec', function() {
       it('should pick hi for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 1, 2);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -191,7 +191,7 @@ describe('distribution/value.spec', function() {
       it('should return NO_CHOICE for THIRD_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 1, 2);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -202,7 +202,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for FIRST_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(10, 11, 13, 14, 15));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -212,7 +212,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(10, 11, 13, 14, 15));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -222,7 +222,7 @@ describe('distribution/value.spec', function() {
       it('should reject a "solved" var', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(10));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -235,7 +235,7 @@ describe('distribution/value.spec', function() {
       it('should reject a "rejected" var', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
@@ -259,7 +259,7 @@ describe('distribution/value.spec', function() {
       it('should pick lo for FIRST_CHOICE ', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -270,7 +270,7 @@ describe('distribution/value.spec', function() {
       it('should pick hi for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -281,7 +281,7 @@ describe('distribution/value.spec', function() {
       it('should return NO_CHOICE for THIRD_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -292,7 +292,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for FIRST_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 117], [119, 120]));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -302,7 +302,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 117], [119, 120]));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -312,7 +312,7 @@ describe('distribution/value.spec', function() {
       it('should reject a "solved" var', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_value(120));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -325,7 +325,7 @@ describe('distribution/value.spec', function() {
       it('should reject a "rejected" var', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
@@ -342,7 +342,7 @@ describe('distribution/value.spec', function() {
       it('should pick lo for FIRST_CHOICE ', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -353,7 +353,7 @@ describe('distribution/value.spec', function() {
       it('should pick hi for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -364,7 +364,7 @@ describe('distribution/value.spec', function() {
       it('should return NO_CHOICE for third choice', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -375,7 +375,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for FIRST_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(2, 3, 4, 6, 7, 8, 10, 11));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -385,7 +385,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(2, 3, 4, 6, 7, 8, 10, 11));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -395,7 +395,7 @@ describe('distribution/value.spec', function() {
       it('should reject a "solved" var', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -408,7 +408,7 @@ describe('distribution/value.spec', function() {
       it('should reject a "rejected" var', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
@@ -436,7 +436,7 @@ describe('distribution/value.spec', function() {
         it('should pick hi for FIRST_CHOICE ', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 102);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -447,7 +447,7 @@ describe('distribution/value.spec', function() {
         it('should pick hi for SECOND_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 102);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -458,7 +458,7 @@ describe('distribution/value.spec', function() {
         it('should return NO_CHOICE for THIRD_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 102);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -472,7 +472,7 @@ describe('distribution/value.spec', function() {
         it('should pick mid for FIRST_CHOICE ', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 103);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -483,7 +483,7 @@ describe('distribution/value.spec', function() {
         it('should remove mid for SECOND_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 103);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -494,7 +494,7 @@ describe('distribution/value.spec', function() {
         it('should return NO_CHOICE for THIRD_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 103);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -508,7 +508,7 @@ describe('distribution/value.spec', function() {
         it('should pick low-mid for FIRST_CHOICE ', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 104);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -519,7 +519,7 @@ describe('distribution/value.spec', function() {
         it('should remove mid for SECOND_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 104);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -530,7 +530,7 @@ describe('distribution/value.spec', function() {
         it('should return NO_CHOICE for THIRD_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 104);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -544,7 +544,7 @@ describe('distribution/value.spec', function() {
         it('should pick mid for FIRST_CHOICE ', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 120);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -555,7 +555,7 @@ describe('distribution/value.spec', function() {
         it('should remove mid for SECOND_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 120);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -566,7 +566,7 @@ describe('distribution/value.spec', function() {
         it('should return NO_CHOICE for THIRD_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 120);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -580,7 +580,7 @@ describe('distribution/value.spec', function() {
         it('should pick hi-mid for FIRST_CHOICE ', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 121);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -591,7 +591,7 @@ describe('distribution/value.spec', function() {
         it('should remove mid for SECOND_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 121);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -602,7 +602,7 @@ describe('distribution/value.spec', function() {
         it('should return NO_CHOICE for THIRD_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 121);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -614,7 +614,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for FIRST_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 112], [118, 120]));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -624,7 +624,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 112], [118, 120]));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -634,7 +634,7 @@ describe('distribution/value.spec', function() {
       it('should reject a "solved" var', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_value(120));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -647,7 +647,7 @@ describe('distribution/value.spec', function() {
       it('should reject a "rejected" var', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
@@ -666,7 +666,7 @@ describe('distribution/value.spec', function() {
         it('should pick hi for FIRST_CHOICE ', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 1, 2);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -677,7 +677,7 @@ describe('distribution/value.spec', function() {
         it('should pick hi for SECOND_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 1, 2);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -688,7 +688,7 @@ describe('distribution/value.spec', function() {
         it('should return NO_CHOICE for THIRD_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 1, 2);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -702,7 +702,7 @@ describe('distribution/value.spec', function() {
         it('should pick mid for FIRST_CHOICE ', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3));
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -713,7 +713,7 @@ describe('distribution/value.spec', function() {
         it('should remove mid for SECOND_CHOICE', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3));
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -724,7 +724,7 @@ describe('distribution/value.spec', function() {
         it('should return NO_CHOICE for THIRD_CHOICE', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3));
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -738,7 +738,7 @@ describe('distribution/value.spec', function() {
         it('should pick low-mid for FIRST_CHOICE ', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3, 4));
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -749,7 +749,7 @@ describe('distribution/value.spec', function() {
         it('should remove mid for SECOND_CHOICE', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3, 4));
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -760,7 +760,7 @@ describe('distribution/value.spec', function() {
         it('should return NO_CHOICE for THIRD_CHOICE', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3, 4));
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -774,7 +774,7 @@ describe('distribution/value.spec', function() {
         it('should pick mid for FIRST_CHOICE ', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 10);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -785,7 +785,7 @@ describe('distribution/value.spec', function() {
         it('should remove mid for SECOND_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 10);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -796,7 +796,7 @@ describe('distribution/value.spec', function() {
         it('should return NO_CHOICE for THIRD_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 10);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -810,7 +810,7 @@ describe('distribution/value.spec', function() {
         it('should pick hi-mid for FIRST_CHOICE ', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 11);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -821,7 +821,7 @@ describe('distribution/value.spec', function() {
         it('should remove mid for SECOND_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 11);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -832,7 +832,7 @@ describe('distribution/value.spec', function() {
         it('should return NO_CHOICE for THIRD_CHOICE', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 11);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -844,7 +844,7 @@ describe('distribution/value.spec', function() {
       it('should pick lo for FIRST_CHOICE ', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 1);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -855,7 +855,7 @@ describe('distribution/value.spec', function() {
       it('should pick hi for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 1);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -866,7 +866,7 @@ describe('distribution/value.spec', function() {
       it('should return NO_CHOICE for THIRD_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 1);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -877,7 +877,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for FIRST_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 2, 8, 9, 10));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -887,7 +887,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 2, 8, 9, 10));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -898,7 +898,7 @@ describe('distribution/value.spec', function() {
         // note: only rejects with ASSERTs
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(5));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -912,7 +912,7 @@ describe('distribution/value.spec', function() {
         // note: only rejects with ASSERTs
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
@@ -933,7 +933,7 @@ describe('distribution/value.spec', function() {
     it('should throw if choice is not a number', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 110, 120);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
 
@@ -945,7 +945,7 @@ describe('distribution/value.spec', function() {
       it('should pick lower half for FIRST_CHOICE ', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -956,7 +956,7 @@ describe('distribution/value.spec', function() {
       it('should pick upper half for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -967,7 +967,7 @@ describe('distribution/value.spec', function() {
       it('should return NO_CHOICE for THIRD_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -978,7 +978,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for FIRST_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([100, 101], [108, 112], [118, 120]));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -988,7 +988,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([100, 101], [108, 112], [118, 120]));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1000,7 +1000,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 102);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1012,7 +1012,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 103);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1024,7 +1024,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 104);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1038,7 +1038,7 @@ describe('distribution/value.spec', function() {
         // note: only rejects with ASSERTs
         let config = config_create();
         config_addVarRange(config, 'A', 120, 120);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1052,7 +1052,7 @@ describe('distribution/value.spec', function() {
         // note: only rejects with ASSERTs
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
@@ -1068,7 +1068,7 @@ describe('distribution/value.spec', function() {
       it('should pick lower half for FIRST_CHOICE ', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1079,7 +1079,7 @@ describe('distribution/value.spec', function() {
       it('should pick upper half for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1090,7 +1090,7 @@ describe('distribution/value.spec', function() {
       it('should return NO_CHOICE for THIRD_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1101,7 +1101,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for FIRST_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 5, 6, 7, 8, 11, 12, 14));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1111,7 +1111,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 5, 6, 7, 8, 11, 12, 14));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1123,7 +1123,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 1, 2);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1135,7 +1135,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3));
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1147,7 +1147,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3, 4));
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1161,7 +1161,7 @@ describe('distribution/value.spec', function() {
         // note: only rejects with ASSERTs
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(5, 5));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1175,7 +1175,7 @@ describe('distribution/value.spec', function() {
         // note: only rejects with ASSERTs
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
@@ -1196,7 +1196,7 @@ describe('distribution/value.spec', function() {
     it('should throw if choice is not a number', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 110, 120);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
 
@@ -1208,7 +1208,7 @@ describe('distribution/value.spec', function() {
       it('should pick lower half for FIRST_CHOICE ', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1219,7 +1219,7 @@ describe('distribution/value.spec', function() {
       it('should pick upper half for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1230,7 +1230,7 @@ describe('distribution/value.spec', function() {
       it('should return NO_CHOICE for THIRD_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1241,7 +1241,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for FIRST_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([100, 101], [108, 112], [118, 120]));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1251,7 +1251,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([100, 101], [108, 112], [118, 120]));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1263,7 +1263,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 102);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1275,7 +1275,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 103);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1287,7 +1287,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 104);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1301,7 +1301,7 @@ describe('distribution/value.spec', function() {
         // note: only rejects with ASSERTs
         let config = config_create();
         config_addVarRange(config, 'A', 120, 120);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1315,7 +1315,7 @@ describe('distribution/value.spec', function() {
         // note: only rejects with ASSERTs
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
@@ -1331,7 +1331,7 @@ describe('distribution/value.spec', function() {
       it('should pick lower half for FIRST_CHOICE ', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1342,7 +1342,7 @@ describe('distribution/value.spec', function() {
       it('should pick upper half for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1353,7 +1353,7 @@ describe('distribution/value.spec', function() {
       it('should return NO_CHOICE for THIRD_CHOICE', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1364,7 +1364,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for FIRST_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 5, 6, 7, 8, 11, 12, 14));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1374,7 +1374,7 @@ describe('distribution/value.spec', function() {
       it('should intersect and not use lower range blindly for SECOND_CHOICE', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 5, 6, 7, 8, 11, 12, 14));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1386,7 +1386,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 1, 2);
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1398,7 +1398,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3));
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1410,7 +1410,7 @@ describe('distribution/value.spec', function() {
         it('should work with two values in one range', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3, 4));
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
@@ -1424,7 +1424,7 @@ describe('distribution/value.spec', function() {
         // note: only rejects with ASSERTs
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(5, 5));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
@@ -1438,7 +1438,7 @@ describe('distribution/value.spec', function() {
         // note: only rejects with ASSERTs
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();

--- a/tests/specs/distribution/value.spec.js
+++ b/tests/specs/distribution/value.spec.js
@@ -62,7 +62,7 @@ describe('distribution/value.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 0, 0);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
 
       let dom = _distribute_getNextDomainForVar('naive', space, A);
@@ -83,7 +83,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMin(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_value(101));
@@ -94,7 +94,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMin(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_value(102));
@@ -105,7 +105,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMin(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -116,7 +116,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 111], [113, 120]));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMin(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_value(110));
@@ -126,7 +126,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 111], [113, 120]));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         let A = config.all_var_names.indexOf('A');
         expect(distribution_valueByMin(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_ranges([111, 111], [113, 120]));
@@ -136,7 +136,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 110);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         // note: only rejects with ASSERTs
@@ -149,7 +149,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
 
@@ -166,7 +166,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 1, 2);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMin(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(1));
@@ -177,7 +177,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 1, 2);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMin(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(2));
@@ -188,7 +188,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 1, 2);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMin(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -199,7 +199,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(10, 11, 13, 14, 15));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMin(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(10));
@@ -209,7 +209,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(10, 11, 13, 14, 15));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMin(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(11, 13, 14, 15));
@@ -219,7 +219,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(10));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         // note: only rejects with ASSERTs
@@ -232,7 +232,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
 
@@ -256,7 +256,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMax(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(102, 102));
@@ -267,7 +267,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMax(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_range(101, 101));
@@ -278,7 +278,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 101, 102);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMax(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -289,7 +289,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 117], [119, 120]));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMax(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_value(120));
@@ -299,7 +299,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 117], [119, 120]));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMax(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_ranges([110, 117], [119, 119]));
@@ -309,7 +309,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_value(120));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         // note: only rejects with ASSERTs
@@ -322,7 +322,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
 
@@ -339,7 +339,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMax(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(10));
@@ -350,7 +350,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMax(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_range(6, 9));
@@ -361,7 +361,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMax(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -372,7 +372,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(2, 3, 4, 6, 7, 8, 10, 11));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMax(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(11));
@@ -382,7 +382,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(2, 3, 4, 6, 7, 8, 10, 11));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMax(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(2, 3, 4, 6, 7, 8, 10));
@@ -392,7 +392,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         // note: only rejects with ASSERTs
@@ -405,7 +405,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
 
@@ -433,7 +433,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 102);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(102, 102));
@@ -444,7 +444,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 102);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_range(101, 101));
@@ -455,7 +455,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 102);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -469,7 +469,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 103);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(102, 102));
@@ -480,7 +480,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 103);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_ranges([101, 101], [103, 103]));
@@ -491,7 +491,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 103);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -505,7 +505,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 104);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(103, 103));
@@ -516,7 +516,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 104);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_ranges([101, 102], [104, 104]));
@@ -527,7 +527,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 104);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -541,7 +541,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 120);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(110, 110));
@@ -552,7 +552,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 120);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_ranges([100, 109], [111, 120]));
@@ -563,7 +563,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 120);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -577,7 +577,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 121);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(111, 111));
@@ -588,7 +588,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 121);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_ranges([100, 110], [112, 121]));
@@ -599,7 +599,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 100, 121);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -611,7 +611,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 112], [118, 120]));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_value(118));
@@ -621,7 +621,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([110, 112], [118, 120]));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_ranges([110, 112], [119, 120]));
@@ -631,7 +631,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_value(120));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         // note: only rejects with ASSERTs
@@ -644,7 +644,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
 
@@ -663,7 +663,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 1, 2);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(2));
@@ -674,7 +674,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 1, 2);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(1));
@@ -685,7 +685,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 1, 2);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -699,7 +699,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3));
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(2));
@@ -710,7 +710,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3));
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(1, 3));
@@ -721,7 +721,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3));
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -735,7 +735,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3, 4));
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(3));
@@ -746,7 +746,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3, 4));
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(1, 2, 4));
@@ -757,7 +757,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3, 4));
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -771,7 +771,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 10);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(5));
@@ -782,7 +782,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 10);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(0, 1, 2, 3, 4, 6, 7, 8, 9, 10));
@@ -793,7 +793,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 10);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -807,7 +807,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 11);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(6));
@@ -818,7 +818,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 11);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11));
@@ -829,7 +829,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 0, 11);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueByMid(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -841,7 +841,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 1);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(1));
@@ -852,7 +852,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 1);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(0));
@@ -863,7 +863,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 1);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMid(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -874,7 +874,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 2, 8, 9, 10));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMid(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(8));
@@ -884,7 +884,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 2, 8, 9, 10));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueByMid(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(0, 1, 2, 9, 10));
@@ -895,7 +895,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(5));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(() => distribution_valueByMid(space, A, FIRST_CHOICE)).to.throw('DOMAIN_SHOULD_BE_UNDETERMINED');
@@ -909,7 +909,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
 
@@ -930,7 +930,7 @@ describe('distribution/value.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 110, 120);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
 
       expect(_ => distribution_valueBySplitMin(space, A, undefined)).to.throw('CHOICE_SHOULD_BE_NUMBER');
@@ -942,7 +942,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(110, 115));
@@ -953,7 +953,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMin(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_range(116, 120));
@@ -964,7 +964,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMin(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -975,7 +975,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([100, 101], [108, 112], [118, 120]));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_ranges([100, 101], [108, 110]));
@@ -985,7 +985,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([100, 101], [108, 112], [118, 120]));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMin(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_ranges([111, 112], [118, 120]));
@@ -997,7 +997,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 102);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(101, 101));
@@ -1009,7 +1009,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 103);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(101, 102));
@@ -1021,7 +1021,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 104);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(101, 102));
@@ -1035,7 +1035,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 120, 120);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(() => distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.throw('DOMAIN_SHOULD_BE_UNDETERMINED');
@@ -1049,7 +1049,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
 
@@ -1065,7 +1065,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(6, 7, 8));
@@ -1076,7 +1076,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMin(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(9, 10));
@@ -1087,7 +1087,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMin(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -1098,7 +1098,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 5, 6, 7, 8, 11, 12, 14));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(0, 1, 5, 6, 7));
@@ -1108,7 +1108,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 5, 6, 7, 8, 11, 12, 14));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMin(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(8, 11, 12, 14));
@@ -1120,7 +1120,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 1, 2);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(1));
@@ -1132,7 +1132,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3));
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(1, 2));
@@ -1144,7 +1144,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3, 4));
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(1, 2));
@@ -1158,7 +1158,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(5, 5));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(() => distribution_valueBySplitMin(space, A, FIRST_CHOICE)).to.throw('DOMAIN_SHOULD_BE_UNDETERMINED');
@@ -1172,7 +1172,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
 
@@ -1193,7 +1193,7 @@ describe('distribution/value.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 110, 120);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
 
       expect(_ => distribution_valueBySplitMax(space, A, undefined)).to.throw('CHOICE_SHOULD_BE_NUMBER');
@@ -1205,7 +1205,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(116, 120));
@@ -1216,7 +1216,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMax(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_range(110, 115));
@@ -1227,7 +1227,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 110, 120);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMax(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -1238,7 +1238,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([100, 101], [108, 112], [118, 120]));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_ranges([111, 112], [118, 120]));
@@ -1248,7 +1248,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_ranges([100, 101], [108, 112], [118, 120]));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMax(space, A, SECOND_CHOICE)).to.eql(fixt_strdom_ranges([100, 101], [108, 110]));
@@ -1260,7 +1260,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 102);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(102, 102));
@@ -1272,7 +1272,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 103);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(103, 103));
@@ -1284,7 +1284,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 101, 104);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.eql(fixt_strdom_range(103, 104));
@@ -1298,7 +1298,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 120, 120);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(() => distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.throw('DOMAIN_SHOULD_BE_UNDETERMINED');
@@ -1312,7 +1312,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
 
@@ -1328,7 +1328,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(9, 10));
@@ -1339,7 +1339,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMax(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(6, 7, 8));
@@ -1350,7 +1350,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 6, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMax(space, A, THIRD_CHOICE)).to.eql(NO_CHOICE);
@@ -1361,7 +1361,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 5, 6, 7, 8, 11, 12, 14));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(8, 11, 12, 14));
@@ -1371,7 +1371,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(0, 1, 5, 6, 7, 8, 11, 12, 14));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(distribution_valueBySplitMax(space, A, SECOND_CHOICE)).to.eql(fixt_numdom_nums(0, 1, 5, 6, 7));
@@ -1383,7 +1383,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarRange(config, 'A', 1, 2);
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(2));
@@ -1395,7 +1395,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3));
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(3));
@@ -1407,7 +1407,7 @@ describe('distribution/value.spec', function() {
           let config = config_create();
           config_addVarDomain(config, 'A', fixt_arrdom_nums(1, 2, 3, 4));
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
           let A = config.all_var_names.indexOf('A');
 
           expect(distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.eql(fixt_numdom_nums(3, 4));
@@ -1421,7 +1421,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(5, 5));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
 
         expect(() => distribution_valueBySplitMax(space, A, FIRST_CHOICE)).to.throw('DOMAIN_SHOULD_BE_UNDETERMINED');
@@ -1435,7 +1435,7 @@ describe('distribution/value.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(100));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         space.vardoms[A] = fixt_numdom_empty();
 

--- a/tests/specs/distribution/value.spec.js
+++ b/tests/specs/distribution/value.spec.js
@@ -69,7 +69,7 @@ describe('distribution/value.spec', function() {
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
 
-      let dom = _distribute_getNextDomainForVar('naive', space, space.config, A);
+      let dom = _distribute_getNextDomainForVar('naive', space, config, A);
 
       expect(dom).to.eql(fixt_numdom_nums(0));
     });

--- a/tests/specs/distribution/value.spec.js
+++ b/tests/specs/distribution/value.spec.js
@@ -46,13 +46,17 @@ describe('distribution/value.spec', function() {
   });
 
   it('should throw for unknown name', function() {
-    expect(_ => _distribute_getNextDomainForVar('error')).to.throw('unknown next var func');
+    let config = config_create();
+    let space = space_createRoot(config);
+    expect(_ => _distribute_getNextDomainForVar('error', space, config)).to.throw('unknown next var func');
   });
 
   describe('distribution_valueByThrow', function() {
 
     it('should throw', function() {
-      expect(_ => _distribute_getNextDomainForVar('throw')).to.throw('not expecting to pick this distributor');
+      let config = config_create();
+      let space = space_createRoot(config);
+      expect(_ => _distribute_getNextDomainForVar('throw', space, config)).to.throw('not expecting to pick this distributor');
     });
   });
 
@@ -65,7 +69,7 @@ describe('distribution/value.spec', function() {
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
 
-      let dom = _distribute_getNextDomainForVar('naive', space, A);
+      let dom = _distribute_getNextDomainForVar('naive', space, space.config, A);
 
       expect(dom).to.eql(fixt_numdom_nums(0));
     });

--- a/tests/specs/distribution/var.spec.js
+++ b/tests/specs/distribution/var.spec.js
@@ -75,7 +75,7 @@ describe('distribution/var.spec', function() {
         config_addVarDomain(config, 'A', fixt_arrdom_value(10, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -87,7 +87,7 @@ describe('distribution/var.spec', function() {
         config_addVarDomain(config, 'A', fixt_arrdom_value(11, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -99,7 +99,7 @@ describe('distribution/var.spec', function() {
         config_addVarDomain(config, 'A', fixt_arrdom_value(12, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -123,7 +123,7 @@ describe('distribution/var.spec', function() {
         config_addVarDomain(config, 'A', fixt_arrdom_value(12, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -135,7 +135,7 @@ describe('distribution/var.spec', function() {
         config_addVarDomain(config, 'A', fixt_arrdom_value(11, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -147,7 +147,7 @@ describe('distribution/var.spec', function() {
         config_addVarDomain(config, 'A', fixt_arrdom_value(10, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -172,7 +172,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 5, 5);
         config_addVarRange(config, 'B', 11, 12);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -184,7 +184,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 11, 11);
         config_addVarRange(config, 'B', 8, 8);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -196,7 +196,7 @@ describe('distribution/var.spec', function() {
         config_addVarDomain(config, 'A', fixt_arrdom_nums(11, 15, 16, 17, 18, 19));
         config_addVarDomain(config, 'B', fixt_arrdom_nums(8, 9, 10, 12, 13, 14));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -208,7 +208,7 @@ describe('distribution/var.spec', function() {
         config_addVarDomain(config, 'A', fixt_arrdom_nums(11, 13, 14, 18, 19));
         config_addVarDomain(config, 'B', fixt_arrdom_nums(8, 9, 10, 13, 14));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -220,7 +220,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 11, 12);
         config_addVarRange(config, 'B', 11, 11);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -295,7 +295,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'B', 11, 11);
         config_setOption(config, 'varStratOverride', {valtype: 'markov'}, 'A');
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -308,7 +308,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'B', 11, 11);
         config_setOption(config, 'varStratOverride', {valtype: 'markov'}, 'B');
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -322,7 +322,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'B', 11, 11);
         config_setOption(config, 'varStratOverride', {valtype: 'markov'}, 'B');
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -334,7 +334,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 11, 12);
         config_addVarRange(config, 'B', 11, 11);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -346,7 +346,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 11, 11);
         config_addVarRange(config, 'B', 11, 12);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let fallback = {fallback: {type: 'size'}};
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -359,7 +359,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 11, 11);
         config_addVarRange(config, 'B', 11, 11);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let fallback = {fallback: {type: 'size'}};
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -372,7 +372,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 11, 12);
         config_addVarRange(config, 'B', 11, 11);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let fallback = {fallback: {type: 'size'}};
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -468,7 +468,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -487,7 +487,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -507,7 +507,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -526,7 +526,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -545,7 +545,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -565,7 +565,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -583,7 +583,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -602,7 +602,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -620,7 +620,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -639,7 +639,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -658,7 +658,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -677,7 +677,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -693,7 +693,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -710,7 +710,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -729,7 +729,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -749,7 +749,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 10);
         config_addVarRange(config, 'B', 0, 10);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -768,7 +768,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 0, 10);
         config_addVarRange(config, 'B', 0, 0);
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 

--- a/tests/specs/distribution/var.spec.js
+++ b/tests/specs/distribution/var.spec.js
@@ -74,7 +74,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_value(10, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -86,7 +86,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_value(11, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -98,7 +98,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_value(12, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -122,7 +122,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_value(12, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -134,7 +134,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_value(11, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -146,7 +146,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_value(10, true));
         config_addVarDomain(config, 'B', fixt_arrdom_value(11, true));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -171,7 +171,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 5, 5);
         config_addVarRange(config, 'B', 11, 12);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -183,7 +183,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 11, 11);
         config_addVarRange(config, 'B', 8, 8);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -195,7 +195,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(11, 15, 16, 17, 18, 19));
         config_addVarDomain(config, 'B', fixt_arrdom_nums(8, 9, 10, 12, 13, 14));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -207,7 +207,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', fixt_arrdom_nums(11, 13, 14, 18, 19));
         config_addVarDomain(config, 'B', fixt_arrdom_nums(8, 9, 10, 13, 14));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -219,7 +219,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 11, 12);
         config_addVarRange(config, 'B', 11, 11);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -294,7 +294,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 11, 12);
         config_addVarRange(config, 'B', 11, 11);
         config_setOption(config, 'varStratOverride', {valtype: 'markov'}, 'A');
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -307,7 +307,7 @@ describe('distribution/var.spec', function() {
         config_addVarRange(config, 'A', 11, 12);
         config_addVarRange(config, 'B', 11, 11);
         config_setOption(config, 'varStratOverride', {valtype: 'markov'}, 'B');
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -321,7 +321,7 @@ describe('distribution/var.spec', function() {
         config_setOption(config, 'varStratOverride', {valtype: 'markov'}, 'A');
         config_addVarRange(config, 'B', 11, 11);
         config_setOption(config, 'varStratOverride', {valtype: 'markov'}, 'B');
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -333,7 +333,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 11, 12);
         config_addVarRange(config, 'B', 11, 11);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -345,7 +345,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 11, 11);
         config_addVarRange(config, 'B', 11, 12);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let fallback = {fallback: {type: 'size'}};
         let A = config.all_var_names.indexOf('A');
@@ -358,7 +358,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 11, 11);
         config_addVarRange(config, 'B', 11, 11);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let fallback = {fallback: {type: 'size'}};
         let A = config.all_var_names.indexOf('A');
@@ -371,7 +371,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 11, 12);
         config_addVarRange(config, 'B', 11, 11);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let fallback = {fallback: {type: 'size'}};
         let A = config.all_var_names.indexOf('A');
@@ -465,7 +465,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -484,7 +484,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -504,7 +504,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -523,7 +523,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -542,7 +542,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -562,7 +562,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -580,7 +580,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -599,7 +599,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -617,7 +617,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -636,7 +636,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -655,7 +655,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -674,7 +674,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -690,7 +690,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -707,7 +707,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -726,7 +726,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 0);
         config_addVarRange(config, 'B', 0, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -746,7 +746,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 10);
         config_addVarRange(config, 'B', 0, 10);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -765,7 +765,7 @@ describe('distribution/var.spec', function() {
         let config = config_create();
         config_addVarRange(config, 'A', 0, 10);
         config_addVarRange(config, 'B', 0, 0);
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');

--- a/tests/specs/distribution/var.spec.js
+++ b/tests/specs/distribution/var.spec.js
@@ -33,7 +33,7 @@ describe('distribution/var.spec', function() {
 
   describe('distribution_var_by_throw', function() {
     it('should throw', function() {
-      expect(_ => distribution_getNextVarIndex({config: {varStratConfig: {type: 'throw'}}})).to.throw('not expecting to pick this distributor');
+      expect(_ => distribution_getNextVarIndex({config: {varStratConfig: {type: 'throw'}}}, {varStratConfig: {type: 'throw'}})).to.throw('not expecting to pick this distributor');
     });
   });
 
@@ -60,7 +60,7 @@ describe('distribution/var.spec', function() {
         },
       });
 
-      let varIndex = distribution_getNextVarIndex(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space, solver.config);
 
       expect(varIndex, stack).to.equal(solver._space.config.all_var_names.indexOf(out));
     });
@@ -79,7 +79,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMin(space, A, B)).to.equal(BETTER);
+        expect(distribution_varByMin(space, config, A, B)).to.equal(BETTER);
       });
 
       it('should return SAME if lo(v1) = lo(v2)', function() {
@@ -91,7 +91,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMin(space, A, B)).to.equal(SAME);
+        expect(distribution_varByMin(space, config, A, B)).to.equal(SAME);
       });
 
       it('should return WORSE if lo(v1) > lo(v2)', function() {
@@ -103,7 +103,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMin(space, A, B)).to.equal(WORSE);
+        expect(distribution_varByMin(space, config, A, B)).to.equal(WORSE);
       });
     });
 
@@ -127,7 +127,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMax(space, A, B)).to.equal(BETTER);
+        expect(distribution_varByMax(space, config, A, B)).to.equal(BETTER);
       });
 
       it('should return SAME if hi(v1) = hi(v2)', function() {
@@ -139,7 +139,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMax(space, A, B)).to.equal(SAME);
+        expect(distribution_varByMax(space, config, A, B)).to.equal(SAME);
       });
 
       it('should return WORSE if hi(v1) < hi(v2)', function() {
@@ -151,7 +151,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMax(space, A, B)).to.equal(WORSE);
+        expect(distribution_varByMax(space, config, A, B)).to.equal(WORSE);
       });
     });
 
@@ -176,7 +176,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMinSize(space, A, B)).to.equal(BETTER);
+        expect(distribution_varByMinSize(space, config, A, B)).to.equal(BETTER);
       });
 
       it('should return SAME if size(v1) = size(v2) with single range', function() {
@@ -188,7 +188,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMinSize(space, A, B)).to.equal(SAME);
+        expect(distribution_varByMinSize(space, config, A, B)).to.equal(SAME);
       });
 
       it('should return SAME if size(v1) = size(v2) with multiple ranges', function() {
@@ -200,7 +200,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMinSize(space, A, B)).to.equal(SAME);
+        expect(distribution_varByMinSize(space, config, A, B)).to.equal(SAME);
       });
 
       it('should return SAME if size(v1) = size(v2) with different range count', function() {
@@ -212,7 +212,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMinSize(space, A, B)).to.equal(SAME);
+        expect(distribution_varByMinSize(space, config, A, B)).to.equal(SAME);
       });
 
       it('should return WORSE if size(v1) > size(v2)', function() {
@@ -224,7 +224,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMinSize(space, A, B)).to.equal(WORSE);
+        expect(distribution_varByMinSize(space, config, A, B)).to.equal(WORSE);
       });
     });
 
@@ -254,7 +254,7 @@ describe('distribution/var.spec', function() {
           },
         });
 
-        let varName = distribution_getNextVarIndex(solver._space);
+        let varName = distribution_getNextVarIndex(solver._space, solver.config);
         expect(varName).to.eql(solver._space.config.all_var_names.indexOf('A'));
       });
 
@@ -279,7 +279,7 @@ describe('distribution/var.spec', function() {
           },
         });
 
-        let varName = distribution_getNextVarIndex(solver._space);
+        let varName = distribution_getNextVarIndex(solver._space, solver.config);
         expect(varName).to.eql(solver._space.config.all_var_names.indexOf('B'));
       });
     });
@@ -299,7 +299,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMarkov(space, A, B, {})).to.equal(BETTER);
+        expect(distribution_varByMarkov(space, config, A, B, {})).to.equal(BETTER);
       });
 
       it('should say v1 is WORSE if v1 not a markov but v2 is', function() {
@@ -312,7 +312,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMarkov(space, A, B, {})).to.equal(WORSE);
+        expect(distribution_varByMarkov(space, config, A, B, {})).to.equal(WORSE);
       });
 
       it('should say v1 is BETTER if v1 and v2 are both markov vars', function() {
@@ -326,7 +326,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMarkov(space, A, B, {})).to.equal(BETTER);
+        expect(distribution_varByMarkov(space, config, A, B, {})).to.equal(BETTER);
       });
 
       it('should say v1 is SAME as v2 if neither is a markov var', function() {
@@ -338,7 +338,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMarkov(space, A, B, {})).to.equal(SAME);
+        expect(distribution_varByMarkov(space, config, A, B, {})).to.equal(SAME);
       });
 
       it('should use fallback if available and vars are SAME and then return BETTER', function() {
@@ -351,7 +351,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMarkov(space, A, B, fallback)).to.equal(BETTER);
+        expect(distribution_varByMarkov(space, config, A, B, fallback)).to.equal(BETTER);
       });
 
       it('should use fallback if available and vars are SAME but then still return SAME', function() {
@@ -364,7 +364,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMarkov(space, A, B, fallback)).to.equal(SAME);
+        expect(distribution_varByMarkov(space, config, A, B, fallback)).to.equal(SAME);
       });
 
       it('should use fallback if available and vars are SAME and then return WORSE', function() {
@@ -377,7 +377,7 @@ describe('distribution/var.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        expect(distribution_varByMarkov(space, A, B, fallback)).to.equal(WORSE);
+        expect(distribution_varByMarkov(space, config, A, B, fallback)).to.equal(WORSE);
       });
     });
 
@@ -413,7 +413,7 @@ describe('distribution/var.spec', function() {
   //console.log('\n')
   //_front_debug(solver._space.config._front);
 
-        let varIndex = distribution_getNextVarIndex(solver._space);
+        let varIndex = distribution_getNextVarIndex(solver._space, solver.config);
 
         expect(varIndex).to.eql(solver._space.config.all_var_names.indexOf('B'));
       });
@@ -452,7 +452,7 @@ describe('distribution/var.spec', function() {
           },
         });
 
-        let varIndex = distribution_getNextVarIndex(solver._space);
+        let varIndex = distribution_getNextVarIndex(solver._space, solver.config);
 
         expect(varIndex).to.eql(solver._space.config.all_var_names.indexOf('C'));
       });
@@ -479,7 +479,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(BETTER);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(BETTER);
       });
 
       it('should return WORSE if the inverted priority hash says A is higher than B', function() {
@@ -499,7 +499,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(WORSE);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(WORSE);
       });
 
       it('should THROW if the priority hash says A is equal to B', function() {
@@ -518,7 +518,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(() => distribution_varByList(space, A, B, nvconfig)).to.throw('A_CANNOT_GET_SAME_INDEX_FOR_DIFFERENT_NAME');
+        expect(() => distribution_varByList(space, config, A, B, nvconfig)).to.throw('A_CANNOT_GET_SAME_INDEX_FOR_DIFFERENT_NAME');
       });
 
       it('should return WORSE if the priority hash says A is lower than B', function() {
@@ -537,7 +537,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(WORSE);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(WORSE);
       });
 
       it('should return BETTER if the inverted priority hash says A is lower than B', function() {
@@ -557,7 +557,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(BETTER);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(BETTER);
       });
 
       it('should return BETTER if A is in the hash but B is not', function() {
@@ -575,7 +575,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(BETTER);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(BETTER);
       });
 
       it('should return WORSE if A is in the inverted hash but B is not', function() {
@@ -594,7 +594,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(WORSE);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(WORSE);
       });
 
       it('should return WORSE if B is in the hash but A is not', function() {
@@ -612,7 +612,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(WORSE);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(WORSE);
       });
 
       it('should return BETTER if B is in the inverted hash but A is not', function() {
@@ -631,7 +631,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(BETTER);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(BETTER);
       });
 
       it('should throw if A gets value 0 from the hash', function() {
@@ -649,7 +649,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        let f = _ => distribution_varByList(space, A, B, nvconfig);
+        let f = _ => distribution_varByList(space, config, A, B, nvconfig);
         expect(f).to.throw('SHOULD_NOT_USE_INDEX_ZERO');
       });
 
@@ -668,7 +668,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        let f = _ => distribution_varByList(space, A, B, nvconfig);
+        let f = _ => distribution_varByList(space, config, A, B, nvconfig);
         expect(f).to.throw('SHOULD_NOT_USE_INDEX_ZERO');
       });
 
@@ -685,7 +685,7 @@ describe('distribution/var.spec', function() {
           _priorityByIndex: {},
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(SAME);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(SAME);
       });
 
       it('should return SAME if neither A nor B is in the inverted hash without fallback', function() {
@@ -702,7 +702,7 @@ describe('distribution/var.spec', function() {
           _priorityByIndex: {},
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(SAME);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(SAME);
       });
 
       it('should return BETTER if neither is in the hash and fallback is size with A smaller', function() {
@@ -721,7 +721,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(BETTER);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(BETTER);
       });
 
       it('should return BETTER if neither is in the inverted hash and fallback is size with A smaller', function() {
@@ -741,7 +741,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(BETTER);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(BETTER);
       });
 
       it('should return SAME if neither is in the hash and fallback is size with A same size as B', function() {
@@ -760,7 +760,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(SAME);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(SAME);
       });
 
       it('should return WORSE if neither is in the hash and fallback is size with A larger', function() {
@@ -779,7 +779,7 @@ describe('distribution/var.spec', function() {
           },
         };
 
-        expect(distribution_varByList(space, A, B, nvconfig)).to.equal(WORSE);
+        expect(distribution_varByList(space, config, A, B, nvconfig)).to.equal(WORSE);
       });
     });
 
@@ -799,7 +799,7 @@ describe('distribution/var.spec', function() {
           },
         });
 
-        let varName = distribution_getNextVarIndex(solver._space);
+        let varName = distribution_getNextVarIndex(solver._space, solver.config);
 
         expect(varName).to.eql(solver._space.config.all_var_names.indexOf('A'));
       });
@@ -818,7 +818,7 @@ describe('distribution/var.spec', function() {
           },
         });
 
-        let varName = distribution_getNextVarIndex(solver._space);
+        let varName = distribution_getNextVarIndex(solver._space, solver.config);
 
         expect(varName).to.eql(solver._space.config.all_var_names.indexOf('B'));
       });
@@ -836,7 +836,7 @@ describe('distribution/var.spec', function() {
           },
         });
 
-        let varName = distribution_getNextVarIndex(solver._space);
+        let varName = distribution_getNextVarIndex(solver._space, solver.config);
 
         expect(varName).to.eql(solver._space.config.all_var_names.indexOf('A'));
       });
@@ -856,7 +856,7 @@ describe('distribution/var.spec', function() {
           },
         });
 
-        let varName = distribution_getNextVarIndex(solver._space);
+        let varName = distribution_getNextVarIndex(solver._space, solver.config);
         expect(varName, desc).to.eql(solver._space.config.all_var_names.indexOf(expectingName));
       }
 
@@ -885,7 +885,7 @@ describe('distribution/var.spec', function() {
           },
         });
 
-        let varName = distribution_getNextVarIndex(solver._space);
+        let varName = distribution_getNextVarIndex(solver._space, solver.config);
         expect(varName, desc).to.eql(solver._space.config.all_var_names.indexOf(expectedName));
       }
 
@@ -954,7 +954,7 @@ describe('distribution/var.spec', function() {
         },
       });
 
-      let varIndex = distribution_getNextVarIndex(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space, solver.config);
 
       if (resultName !== undefined) {
         expect(varIndex).to.equal(solver._space.config.all_var_names.indexOf(resultName));
@@ -1044,7 +1044,7 @@ describe('distribution/var.spec', function() {
         },
       });
 
-      let varIndex = distribution_getNextVarIndex(solver._space);
+      let varIndex = distribution_getNextVarIndex(solver._space, solver.config);
 
       expect(varIndex).to.equal(solver._space.config.all_var_names.indexOf(expectName));
     }

--- a/tests/specs/distribution/var.spec.js
+++ b/tests/specs/distribution/var.spec.js
@@ -62,7 +62,7 @@ describe('distribution/var.spec', function() {
 
       let varIndex = distribution_getNextVarIndex(solver._space, solver.config);
 
-      expect(varIndex, stack).to.equal(solver._space.config.all_var_names.indexOf(out));
+      expect(varIndex, stack).to.equal(solver.config.all_var_names.indexOf(out));
     });
   }
 
@@ -255,7 +255,7 @@ describe('distribution/var.spec', function() {
         });
 
         let varName = distribution_getNextVarIndex(solver._space, solver.config);
-        expect(varName).to.eql(solver._space.config.all_var_names.indexOf('A'));
+        expect(varName).to.eql(solver.config.all_var_names.indexOf('A'));
       });
 
       it('should count actual elements in the domain B', function() {
@@ -280,7 +280,7 @@ describe('distribution/var.spec', function() {
         });
 
         let varName = distribution_getNextVarIndex(solver._space, solver.config);
-        expect(varName).to.eql(solver._space.config.all_var_names.indexOf('B'));
+        expect(varName).to.eql(solver.config.all_var_names.indexOf('B'));
       });
     });
   });
@@ -410,12 +410,10 @@ describe('distribution/var.spec', function() {
             varStrategy: {type: 'markov'},
           },
         });
-  //console.log('\n')
-  //_front_debug(solver._space.config._front);
 
         let varIndex = distribution_getNextVarIndex(solver._space, solver.config);
 
-        expect(varIndex).to.eql(solver._space.config.all_var_names.indexOf('B'));
+        expect(varIndex).to.eql(solver.config.all_var_names.indexOf('B'));
       });
 
       it('should get markov vars back to front', function() {
@@ -454,7 +452,7 @@ describe('distribution/var.spec', function() {
 
         let varIndex = distribution_getNextVarIndex(solver._space, solver.config);
 
-        expect(varIndex).to.eql(solver._space.config.all_var_names.indexOf('C'));
+        expect(varIndex).to.eql(solver.config.all_var_names.indexOf('C'));
       });
     });
   });
@@ -801,7 +799,7 @@ describe('distribution/var.spec', function() {
 
         let varName = distribution_getNextVarIndex(solver._space, solver.config);
 
-        expect(varName).to.eql(solver._space.config.all_var_names.indexOf('A'));
+        expect(varName).to.eql(solver.config.all_var_names.indexOf('A'));
       });
 
       it('should solve vars in the explicit order of the list B', function() {
@@ -820,7 +818,7 @@ describe('distribution/var.spec', function() {
 
         let varName = distribution_getNextVarIndex(solver._space, solver.config);
 
-        expect(varName).to.eql(solver._space.config.all_var_names.indexOf('B'));
+        expect(varName).to.eql(solver.config.all_var_names.indexOf('B'));
       });
 
       it('should not crash if a var is not on the list or when list is empty', function() {
@@ -838,7 +836,7 @@ describe('distribution/var.spec', function() {
 
         let varName = distribution_getNextVarIndex(solver._space, solver.config);
 
-        expect(varName).to.eql(solver._space.config.all_var_names.indexOf('A'));
+        expect(varName).to.eql(solver.config.all_var_names.indexOf('A'));
       });
 
       function unlistedTest(desc, targetNames, expectingName) {
@@ -857,7 +855,7 @@ describe('distribution/var.spec', function() {
         });
 
         let varName = distribution_getNextVarIndex(solver._space, solver.config);
-        expect(varName, desc).to.eql(solver._space.config.all_var_names.indexOf(expectingName));
+        expect(varName, desc).to.eql(solver.config.all_var_names.indexOf(expectingName));
       }
 
       it('should assume unlisted vars come after listed vars', function() {
@@ -886,7 +884,7 @@ describe('distribution/var.spec', function() {
         });
 
         let varName = distribution_getNextVarIndex(solver._space, solver.config);
-        expect(varName, desc).to.eql(solver._space.config.all_var_names.indexOf(expectedName));
+        expect(varName, desc).to.eql(solver.config.all_var_names.indexOf(expectedName));
       }
 
       it('should work with list as fallback dist', function() {
@@ -957,7 +955,7 @@ describe('distribution/var.spec', function() {
       let varIndex = distribution_getNextVarIndex(solver._space, solver.config);
 
       if (resultName !== undefined) {
-        expect(varIndex).to.equal(solver._space.config.all_var_names.indexOf(resultName));
+        expect(varIndex).to.equal(solver.config.all_var_names.indexOf(resultName));
       }
     }
 
@@ -1046,7 +1044,7 @@ describe('distribution/var.spec', function() {
 
       let varIndex = distribution_getNextVarIndex(solver._space, solver.config);
 
-      expect(varIndex).to.equal(solver._space.config.all_var_names.indexOf(expectName));
+      expect(varIndex).to.equal(solver.config.all_var_names.indexOf(expectName));
     }
 
     it('should prioritize list over rest A', function() {

--- a/tests/specs/exports/export.cases.spec.js
+++ b/tests/specs/exports/export.cases.spec.js
@@ -739,7 +739,7 @@ describe('exports/export.cases.spec', function() {
         let solution = solver.solve();
 
         expect(solution).to.eql([{A: [19, 20], B: [20, 21]}]); // return all valid values that still satisfy all constraints (->none)
-        expect(space_getUnsolvedVarCount(solver._space)).to.eql(0); // should not target A or B because they are unconstrained
+        expect(space_getUnsolvedVarCount(solver._space, solver.config)).to.eql(0); // should not target A or B because they are unconstrained
       });
       it('constrained AB should appear in spaces unsolved vars list', function() {
         let solver = new Solver();

--- a/tests/specs/exports/export.cases.spec.js
+++ b/tests/specs/exports/export.cases.spec.js
@@ -749,7 +749,7 @@ describe('exports/export.cases.spec', function() {
         let solution = solver.solve({});
 
         expect(solution).to.eql([{A: 19, B: 21}, {A: 19, B: 22}, {A: 20, B: 21}, {A: 20, B: 22}]); // now it must solve. note: result will be different when we optimize neq to "solve" properly
-        expect(_space_getUnsolvedVarNamesFresh(solver._space).sort()).to.eql(['A', 'B']); // should A and B because they are under neq
+        expect(_space_getUnsolvedVarNamesFresh(solver._space, solver.config).sort()).to.eql(['A', 'B']); // should A and B because they are under neq
       });
     });
   });

--- a/tests/specs/propagators/eq.spec.js
+++ b/tests/specs/propagators/eq.spec.js
@@ -45,12 +45,10 @@ describe('propagators/eq.spec', function() {
     let space = space_createRoot(config);
     space_initFromConfig(space, config);
 
-    expect(_ => propagator_eqStepBare(space, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('B'))).not.to.throw();
-    expect(_ => propagator_eqStepBare()).to.throw('SHOULD_GET_SPACE');
-    expect(_ => propagator_eqStepBare(space)).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
-    expect(_ => propagator_eqStepBare(space, config.all_var_names.indexOf('A'))).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
-    expect(_ => propagator_eqStepBare(space, undefined, config.all_var_names.indexOf('B'))).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
-    expect(_ => propagator_eqStepBare(undefined, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('B'))).to.throw('SHOULD_GET_SPACE');
+    expect(_ => propagator_eqStepBare(space, config, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('B'))).not.to.throw();
+    expect(_ => propagator_eqStepBare(space, config)).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
+    expect(_ => propagator_eqStepBare(space, config, config.all_var_names.indexOf('A'))).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
+    expect(_ => propagator_eqStepBare(space, config, undefined, config.all_var_names.indexOf('B'))).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
   });
 
   it('should throw for empty domains', function() {
@@ -64,10 +62,10 @@ describe('propagators/eq.spec', function() {
     space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
     space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
 
-    expect(_ => propagator_eqStepBare(space, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('B'))).not.to.throw();
-    expect(_ => propagator_eqStepBare(space, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('D'))).to.throw('SHOULD_NOT_BE_REJECTED');
-    expect(_ => propagator_eqStepBare(space, config.all_var_names.indexOf('C'), config.all_var_names.indexOf('B'))).to.throw('SHOULD_NOT_BE_REJECTED');
-    expect(_ => propagator_eqStepBare(space, config.all_var_names.indexOf('C'), config.all_var_names.indexOf('D'))).to.throw('SHOULD_NOT_BE_REJECTED');
+    expect(_ => propagator_eqStepBare(space, config, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('B'))).not.to.throw();
+    expect(_ => propagator_eqStepBare(space, config, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('D'))).to.throw('SHOULD_NOT_BE_REJECTED');
+    expect(_ => propagator_eqStepBare(space, config, config.all_var_names.indexOf('C'), config.all_var_names.indexOf('B'))).to.throw('SHOULD_NOT_BE_REJECTED');
+    expect(_ => propagator_eqStepBare(space, config, config.all_var_names.indexOf('C'), config.all_var_names.indexOf('D'))).to.throw('SHOULD_NOT_BE_REJECTED');
   });
 
   it('with array should split a domain if it covers multiple ranges of other domain', function() {
@@ -79,7 +77,7 @@ describe('propagators/eq.spec', function() {
     let A = config.all_var_names.indexOf('A');
     let B = config.all_var_names.indexOf('B');
 
-    propagator_eqStepBare(space, A, B);
+    propagator_eqStepBare(space, config, A, B);
     expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([0, 10], [20, 300]));
     expect(space.vardoms[B]).to.eql(fixt_strdom_ranges([0, 10], [20, 300]));
   });
@@ -95,7 +93,7 @@ describe('propagators/eq.spec', function() {
 
     let C = fixt_numdom_nums(0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15);
 
-    propagator_eqStepBare(space, A, B);
+    propagator_eqStepBare(space, config, A, B);
     expect(space.vardoms[B]).to.eql(C);
     expect(space.vardoms[A]).to.eql(C);
   });
@@ -112,7 +110,7 @@ describe('propagators/eq.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        propagator_eqStepBare(space, A, B);
+        propagator_eqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(domain_toNumstr(domain));
         expect(space.vardoms[B]).to.eql(domain_toNumstr(domain));
       });
@@ -147,7 +145,7 @@ describe('propagators/eq.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        propagator_eqStepBare(space, A, B);
+        propagator_eqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(result);
         expect(space.vardoms[B]).to.eql(result);
       });
@@ -161,7 +159,7 @@ describe('propagators/eq.spec', function() {
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
-        propagator_eqStepBare(space, A, B);
+        propagator_eqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(result);
         expect(space.vardoms[B]).to.eql(result);
       });

--- a/tests/specs/propagators/eq.spec.js
+++ b/tests/specs/propagators/eq.spec.js
@@ -42,7 +42,7 @@ describe('propagators/eq.spec', function() {
     let config = config_create();
     config_addVarRange(config, 'A', 11, 15);
     config_addVarRange(config, 'B', 5, 8);
-    let space = space_createRoot(config);
+    let space = space_createRoot();
     space_initFromConfig(space, config);
 
     expect(_ => propagator_eqStepBare(space, config, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('B'))).not.to.throw();
@@ -57,7 +57,7 @@ describe('propagators/eq.spec', function() {
     config_addVarRange(config, 'B', 11, 15);
     config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
     config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
-    let space = space_createRoot(config);
+    let space = space_createRoot();
     space_initFromConfig(space, config);
     space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
     space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
@@ -72,7 +72,7 @@ describe('propagators/eq.spec', function() {
     let config = config_create();
     config_addVarDomain(config, 'A', fixt_arrdom_range(SUB, SUP));
     config_addVarDomain(config, 'B', fixt_arrdom_ranges([0, 10], [20, 300]));
-    let space = space_createRoot(config);
+    let space = space_createRoot();
     space_initFromConfig(space, config);
     let A = config.all_var_names.indexOf('A');
     let B = config.all_var_names.indexOf('B');
@@ -86,7 +86,7 @@ describe('propagators/eq.spec', function() {
     let config = config_create();
     config_addVarRange(config, 'A', SUB, 15);
     config_addVarDomain(config, 'B', fixt_arrdom_nums(0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15));
-    let space = space_createRoot(config);
+    let space = space_createRoot();
     space_initFromConfig(space, config);
     let A = config.all_var_names.indexOf('A');
     let B = config.all_var_names.indexOf('B');
@@ -104,7 +104,7 @@ describe('propagators/eq.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', domain_any_clone(domain, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain, FORCE_ARRAY));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         let A = config.all_var_names.indexOf('A');
@@ -140,7 +140,7 @@ describe('propagators/eq.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', domain_any_clone(left, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(right, FORCE_ARRAY));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -154,7 +154,7 @@ describe('propagators/eq.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', domain_any_clone(right, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(left, FORCE_ARRAY));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');

--- a/tests/specs/propagators/eq.spec.js
+++ b/tests/specs/propagators/eq.spec.js
@@ -43,7 +43,7 @@ describe('propagators/eq.spec', function() {
     config_addVarRange(config, 'A', 11, 15);
     config_addVarRange(config, 'B', 5, 8);
     let space = space_createRoot(config);
-    space_initFromConfig(space);
+    space_initFromConfig(space, config);
 
     expect(_ => propagator_eqStepBare(space, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('B'))).not.to.throw();
     expect(_ => propagator_eqStepBare()).to.throw('SHOULD_GET_SPACE');
@@ -60,7 +60,7 @@ describe('propagators/eq.spec', function() {
     config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
     config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
     let space = space_createRoot(config);
-    space_initFromConfig(space);
+    space_initFromConfig(space, config);
     space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
     space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
 
@@ -75,7 +75,7 @@ describe('propagators/eq.spec', function() {
     config_addVarDomain(config, 'A', fixt_arrdom_range(SUB, SUP));
     config_addVarDomain(config, 'B', fixt_arrdom_ranges([0, 10], [20, 300]));
     let space = space_createRoot(config);
-    space_initFromConfig(space);
+    space_initFromConfig(space, config);
     let A = config.all_var_names.indexOf('A');
     let B = config.all_var_names.indexOf('B');
 
@@ -89,7 +89,7 @@ describe('propagators/eq.spec', function() {
     config_addVarRange(config, 'A', SUB, 15);
     config_addVarDomain(config, 'B', fixt_arrdom_nums(0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15));
     let space = space_createRoot(config);
-    space_initFromConfig(space);
+    space_initFromConfig(space, config);
     let A = config.all_var_names.indexOf('A');
     let B = config.all_var_names.indexOf('B');
 
@@ -107,7 +107,7 @@ describe('propagators/eq.spec', function() {
         config_addVarDomain(config, 'A', domain_any_clone(domain, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain, FORCE_ARRAY));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
@@ -143,7 +143,7 @@ describe('propagators/eq.spec', function() {
         config_addVarDomain(config, 'A', domain_any_clone(left, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(right, FORCE_ARRAY));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 
@@ -157,7 +157,7 @@ describe('propagators/eq.spec', function() {
         config_addVarDomain(config, 'A', domain_any_clone(right, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(left, FORCE_ARRAY));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
         let A = config.all_var_names.indexOf('A');
         let B = config.all_var_names.indexOf('B');
 

--- a/tests/specs/propagators/lt.spec.js
+++ b/tests/specs/propagators/lt.spec.js
@@ -51,7 +51,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
       config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
       space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
 
@@ -66,7 +66,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 100));
       config_addVarDomain(config, 'B', fixt_arrdom_range(95, 99));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -81,7 +81,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, SUP));
       config_addVarDomain(config, 'B', fixt_arrdom_range(95, SUP));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -96,7 +96,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 100));
       config_addVarDomain(config, 'B', fixt_arrdom_range(101, 101));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -111,7 +111,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 150));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 200));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -126,7 +126,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(190, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 150));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -141,7 +141,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(200, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 300));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -156,7 +156,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(200, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(200, 300));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -171,7 +171,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [120, 150]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
       propagator_ltStepBare(space, A, B);
@@ -182,7 +182,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [100, 150]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
       space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
       propagator_ltStepBare(space, A, B);
@@ -193,7 +193,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [100, 100]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
       space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
       propagator_ltStepBare(space, A, B);
@@ -206,7 +206,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60]));
       config_addVarDomain(config, 'B', fixt_arrdom_ranges([0, 10], [20, 100]));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
       propagator_ltStepBare(space, A, B);
@@ -217,7 +217,7 @@ describe('propagators/lt.spec', function() {
       //config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60]));
       //config_addVarDomain(config, 'B', fixt_arrdom_ranges([0, 5], [20, 100]));
       //space = space_createRoot(config);
-      //space_initFromConfig(space);
+      //space_initFromConfig(space, config);
       //propagator_ltStepBare(space, A, B);
       //expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60]));
       //expect(space.vardoms[B]).to.eql(fixt_strdom_ranges([20, 100]));
@@ -226,7 +226,7 @@ describe('propagators/lt.spec', function() {
       //config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60]));
       //config_addVarDomain(config, 'B', fixt_arrdom_ranges([10, 10], [20, 100]));
       //space = space_createRoot(config);
-      //space_initFromConfig(space);
+      //space_initFromConfig(space, config);
       //propagator_ltStepBare(space, A, B);
       //expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60]));
       //expect(space.vardoms[B]).to.eql(fixt_strdom_ranges([20, 100]));
@@ -242,7 +242,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
       config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
       space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
 
@@ -262,7 +262,7 @@ describe('propagators/lt.spec', function() {
       config_addVarRange(config, 'A', 0, 10);
       config_addVarRange(config, 'B', 5, 9);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -277,7 +277,7 @@ describe('propagators/lt.spec', function() {
       config_addVarRange(config, 'A', 0, 15);
       config_addVarRange(config, 'B', 5, 15);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -292,7 +292,7 @@ describe('propagators/lt.spec', function() {
       config_addVarRange(config, 'A', 0, 10);
       config_addVarRange(config, 'B', 11, 15);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -307,7 +307,7 @@ describe('propagators/lt.spec', function() {
       config_addVarRange(config, 'A', 0, 13);
       config_addVarRange(config, 'B', 10, 15);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -322,7 +322,7 @@ describe('propagators/lt.spec', function() {
       config_addVarRange(config, 'A', 11, 15);
       config_addVarRange(config, 'B', 5, 8);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -337,7 +337,7 @@ describe('propagators/lt.spec', function() {
       config_addVarRange(config, 'A', 8, 8);
       config_addVarRange(config, 'B', 5, 10);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -352,7 +352,7 @@ describe('propagators/lt.spec', function() {
       config_addVarRange(config, 'A', 7, 7);
       config_addVarRange(config, 'B', 7, 13);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');

--- a/tests/specs/propagators/lt.spec.js
+++ b/tests/specs/propagators/lt.spec.js
@@ -36,8 +36,6 @@ describe('propagators/lt.spec', function() {
   it('should require two vars', function() {
     let space = space_createRoot();
 
-    expect(() => propagator_ltStepBare()).to.throw('SHOULD_GET_SPACE');
-    expect(() => propagator_ltStepBare({})).to.throw('SHOULD_GET_SPACE');
     expect(() => propagator_ltStepBare(space, 'A')).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
     expect(() => propagator_ltStepBare(space, undefined, 'B')).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
   });
@@ -55,10 +53,10 @@ describe('propagators/lt.spec', function() {
       space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
       space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
 
-      expect(_ => propagator_ltStepBare(space, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('B'))).not.to.throw();
-      expect(_ => propagator_ltStepBare(space, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('D'))).to.throw('SHOULD_NOT_BE_REJECTED');
-      expect(_ => propagator_ltStepBare(space, config.all_var_names.indexOf('C'), config.all_var_names.indexOf('B'))).to.throw('SHOULD_NOT_BE_REJECTED');
-      expect(_ => propagator_ltStepBare(space, config.all_var_names.indexOf('C'), config.all_var_names.indexOf('D'))).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_ltStepBare(space, config, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('B'))).not.to.throw();
+      expect(_ => propagator_ltStepBare(space, config, config.all_var_names.indexOf('A'), config.all_var_names.indexOf('D'))).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_ltStepBare(space, config, config.all_var_names.indexOf('C'), config.all_var_names.indexOf('B'))).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_ltStepBare(space, config, config.all_var_names.indexOf('C'), config.all_var_names.indexOf('D'))).to.throw('SHOULD_NOT_BE_REJECTED');
     });
 
     it('should remove any value from v1 that is gte to max(v2)', function() {
@@ -71,7 +69,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(90, 98));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(95, 99));
     });
@@ -86,7 +84,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(90, SUP - 1));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(95, SUP));
     });
@@ -101,7 +99,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(90, 100));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(101, 101));
     });
@@ -116,7 +114,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(90, 150));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(100, 200));
     });
@@ -131,7 +129,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_empty());
       expect(space.vardoms[B]).to.eql(fixt_numdom_empty());
     });
@@ -146,7 +144,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(200, 200));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(201, 300));
     });
@@ -161,7 +159,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(200, 200));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(201, 300));
     });
@@ -174,7 +172,7 @@ describe('propagators/lt.spec', function() {
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60], [70, 98]));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(11, 100));
 
@@ -185,7 +183,7 @@ describe('propagators/lt.spec', function() {
       space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60], [70, 98]));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(11, 100));
 
@@ -196,7 +194,7 @@ describe('propagators/lt.spec', function() {
       space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60], [70, 98]));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(11, 100));
     });
@@ -209,7 +207,7 @@ describe('propagators/lt.spec', function() {
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60]));
       expect(space.vardoms[B]).to.eql(fixt_strdom_ranges([20, 100]));
 
@@ -218,7 +216,7 @@ describe('propagators/lt.spec', function() {
       //config_addVarDomain(config, 'B', fixt_arrdom_ranges([0, 5], [20, 100]));
       //space = space_createRoot(config);
       //space_initFromConfig(space, config);
-      //propagator_ltStepBare(space, A, B);
+      //propagator_ltStepBare(space, config, A, B);
       //expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60]));
       //expect(space.vardoms[B]).to.eql(fixt_strdom_ranges([20, 100]));
       //
@@ -227,7 +225,7 @@ describe('propagators/lt.spec', function() {
       //config_addVarDomain(config, 'B', fixt_arrdom_ranges([10, 10], [20, 100]));
       //space = space_createRoot(config);
       //space_initFromConfig(space, config);
-      //propagator_ltStepBare(space, A, B);
+      //propagator_ltStepBare(space, config, A, B);
       //expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60]));
       //expect(space.vardoms[B]).to.eql(fixt_strdom_ranges([20, 100]));
     });
@@ -251,10 +249,10 @@ describe('propagators/lt.spec', function() {
       let C = config.all_var_names.indexOf('C');
       let D = config.all_var_names.indexOf('D');
 
-      expect(_ => propagator_ltStepBare(space, A, B)).not.to.throw();
-      expect(_ => propagator_ltStepBare(space, A, D)).to.throw('SHOULD_NOT_BE_REJECTED');
-      expect(_ => propagator_ltStepBare(space, C, B)).to.throw('SHOULD_NOT_BE_REJECTED');
-      expect(_ => propagator_ltStepBare(space, C, D)).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_ltStepBare(space, config, A, B)).not.to.throw();
+      expect(_ => propagator_ltStepBare(space, config, A, D)).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_ltStepBare(space, config, C, B)).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_ltStepBare(space, config, C, D)).to.throw('SHOULD_NOT_BE_REJECTED');
     });
 
     it('should remove any value from v1 that is gte to max(v2)', function() {
@@ -267,7 +265,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(0, 8));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(5, 9));
     });
@@ -282,7 +280,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(0, 14));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(5, 15));
     });
@@ -297,7 +295,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(0, 10));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(11, 15));
     });
@@ -312,7 +310,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(0, 13));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(10, 15));
     });
@@ -327,7 +325,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_empty());
       expect(space.vardoms[B]).to.eql(fixt_numdom_empty());
     });
@@ -342,7 +340,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(8, 8));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(9, 10));
     });
@@ -357,7 +355,7 @@ describe('propagators/lt.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_ltStepBare(space, A, B);
+      propagator_ltStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(7, 7));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(8, 13));
     });

--- a/tests/specs/propagators/lt.spec.js
+++ b/tests/specs/propagators/lt.spec.js
@@ -48,7 +48,7 @@ describe('propagators/lt.spec', function() {
       config_addVarDomain(config, 'B', fixt_arrdom_range(200, 300));
       config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
       config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
       space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
       space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
@@ -63,7 +63,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 100));
       config_addVarDomain(config, 'B', fixt_arrdom_range(95, 99));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -78,7 +78,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, SUP));
       config_addVarDomain(config, 'B', fixt_arrdom_range(95, SUP));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -93,7 +93,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 100));
       config_addVarDomain(config, 'B', fixt_arrdom_range(101, 101));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -108,7 +108,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 150));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 200));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -123,7 +123,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(190, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 150));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -138,7 +138,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(200, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 300));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -153,7 +153,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(200, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(200, 300));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -168,7 +168,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [120, 150]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -179,7 +179,7 @@ describe('propagators/lt.spec', function() {
       config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [100, 150]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
-      space = space_createRoot(config);
+      space = space_createRoot();
       space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
@@ -190,7 +190,7 @@ describe('propagators/lt.spec', function() {
       config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [100, 100]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
-      space = space_createRoot(config);
+      space = space_createRoot();
       space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
@@ -203,7 +203,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60]));
       config_addVarDomain(config, 'B', fixt_arrdom_ranges([0, 10], [20, 100]));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -214,7 +214,7 @@ describe('propagators/lt.spec', function() {
       //config = config_create();
       //config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60]));
       //config_addVarDomain(config, 'B', fixt_arrdom_ranges([0, 5], [20, 100]));
-      //space = space_createRoot(config);
+      //space = space_createRoot();
       //space_initFromConfig(space, config);
       //propagator_ltStepBare(space, config, A, B);
       //expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60]));
@@ -223,7 +223,7 @@ describe('propagators/lt.spec', function() {
       //config = config_create();
       //config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60]));
       //config_addVarDomain(config, 'B', fixt_arrdom_ranges([10, 10], [20, 100]));
-      //space = space_createRoot(config);
+      //space = space_createRoot();
       //space_initFromConfig(space, config);
       //propagator_ltStepBare(space, config, A, B);
       //expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60]));
@@ -239,7 +239,7 @@ describe('propagators/lt.spec', function() {
       config_addVarRange(config, 'B', 11, 15);
       config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
       config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
       space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
       space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
@@ -259,7 +259,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 0, 10);
       config_addVarRange(config, 'B', 5, 9);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -274,7 +274,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 0, 15);
       config_addVarRange(config, 'B', 5, 15);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -289,7 +289,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 0, 10);
       config_addVarRange(config, 'B', 11, 15);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -304,7 +304,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 0, 13);
       config_addVarRange(config, 'B', 10, 15);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -319,7 +319,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 11, 15);
       config_addVarRange(config, 'B', 5, 8);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -334,7 +334,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 8, 8);
       config_addVarRange(config, 'B', 5, 10);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -349,7 +349,7 @@ describe('propagators/lt.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 7, 7);
       config_addVarRange(config, 'B', 7, 13);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');

--- a/tests/specs/propagators/lte.spec.js
+++ b/tests/specs/propagators/lte.spec.js
@@ -36,8 +36,6 @@ describe('propagators/lte.spec', function() {
   it('should require two vars', function() {
     let space = space_createRoot();
 
-    expect(() => propagator_lteStepBare()).to.throw('SHOULD_GET_SPACE');
-    expect(() => propagator_lteStepBare({})).to.throw('SHOULD_GET_SPACE');
     expect(() => propagator_lteStepBare(space, 'A')).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
     expect(() => propagator_lteStepBare(space, undefined, 'B')).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
   });
@@ -60,10 +58,10 @@ describe('propagators/lte.spec', function() {
       let C = config.all_var_names.indexOf('C');
       let D = config.all_var_names.indexOf('D');
 
-      expect(_ => propagator_lteStepBare(space, A, B)).not.to.throw();
-      expect(_ => propagator_lteStepBare(space, A, D)).to.throw('SHOULD_NOT_BE_REJECTED');
-      expect(_ => propagator_lteStepBare(space, C, B)).to.throw('SHOULD_NOT_BE_REJECTED');
-      expect(_ => propagator_lteStepBare(space, C, D)).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_lteStepBare(space, config, A, B)).not.to.throw();
+      expect(_ => propagator_lteStepBare(space, config, A, D)).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_lteStepBare(space, config, C, B)).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_lteStepBare(space, config, C, D)).to.throw('SHOULD_NOT_BE_REJECTED');
     });
 
     it('should remove any value from v1 that is gt to max(v2)', function() {
@@ -76,7 +74,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(90, 99));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(95, 99));
     });
@@ -91,7 +89,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(90, SUP));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(95, SUP));
     });
@@ -106,7 +104,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(90, 100));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(101, 101));
     });
@@ -121,7 +119,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(90, 150));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(100, 200));
     });
@@ -136,7 +134,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_empty());
       expect(space.vardoms[B]).to.eql(fixt_numdom_empty());
     });
@@ -151,7 +149,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(200, 200));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(200, 300));
     });
@@ -166,7 +164,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_range(200, 200));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(200, 300));
     });
@@ -179,7 +177,7 @@ describe('propagators/lte.spec', function() {
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60], [70, 98]));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(10, 100));
 
@@ -190,7 +188,7 @@ describe('propagators/lte.spec', function() {
       space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [100, 100]));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(10, 100));
 
@@ -201,7 +199,7 @@ describe('propagators/lte.spec', function() {
       space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [100, 100]));
       expect(space.vardoms[B]).to.eql(fixt_strdom_range(10, 100));
     });
@@ -214,7 +212,7 @@ describe('propagators/lte.spec', function() {
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60]));
       expect(space.vardoms[B]).to.eql(fixt_strdom_ranges([10, 10], [20, 100]));
 
@@ -225,7 +223,7 @@ describe('propagators/lte.spec', function() {
       space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60]));
       expect(space.vardoms[B]).to.eql(fixt_strdom_ranges([20, 100]));
 
@@ -236,7 +234,7 @@ describe('propagators/lte.spec', function() {
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
       space_initFromConfig(space, config);
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60]));
       expect(space.vardoms[B]).to.eql(fixt_strdom_ranges([10, 10], [20, 100]));
     });
@@ -260,10 +258,10 @@ describe('propagators/lte.spec', function() {
       let C = config.all_var_names.indexOf('C');
       let D = config.all_var_names.indexOf('D');
 
-      expect(_ => propagator_lteStepBare(space, A, B)).not.to.throw();
-      expect(_ => propagator_lteStepBare(space, A, D)).to.throw('SHOULD_NOT_BE_REJECTED');
-      expect(_ => propagator_lteStepBare(space, C, B)).to.throw('SHOULD_NOT_BE_REJECTED');
-      expect(_ => propagator_lteStepBare(space, C, D)).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_lteStepBare(space, config, A, B)).not.to.throw();
+      expect(_ => propagator_lteStepBare(space, config, A, D)).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_lteStepBare(space, config, C, B)).to.throw('SHOULD_NOT_BE_REJECTED');
+      expect(_ => propagator_lteStepBare(space, config, C, D)).to.throw('SHOULD_NOT_BE_REJECTED');
     });
 
     it('should remove any value from v1 that is gte to max(v2)', function() {
@@ -276,7 +274,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(0, 9));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(5, 9));
     });
@@ -291,7 +289,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(0, 15));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(5, 15));
     });
@@ -306,7 +304,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(0, 10));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(11, 15));
     });
@@ -321,7 +319,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(0, 13));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(10, 15));
     });
@@ -336,7 +334,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_empty());
       expect(space.vardoms[B]).to.eql(fixt_numdom_empty());
     });
@@ -351,7 +349,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(8, 8));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(8, 10));
     });
@@ -366,7 +364,7 @@ describe('propagators/lte.spec', function() {
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
 
-      propagator_lteStepBare(space, A, B);
+      propagator_lteStepBare(space, config, A, B);
       expect(space.vardoms[A]).to.eql(fixt_numdom_range(7, 7));
       expect(space.vardoms[B]).to.eql(fixt_numdom_range(7, 13));
     });

--- a/tests/specs/propagators/lte.spec.js
+++ b/tests/specs/propagators/lte.spec.js
@@ -48,7 +48,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'B', fixt_arrdom_range(200, 300));
       config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
       config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
       space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
       space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
@@ -68,7 +68,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 100));
       config_addVarDomain(config, 'B', fixt_arrdom_range(95, 99));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -83,7 +83,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, SUP));
       config_addVarDomain(config, 'B', fixt_arrdom_range(95, SUP));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -98,7 +98,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 100));
       config_addVarDomain(config, 'B', fixt_arrdom_range(101, 101));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -113,7 +113,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 150));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 200));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -128,7 +128,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(190, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 150));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -143,7 +143,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(200, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 300));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -158,7 +158,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_range(200, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(200, 300));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -173,7 +173,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [120, 150]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -184,7 +184,7 @@ describe('propagators/lte.spec', function() {
       config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [100, 150]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
-      space = space_createRoot(config);
+      space = space_createRoot();
       space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
@@ -195,7 +195,7 @@ describe('propagators/lte.spec', function() {
       config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [100, 100]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
-      space = space_createRoot(config);
+      space = space_createRoot();
       space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
@@ -208,7 +208,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60]));
       config_addVarDomain(config, 'B', fixt_arrdom_ranges([0, 10], [20, 100]));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -219,7 +219,7 @@ describe('propagators/lte.spec', function() {
       config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60]));
       config_addVarDomain(config, 'B', fixt_arrdom_ranges([0, 5], [20, 100]));
-      space = space_createRoot(config);
+      space = space_createRoot();
       space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
@@ -230,7 +230,7 @@ describe('propagators/lte.spec', function() {
       config = config_create();
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60]));
       config_addVarDomain(config, 'B', fixt_arrdom_ranges([10, 10], [20, 100]));
-      space = space_createRoot(config);
+      space = space_createRoot();
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
       space_initFromConfig(space, config);
@@ -248,7 +248,7 @@ describe('propagators/lte.spec', function() {
       config_addVarRange(config, 'B', 11, 15);
       config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
       config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
       space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
       space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
@@ -268,7 +268,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 0, 10);
       config_addVarRange(config, 'B', 5, 9);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -283,7 +283,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 0, 15);
       config_addVarRange(config, 'B', 5, 15);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -298,7 +298,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 0, 10);
       config_addVarRange(config, 'B', 11, 15);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -313,7 +313,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 0, 13);
       config_addVarRange(config, 'B', 10, 15);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -328,7 +328,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 11, 15);
       config_addVarRange(config, 'B', 5, 8);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -343,7 +343,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 8, 8);
       config_addVarRange(config, 'B', 5, 10);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
@@ -358,7 +358,7 @@ describe('propagators/lte.spec', function() {
       let config = config_create();
       config_addVarRange(config, 'A', 7, 7);
       config_addVarRange(config, 'B', 7, 13);
-      let space = space_createRoot(config);
+      let space = space_createRoot();
       space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');

--- a/tests/specs/propagators/lte.spec.js
+++ b/tests/specs/propagators/lte.spec.js
@@ -51,7 +51,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
       config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
       space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
 
@@ -71,7 +71,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 100));
       config_addVarDomain(config, 'B', fixt_arrdom_range(95, 99));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -86,7 +86,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, SUP));
       config_addVarDomain(config, 'B', fixt_arrdom_range(95, SUP));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -101,7 +101,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 100));
       config_addVarDomain(config, 'B', fixt_arrdom_range(101, 101));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -116,7 +116,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(90, 150));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 200));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -131,7 +131,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(190, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 150));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -146,7 +146,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(200, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(100, 300));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -161,7 +161,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_range(200, 200));
       config_addVarDomain(config, 'B', fixt_arrdom_range(200, 300));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -176,7 +176,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [120, 150]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
       propagator_lteStepBare(space, A, B);
@@ -187,7 +187,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [100, 150]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
       space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
       propagator_lteStepBare(space, A, B);
@@ -198,7 +198,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60], [70, 98], [100, 100]));
       config_addVarDomain(config, 'B', fixt_arrdom_range(0, 100));
       space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
       propagator_lteStepBare(space, A, B);
@@ -211,7 +211,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60]));
       config_addVarDomain(config, 'B', fixt_arrdom_ranges([0, 10], [20, 100]));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
       propagator_lteStepBare(space, A, B);
@@ -222,7 +222,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'A', fixt_arrdom_ranges([10, 20], [30, 40], [50, 60]));
       config_addVarDomain(config, 'B', fixt_arrdom_ranges([0, 5], [20, 100]));
       space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
       propagator_lteStepBare(space, A, B);
@@ -235,7 +235,7 @@ describe('propagators/lte.spec', function() {
       space = space_createRoot(config);
       A = config.all_var_names.indexOf('A');
       B = config.all_var_names.indexOf('B');
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       propagator_lteStepBare(space, A, B);
       expect(space.vardoms[A]).to.eql(fixt_strdom_ranges([10, 20], [30, 40], [50, 60]));
       expect(space.vardoms[B]).to.eql(fixt_strdom_ranges([10, 10], [20, 100]));
@@ -251,7 +251,7 @@ describe('propagators/lte.spec', function() {
       config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
       config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
       space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
       space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
 
@@ -271,7 +271,7 @@ describe('propagators/lte.spec', function() {
       config_addVarRange(config, 'A', 0, 10);
       config_addVarRange(config, 'B', 5, 9);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -286,7 +286,7 @@ describe('propagators/lte.spec', function() {
       config_addVarRange(config, 'A', 0, 15);
       config_addVarRange(config, 'B', 5, 15);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -301,7 +301,7 @@ describe('propagators/lte.spec', function() {
       config_addVarRange(config, 'A', 0, 10);
       config_addVarRange(config, 'B', 11, 15);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -316,7 +316,7 @@ describe('propagators/lte.spec', function() {
       config_addVarRange(config, 'A', 0, 13);
       config_addVarRange(config, 'B', 10, 15);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -331,7 +331,7 @@ describe('propagators/lte.spec', function() {
       config_addVarRange(config, 'A', 11, 15);
       config_addVarRange(config, 'B', 5, 8);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -346,7 +346,7 @@ describe('propagators/lte.spec', function() {
       config_addVarRange(config, 'A', 8, 8);
       config_addVarRange(config, 'B', 5, 10);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');
@@ -361,7 +361,7 @@ describe('propagators/lte.spec', function() {
       config_addVarRange(config, 'A', 7, 7);
       config_addVarRange(config, 'B', 7, 13);
       let space = space_createRoot(config);
-      space_initFromConfig(space);
+      space_initFromConfig(space, config);
 
       let A = config.all_var_names.indexOf('A');
       let B = config.all_var_names.indexOf('B');

--- a/tests/specs/propagators/markov.spec.js
+++ b/tests/specs/propagators/markov.spec.js
@@ -34,7 +34,7 @@ describe('propagators/markov.spec', function() {
       let Aindex = solver._space.config.all_var_names.indexOf('A');
 
       // A=0, which is in legend and has prob=1
-      propagator_markovStepBare(solver._space, Aindex);
+      propagator_markovStepBare(solver._space, solver.config, Aindex);
       expect(solver.getDomain(solver._space, Aindex)).to.eql(fixt_arrdom_nums(0));
     });
 
@@ -56,7 +56,7 @@ describe('propagators/markov.spec', function() {
       let Aindex = solver._space.config.all_var_names.indexOf('A');
 
       // A=0, which is not in legend
-      propagator_markovStepBare(solver._space, Aindex);
+      propagator_markovStepBare(solver._space, solver.config, Aindex);
       expect(solver.getDomain(solver._space, Aindex)).to.eql(fixt_arrdom_empty(1));
     });
 
@@ -80,7 +80,7 @@ describe('propagators/markov.spec', function() {
         let Aindex = solver._space.config.all_var_names.indexOf('A');
 
         // A=0, which is in legend but has prob=0
-        propagator_markovStepBare(solver._space, Aindex);
+        propagator_markovStepBare(solver._space, solver.config, Aindex);
         expect(solver.getDomain(solver._space, Aindex)).to.eql(fixt_arrdom_empty(1));
       });
 
@@ -102,7 +102,7 @@ describe('propagators/markov.spec', function() {
         let Aindex = solver._space.config.all_var_names.indexOf('A');
 
         // A=0, which is in legend and has prob=1
-        propagator_markovStepBare(solver._space, Aindex);
+        propagator_markovStepBare(solver._space, solver.config, Aindex);
         expect(solver.getDomain(solver._space, Aindex)).to.eql(fixt_arrdom_empty(1));
       });
     });
@@ -131,7 +131,7 @@ describe('propagators/markov.spec', function() {
 
         // A=0, which is in legend and has prob=0 in first row,
         // but only second row is considered which gives prob=1
-        propagator_markovStepBare(solver._space, Aindex);
+        propagator_markovStepBare(solver._space, solver.config, Aindex);
         expect(solver.getDomain(solver._space, Aindex)).to.eql(fixt_arrdom_nums(0));
       });
 
@@ -158,7 +158,7 @@ describe('propagators/markov.spec', function() {
 
         // A=0, which is in legend and has prob=1 in first row,
         // but only second row is considered which gives prob=0
-        propagator_markovStepBare(solver._space, Aindex);
+        propagator_markovStepBare(solver._space, solver.config, Aindex);
         expect(solver.getDomain(solver._space, Aindex)).to.eql(fixt_arrdom_empty(1));
       });
     });

--- a/tests/specs/propagators/markov.spec.js
+++ b/tests/specs/propagators/markov.spec.js
@@ -31,7 +31,7 @@ describe('propagators/markov.spec', function() {
       });
       solver._prepare({});
 
-      let Aindex = solver._space.config.all_var_names.indexOf('A');
+      let Aindex = solver.config.all_var_names.indexOf('A');
 
       // A=0, which is in legend and has prob=1
       propagator_markovStepBare(solver._space, solver.config, Aindex);
@@ -53,7 +53,7 @@ describe('propagators/markov.spec', function() {
       });
       solver._prepare({});
 
-      let Aindex = solver._space.config.all_var_names.indexOf('A');
+      let Aindex = solver.config.all_var_names.indexOf('A');
 
       // A=0, which is not in legend
       propagator_markovStepBare(solver._space, solver.config, Aindex);
@@ -77,7 +77,7 @@ describe('propagators/markov.spec', function() {
         });
         solver._prepare({});
 
-        let Aindex = solver._space.config.all_var_names.indexOf('A');
+        let Aindex = solver.config.all_var_names.indexOf('A');
 
         // A=0, which is in legend but has prob=0
         propagator_markovStepBare(solver._space, solver.config, Aindex);
@@ -99,7 +99,7 @@ describe('propagators/markov.spec', function() {
         });
         solver._prepare({});
 
-        let Aindex = solver._space.config.all_var_names.indexOf('A');
+        let Aindex = solver.config.all_var_names.indexOf('A');
 
         // A=0, which is in legend and has prob=1
         propagator_markovStepBare(solver._space, solver.config, Aindex);
@@ -127,7 +127,7 @@ describe('propagators/markov.spec', function() {
         });
         solver._prepare({});
 
-        let Aindex = solver._space.config.all_var_names.indexOf('A');
+        let Aindex = solver.config.all_var_names.indexOf('A');
 
         // A=0, which is in legend and has prob=0 in first row,
         // but only second row is considered which gives prob=1
@@ -154,7 +154,7 @@ describe('propagators/markov.spec', function() {
         });
         solver._prepare({});
 
-        let Aindex = solver._space.config.all_var_names.indexOf('A');
+        let Aindex = solver.config.all_var_names.indexOf('A');
 
         // A=0, which is in legend and has prob=1 in first row,
         // but only second row is considered which gives prob=0

--- a/tests/specs/propagators/neq.spec.js
+++ b/tests/specs/propagators/neq.spec.js
@@ -40,7 +40,7 @@ describe('propagators/neq.spec', function() {
     let config = config_create();
     config_addVarDomain(config, 'A', fixt_arrdom_nums(11, 15));
     config_addVarDomain(config, 'B', fixt_arrdom_nums(5, 8));
-    let space = space_createRoot(config);
+    let space = space_createRoot();
     space_initFromConfig(space, config);
 
     let A = config.all_var_names.indexOf('A');
@@ -60,7 +60,7 @@ describe('propagators/neq.spec', function() {
     config_addVarDomain(config, 'B', fixt_arrdom_nums(11, 15));
     config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
     config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
-    let space = space_createRoot(config);
+    let space = space_createRoot();
     space_initFromConfig(space, config);
     space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
     space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
@@ -83,7 +83,7 @@ describe('propagators/neq.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', domain_any_clone(domain1, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain2, FORCE_ARRAY));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         let A = config.all_var_names.indexOf('A');
@@ -98,7 +98,7 @@ describe('propagators/neq.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', domain_any_clone(domain2, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain1, FORCE_ARRAY));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         let A = config.all_var_names.indexOf('A');
@@ -140,7 +140,7 @@ describe('propagators/neq.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', domain_any_clone(solvedDomain, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(unsolvedDomainBefore, FORCE_ARRAY));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         let A = config.all_var_names.indexOf('A');
@@ -155,7 +155,7 @@ describe('propagators/neq.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', domain_any_clone(unsolvedDomainBefore, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(solvedDomain, FORCE_ARRAY));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         let B = config.all_var_names.indexOf('B');
@@ -197,7 +197,7 @@ describe('propagators/neq.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', domain_any_clone(domain1, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain2, FORCE_ARRAY));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         let A = config.all_var_names.indexOf('A');
@@ -212,7 +212,7 @@ describe('propagators/neq.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', domain_any_clone(domain2, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain1, FORCE_ARRAY));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         let A = config.all_var_names.indexOf('A');
@@ -227,7 +227,7 @@ describe('propagators/neq.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', domain_any_clone(domain1, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain1, FORCE_ARRAY));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         let A = config.all_var_names.indexOf('A');
@@ -242,7 +242,7 @@ describe('propagators/neq.spec', function() {
         let config = config_create();
         config_addVarDomain(config, 'A', domain_any_clone(domain2, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain2, FORCE_ARRAY));
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         let A = config.all_var_names.indexOf('A');

--- a/tests/specs/propagators/neq.spec.js
+++ b/tests/specs/propagators/neq.spec.js
@@ -43,8 +43,8 @@ describe('propagators/neq.spec', function() {
     let space = space_createRoot(config);
     space_initFromConfig(space, config);
 
-    let A = space.config.all_var_names.indexOf('A');
-    let B = space.config.all_var_names.indexOf('B');
+    let A = config.all_var_names.indexOf('A');
+    let B = config.all_var_names.indexOf('B');
 
     expect(_ => propagator_neqStepBare(space, config, A, B)).not.to.throw();
     expect(_ => propagator_neqStepBare()).to.throw('SHOULD_GET_SPACE');
@@ -65,10 +65,10 @@ describe('propagators/neq.spec', function() {
     space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
     space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
 
-    let A = space.config.all_var_names.indexOf('A');
-    let B = space.config.all_var_names.indexOf('B');
-    let C = space.config.all_var_names.indexOf('C');
-    let D = space.config.all_var_names.indexOf('D');
+    let A = config.all_var_names.indexOf('A');
+    let B = config.all_var_names.indexOf('B');
+    let C = config.all_var_names.indexOf('C');
+    let D = config.all_var_names.indexOf('D');
 
     expect(_ => propagator_neqStepBare(space, config, A, B)).not.to.throw();
     expect(_ => propagator_neqStepBare(space, config, A, D)).to.throw('SHOULD_NOT_BE_REJECTED');
@@ -86,8 +86,8 @@ describe('propagators/neq.spec', function() {
         let space = space_createRoot(config);
         space_initFromConfig(space, config);
 
-        let A = space.config.all_var_names.indexOf('A');
-        let B = space.config.all_var_names.indexOf('B');
+        let A = config.all_var_names.indexOf('A');
+        let B = config.all_var_names.indexOf('B');
 
         propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(domain1);
@@ -101,8 +101,8 @@ describe('propagators/neq.spec', function() {
         let space = space_createRoot(config);
         space_initFromConfig(space, config);
 
-        let A = space.config.all_var_names.indexOf('A');
-        let B = space.config.all_var_names.indexOf('B');
+        let A = config.all_var_names.indexOf('A');
+        let B = config.all_var_names.indexOf('B');
 
         propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(domain2);
@@ -143,8 +143,8 @@ describe('propagators/neq.spec', function() {
         let space = space_createRoot(config);
         space_initFromConfig(space, config);
 
-        let A = space.config.all_var_names.indexOf('A');
-        let B = space.config.all_var_names.indexOf('B');
+        let A = config.all_var_names.indexOf('A');
+        let B = config.all_var_names.indexOf('B');
 
         propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(solvedDomain);
@@ -158,8 +158,8 @@ describe('propagators/neq.spec', function() {
         let space = space_createRoot(config);
         space_initFromConfig(space, config);
 
-        let A = space.config.all_var_names.indexOf('A');
-        let B = space.config.all_var_names.indexOf('B');
+        let B = config.all_var_names.indexOf('B');
+        let A = config.all_var_names.indexOf('A');
 
         propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(unsolvedDomainAfter);
@@ -200,8 +200,8 @@ describe('propagators/neq.spec', function() {
         let space = space_createRoot(config);
         space_initFromConfig(space, config);
 
-        let A = space.config.all_var_names.indexOf('A');
-        let B = space.config.all_var_names.indexOf('B');
+        let A = config.all_var_names.indexOf('A');
+        let B = config.all_var_names.indexOf('B');
 
         propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(domain1);
@@ -215,8 +215,8 @@ describe('propagators/neq.spec', function() {
         let space = space_createRoot(config);
         space_initFromConfig(space, config);
 
-        let A = space.config.all_var_names.indexOf('A');
-        let B = space.config.all_var_names.indexOf('B');
+        let A = config.all_var_names.indexOf('A');
+        let B = config.all_var_names.indexOf('B');
 
         propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(domain2);
@@ -230,8 +230,8 @@ describe('propagators/neq.spec', function() {
         let space = space_createRoot(config);
         space_initFromConfig(space, config);
 
-        let A = space.config.all_var_names.indexOf('A');
-        let B = space.config.all_var_names.indexOf('B');
+        let A = config.all_var_names.indexOf('A');
+        let B = config.all_var_names.indexOf('B');
 
         propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(fixt_numdom_empty());
@@ -245,8 +245,8 @@ describe('propagators/neq.spec', function() {
         let space = space_createRoot(config);
         space_initFromConfig(space, config);
 
-        let A = space.config.all_var_names.indexOf('A');
-        let B = space.config.all_var_names.indexOf('B');
+        let A = config.all_var_names.indexOf('A');
+        let B = config.all_var_names.indexOf('B');
 
         propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(fixt_numdom_empty());

--- a/tests/specs/propagators/neq.spec.js
+++ b/tests/specs/propagators/neq.spec.js
@@ -46,10 +46,10 @@ describe('propagators/neq.spec', function() {
     let A = space.config.all_var_names.indexOf('A');
     let B = space.config.all_var_names.indexOf('B');
 
-    expect(_ => propagator_neqStepBare(space, A, B)).not.to.throw();
+    expect(_ => propagator_neqStepBare(space, config, A, B)).not.to.throw();
     expect(_ => propagator_neqStepBare()).to.throw('SHOULD_GET_SPACE');
     expect(_ => propagator_neqStepBare(space)).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
-    expect(_ => propagator_neqStepBare(space, A)).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
+    expect(_ => propagator_neqStepBare(space, config, A)).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
     expect(_ => propagator_neqStepBare(space, undefined, B)).to.throw('VAR_INDEX_SHOULD_BE_NUMBER');
     expect(_ => propagator_neqStepBare(undefined, A, B)).to.throw('SHOULD_GET_SPACE');
   });
@@ -70,10 +70,10 @@ describe('propagators/neq.spec', function() {
     let C = space.config.all_var_names.indexOf('C');
     let D = space.config.all_var_names.indexOf('D');
 
-    expect(_ => propagator_neqStepBare(space, A, B)).not.to.throw();
-    expect(_ => propagator_neqStepBare(space, A, D)).to.throw('SHOULD_NOT_BE_REJECTED');
-    expect(_ => propagator_neqStepBare(space, C, B)).to.throw('SHOULD_NOT_BE_REJECTED');
-    expect(_ => propagator_neqStepBare(space, C, D)).to.throw('SHOULD_NOT_BE_REJECTED');
+    expect(_ => propagator_neqStepBare(space, config, A, B)).not.to.throw();
+    expect(_ => propagator_neqStepBare(space, config, A, D)).to.throw('SHOULD_NOT_BE_REJECTED');
+    expect(_ => propagator_neqStepBare(space, config, C, B)).to.throw('SHOULD_NOT_BE_REJECTED');
+    expect(_ => propagator_neqStepBare(space, config, C, D)).to.throw('SHOULD_NOT_BE_REJECTED');
   });
 
   describe('should not change anything as long as both domains are unsolved', function() {
@@ -89,7 +89,7 @@ describe('propagators/neq.spec', function() {
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
 
-        propagator_neqStepBare(space, A, B);
+        propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(domain1);
         expect(space.vardoms[B]).to.eql(domain2);
       });
@@ -104,7 +104,7 @@ describe('propagators/neq.spec', function() {
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
 
-        propagator_neqStepBare(space, A, B);
+        propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(domain2);
         expect(space.vardoms[B]).to.eql(domain1);
       });
@@ -146,7 +146,7 @@ describe('propagators/neq.spec', function() {
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
 
-        propagator_neqStepBare(space, A, B);
+        propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(solvedDomain);
         expect(space.vardoms[B]).to.eql(unsolvedDomainAfter);
       });
@@ -161,7 +161,7 @@ describe('propagators/neq.spec', function() {
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
 
-        propagator_neqStepBare(space, A, B);
+        propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(unsolvedDomainAfter);
         expect(space.vardoms[B]).to.eql(solvedDomain);
       });
@@ -203,7 +203,7 @@ describe('propagators/neq.spec', function() {
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
 
-        propagator_neqStepBare(space, A, B);
+        propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(domain1);
         expect(space.vardoms[B]).to.eql(domain2);
       });
@@ -218,7 +218,7 @@ describe('propagators/neq.spec', function() {
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
 
-        propagator_neqStepBare(space, A, B);
+        propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(domain2);
         expect(space.vardoms[B]).to.eql(domain1);
       });
@@ -233,7 +233,7 @@ describe('propagators/neq.spec', function() {
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
 
-        propagator_neqStepBare(space, A, B);
+        propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(fixt_numdom_empty());
         expect(space.vardoms[B]).to.eql(fixt_numdom_empty());
       });
@@ -248,7 +248,7 @@ describe('propagators/neq.spec', function() {
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
 
-        propagator_neqStepBare(space, A, B);
+        propagator_neqStepBare(space, config, A, B);
         expect(space.vardoms[A]).to.eql(fixt_numdom_empty());
         expect(space.vardoms[B]).to.eql(fixt_numdom_empty());
       });

--- a/tests/specs/propagators/neq.spec.js
+++ b/tests/specs/propagators/neq.spec.js
@@ -41,7 +41,7 @@ describe('propagators/neq.spec', function() {
     config_addVarDomain(config, 'A', fixt_arrdom_nums(11, 15));
     config_addVarDomain(config, 'B', fixt_arrdom_nums(5, 8));
     let space = space_createRoot(config);
-    space_initFromConfig(space);
+    space_initFromConfig(space, config);
 
     let A = space.config.all_var_names.indexOf('A');
     let B = space.config.all_var_names.indexOf('B');
@@ -61,7 +61,7 @@ describe('propagators/neq.spec', function() {
     config_addVarDomain(config, 'C', fixt_arrdom_nums(100));
     config_addVarDomain(config, 'D', fixt_arrdom_nums(100));
     let space = space_createRoot(config);
-    space_initFromConfig(space);
+    space_initFromConfig(space, config);
     space.vardoms[config.all_var_names.indexOf('C')] = fixt_numdom_empty();
     space.vardoms[config.all_var_names.indexOf('D')] = fixt_numdom_empty();
 
@@ -84,7 +84,7 @@ describe('propagators/neq.spec', function() {
         config_addVarDomain(config, 'A', domain_any_clone(domain1, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain2, FORCE_ARRAY));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
@@ -99,7 +99,7 @@ describe('propagators/neq.spec', function() {
         config_addVarDomain(config, 'A', domain_any_clone(domain2, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain1, FORCE_ARRAY));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
@@ -141,7 +141,7 @@ describe('propagators/neq.spec', function() {
         config_addVarDomain(config, 'A', domain_any_clone(solvedDomain, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(unsolvedDomainBefore, FORCE_ARRAY));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
@@ -156,7 +156,7 @@ describe('propagators/neq.spec', function() {
         config_addVarDomain(config, 'A', domain_any_clone(unsolvedDomainBefore, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(solvedDomain, FORCE_ARRAY));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
@@ -198,7 +198,7 @@ describe('propagators/neq.spec', function() {
         config_addVarDomain(config, 'A', domain_any_clone(domain1, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain2, FORCE_ARRAY));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
@@ -213,7 +213,7 @@ describe('propagators/neq.spec', function() {
         config_addVarDomain(config, 'A', domain_any_clone(domain2, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain1, FORCE_ARRAY));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
@@ -228,7 +228,7 @@ describe('propagators/neq.spec', function() {
         config_addVarDomain(config, 'A', domain_any_clone(domain1, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain1, FORCE_ARRAY));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');
@@ -243,7 +243,7 @@ describe('propagators/neq.spec', function() {
         config_addVarDomain(config, 'A', domain_any_clone(domain2, FORCE_ARRAY));
         config_addVarDomain(config, 'B', domain_any_clone(domain2, FORCE_ARRAY));
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         let A = space.config.all_var_names.indexOf('A');
         let B = space.config.all_var_names.indexOf('B');

--- a/tests/specs/propagators/reified.spec.js
+++ b/tests/specs/propagators/reified.spec.js
@@ -58,7 +58,7 @@ describe('propagators/reified.spec', function() {
           config_addVarDomain(config, 'A', domain_any_clone(A_in, FORCE_ARRAY));
           config_addVarDomain(config, 'B', domain_any_clone(B_in, FORCE_ARRAY));
           config_addVarDomain(config, 'bool', domain_any_clone(bool_in, FORCE_ARRAY));
-          let space = space_createRoot(config);
+          let space = space_createRoot();
           space_initFromConfig(space, config);
 
           expect(op === 'eq' || op === 'neq', 'if this breaks just update the test and update the new values').to.equal(true);

--- a/tests/specs/propagators/reified.spec.js
+++ b/tests/specs/propagators/reified.spec.js
@@ -59,7 +59,7 @@ describe('propagators/reified.spec', function() {
           config_addVarDomain(config, 'B', domain_any_clone(B_in, FORCE_ARRAY));
           config_addVarDomain(config, 'bool', domain_any_clone(bool_in, FORCE_ARRAY));
           let space = space_createRoot(config);
-          space_initFromConfig(space);
+          space_initFromConfig(space, config);
 
           expect(op === 'eq' || op === 'neq', 'if this breaks just update the test and update the new values').to.equal(true);
           let opFunc = op === 'eq' ? propagator_eqStepBare : propagator_neqStepBare;

--- a/tests/specs/propagators/reified.spec.js
+++ b/tests/specs/propagators/reified.spec.js
@@ -67,9 +67,9 @@ describe('propagators/reified.spec', function() {
           let rejectsOp = op === 'eq' ? propagator_eqStepWouldReject : propagator_neqStepWouldReject;
           let rejectsNop = op !== 'eq' ? propagator_eqStepWouldReject : propagator_neqStepWouldReject;
 
-          let A = space.config.all_var_names.indexOf('A');
-          let B = space.config.all_var_names.indexOf('B');
-          let bool = space.config.all_var_names.indexOf('bool');
+          let A = config.all_var_names.indexOf('A');
+          let B = config.all_var_names.indexOf('B');
+          let bool = config.all_var_names.indexOf('bool');
           propagator_reifiedStepBare(space, config, A, B, bool, opFunc, nopFunc, op, invop, rejectsOp, rejectsNop);
 
           expect(space.vardoms[A], 'A should be unchanged').to.eql(A_in);

--- a/tests/specs/propagators/reified.spec.js
+++ b/tests/specs/propagators/reified.spec.js
@@ -70,7 +70,7 @@ describe('propagators/reified.spec', function() {
           let A = space.config.all_var_names.indexOf('A');
           let B = space.config.all_var_names.indexOf('B');
           let bool = space.config.all_var_names.indexOf('bool');
-          propagator_reifiedStepBare(space, A, B, bool, opFunc, nopFunc, op, invop, rejectsOp, rejectsNop);
+          propagator_reifiedStepBare(space, config, A, B, bool, opFunc, nopFunc, op, invop, rejectsOp, rejectsNop);
 
           expect(space.vardoms[A], 'A should be unchanged').to.eql(A_in);
           expect(space.vardoms[B], 'B should be unchanged').to.eql(B_in);

--- a/tests/specs/space.spec.js
+++ b/tests/specs/space.spec.js
@@ -145,7 +145,7 @@ describe('src/space.spec', function() {
       it('should return true if there are no vars', function() {
         let space = space_createRoot();
         space_initFromConfig(space, space.config);
-        expect(space_updateUnsolvedVarList(space)).to.equal(true);
+        expect(space_updateUnsolvedVarList(space, space.config)).to.equal(true);
       });
 
       it('should return true if all 1 vars are solved', function() {
@@ -153,7 +153,7 @@ describe('src/space.spec', function() {
         config_addVarAnonConstant(space.config, 1);
         space_initFromConfig(space, space.config);
 
-        expect(space_updateUnsolvedVarList(space), 'only one solved var').to.equal(true);
+        expect(space_updateUnsolvedVarList(space, space.config), 'only one solved var').to.equal(true);
       });
 
       it('should return true if all 2 vars are solved', function() {
@@ -162,7 +162,7 @@ describe('src/space.spec', function() {
         config_addVarAnonConstant(space.config, 1);
         space_initFromConfig(space, space.config);
 
-        expect(space_updateUnsolvedVarList(space), 'two solved vars').to.equal(true);
+        expect(space_updateUnsolvedVarList(space, space.config), 'two solved vars').to.equal(true);
       });
 
       it('should return false if one var is not solved and is targeted', function() {
@@ -171,7 +171,7 @@ describe('src/space.spec', function() {
         space.config.targetedVars = space.config.all_var_names.slice(0);
         space_initFromConfig(space, space.config);
 
-        expect(space_updateUnsolvedVarList(space), 'only one unsolved var').to.equal(false);
+        expect(space_updateUnsolvedVarList(space, space.config), 'only one unsolved var').to.equal(false);
       });
 
       it('should have no unsolved var indexes if explicitly targeting no vars', function() {
@@ -190,7 +190,7 @@ describe('src/space.spec', function() {
         space.config.targetedVars = space.config.all_var_names.slice(0);
         space_initFromConfig(space, space.config);
 
-        expect(space_updateUnsolvedVarList(space), 'two unsolved vars').to.equal(false);
+        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars').to.equal(false);
       });
 
       it('should return false if at least one var of two is not solved and not targeted', function() {
@@ -199,7 +199,7 @@ describe('src/space.spec', function() {
         config_addVarAnonRange(space.config, 0, 1);
         space_initFromConfig(space, space.config);
 
-        expect(space_updateUnsolvedVarList(space), 'two unsolved vars').to.equal(true);
+        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars').to.equal(true);
       });
 
       it('should return false if at least one var of three is not solved and all targeted', function() {
@@ -210,7 +210,7 @@ describe('src/space.spec', function() {
         space.config.targetedVars = space.config.all_var_names.slice(0);
         space_initFromConfig(space, space.config);
 
-        expect(space_updateUnsolvedVarList(space), 'two unsolved vars and a solved var').to.equal(false);
+        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars and a solved var').to.equal(false);
       });
 
       it('should return false if at least one var of three is not solved and not targeted', function() {
@@ -220,7 +220,7 @@ describe('src/space.spec', function() {
         config_addVarAnonConstant(space.config, 1);
         space_initFromConfig(space, space.config);
 
-        expect(space_updateUnsolvedVarList(space), 'two unsolved vars and a solved var').to.equal(true);
+        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars and a solved var').to.equal(true);
       });
 
       it('should return false if at least one var of three is not solved and only that one not is targeted', function() {
@@ -231,7 +231,7 @@ describe('src/space.spec', function() {
         space.config.targetedVars = [space.config.all_var_names[A]];
         space_initFromConfig(space, space.config);
 
-        expect(space_updateUnsolvedVarList(space), 'two unsolved vars and a solved var').to.equal(true);
+        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars and a solved var').to.equal(true);
       });
 
       it('should return false if at least one var of three is not solved and that one is targeted', function() {
@@ -242,7 +242,7 @@ describe('src/space.spec', function() {
         space.config.targetedVars = [space.config.all_var_names[A], space.config.all_var_names[B]];
         space_initFromConfig(space, space.config);
 
-        expect(space_updateUnsolvedVarList(space), 'two unsolved vars and a solved var').to.equal(false);
+        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars and a solved var').to.equal(false);
       });
     });
 

--- a/tests/specs/space.spec.js
+++ b/tests/specs/space.spec.js
@@ -55,15 +55,14 @@ describe('src/space.spec', function() {
 
       it('should init vars and var_names', function() {
         expect(space_createRoot().vardoms).to.be.an('array');
-        expect(space_createRoot().config.all_var_names).to.be.an('array');
       });
     });
 
     describe('space_createClone()', function() {
 
       let config = config_create();
-      let space = space_createRoot(config);
-      let clone = space_createClone(space, config);
+      let space = space_createRoot();
+      let clone = space_createClone(space);
 
       it('should return a new space', function() {
         expect(clone).to.not.equal(space);
@@ -82,11 +81,6 @@ describe('src/space.spec', function() {
           expect(clone.vardoms[varName]).to.eql(space.vardoms[varName]);
         }
       });
-
-      // note: the deep clone check is already done above, no need to repeat it
-      it('should clone certain props, copy others', function() {
-        expect(config).to.equal(clone.config);
-      });
     });
 
     describe('targeted vars', function() {
@@ -98,7 +92,7 @@ describe('src/space.spec', function() {
         config_addVarRange(config, 'C', 0, 1);
         config.targetedVars = 'all';
 
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         expect(space_getUnsolvedVarCount(space, config)).to.eql(0);
@@ -110,7 +104,7 @@ describe('src/space.spec', function() {
         config_addVarRange(config, 'B', 0, 1);
         config.targetedVars = ['A', 'B'];
 
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         expect(_space_getUnsolvedVarNamesFresh(space, config).sort()).to.eql(['A', 'B']);
@@ -123,7 +117,7 @@ describe('src/space.spec', function() {
         config_addVarRange(config, 'B', 0, 1);
         config.targetedVars = targets.slice(0);
 
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
 
         expect(_space_getUnsolvedVarNamesFresh(space, config).sort()).to.eql(targets.sort());
@@ -136,7 +130,7 @@ describe('src/space.spec', function() {
         config_addVarRange(config, 'C', 0, 1);
         config.targetedVars = ['FAIL'];
 
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         expect(_ => space_initFromConfig(space, config)).to.throw('E_TARGETED_VARS_SHOULD_EXIST_NOW');
       });
     });
@@ -145,14 +139,14 @@ describe('src/space.spec', function() {
 
       it('should return true if there are no vars', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         expect(space_updateUnsolvedVarList(space, config)).to.equal(true);
       });
 
       it('should return true if all 1 vars are solved', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarAnonConstant(config, 1);
         space_initFromConfig(space, config);
 
@@ -161,7 +155,7 @@ describe('src/space.spec', function() {
 
       it('should return true if all 2 vars are solved', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarAnonConstant(config, 1);
         config_addVarAnonConstant(config, 1);
         space_initFromConfig(space, config);
@@ -171,7 +165,7 @@ describe('src/space.spec', function() {
 
       it('should return false if one var is not solved and is targeted', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarAnonRange(config, 0, 1);
         config.targetedVars = config.all_var_names.slice(0);
         space_initFromConfig(space, config);
@@ -181,7 +175,7 @@ describe('src/space.spec', function() {
 
       it('should have no unsolved var indexes if explicitly targeting no vars', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarAnonRange(config, 0, 1);
         config.targetedVars = [];
         space_initFromConfig(space, config);
@@ -191,7 +185,7 @@ describe('src/space.spec', function() {
 
       it('should return false if at least one var of two is not solved and targeted', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarAnonRange(config, 0, 1);
         config_addVarAnonRange(config, 0, 1);
         config.targetedVars = config.all_var_names.slice(0);
@@ -202,7 +196,7 @@ describe('src/space.spec', function() {
 
       it('should return false if at least one var of two is not solved and not targeted', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarAnonRange(config, 0, 1);
         config_addVarAnonRange(config, 0, 1);
         space_initFromConfig(space, config);
@@ -212,7 +206,7 @@ describe('src/space.spec', function() {
 
       it('should return false if at least one var of three is not solved and all targeted', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarAnonRange(config, 0, 1);
         config_addVarAnonRange(config, 0, 1);
         config_addVarAnonConstant(config, 1);
@@ -224,7 +218,7 @@ describe('src/space.spec', function() {
 
       it('should return false if at least one var of three is not solved and not targeted', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarAnonRange(config, 0, 1);
         config_addVarAnonRange(config, 0, 1);
         config_addVarAnonConstant(config, 1);
@@ -235,7 +229,7 @@ describe('src/space.spec', function() {
 
       it('should return false if at least one var of three is not solved and only that one not is targeted', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarAnonRange(config, 0, 1);
         config_addVarAnonRange(config, 0, 1);
         let A = config_addVarAnonConstant(config, 1);
@@ -247,7 +241,7 @@ describe('src/space.spec', function() {
 
       it('should return false if at least one var of three is not solved and that one is targeted', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         let A = config_addVarAnonRange(config, 0, 1);
         let B = config_addVarAnonRange(config, 0, 1);
         config_addVarAnonConstant(config, 1);
@@ -262,19 +256,19 @@ describe('src/space.spec', function() {
 
       it('should return an object, not array', function() {
         let config = config_create();
-        expect(space_solution(space_createRoot(config), config)).to.be.an('object');
-        expect(space_solution(space_createRoot(config), config)).not.to.be.an('array');
+        expect(space_solution(space_createRoot(), config)).to.be.an('object');
+        expect(space_solution(space_createRoot(), config)).not.to.be.an('array');
       });
 
       it('should return an empty object if there are no vars', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         expect(space_solution(space, config)).to.eql({});
       });
 
       it('should return false if a var covers no (more) elements', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarDomain(config, 'test', fixt_arrdom_nums(100));
         space_initFromConfig(space, config);
         space.vardoms[config.all_var_names.indexOf('test')] = fixt_numdom_empty();
@@ -284,7 +278,7 @@ describe('src/space.spec', function() {
 
       it('should return the value of a var is solved', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarDomain(config, 'test', fixt_arrdom_value(5, true));
         space_initFromConfig(space, config);
 
@@ -293,7 +287,7 @@ describe('src/space.spec', function() {
 
       it('should return the domain of a var if not yet determined', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarRange(config, 'single_range', 10, 120);
         config_addVarDomain(config, 'multi_range', fixt_arrdom_ranges([10, 20], [30, 40]));
         config_addVarDomain(config, 'multi_range_with_solved', fixt_arrdom_ranges([18, 20], [25, 25], [30, 40]));
@@ -308,7 +302,7 @@ describe('src/space.spec', function() {
 
       it('should not add anonymous vars to the result', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         config_addVarAnonConstant(config, 15);
         config_addVarConstant(config, 'addme', 20);
         space_initFromConfig(space, config);
@@ -321,7 +315,7 @@ describe('src/space.spec', function() {
 
       it('should convert a space to its config', function() {
         let config = config_create();
-        let space = space_createRoot(config);
+        let space = space_createRoot();
         space_initFromConfig(space, config);
         let config2 = config_create(); // fresh config object
 
@@ -332,7 +326,7 @@ describe('src/space.spec', function() {
 
       it('should convert a space with a var without domain', function() {
         let config = config_create();
-        let space = space_createRoot(config); // fresh space object
+        let space = space_createRoot(); // fresh space object
         config_addVarNothing(config, 'A'); // becomes [SUB SUP]
         space_initFromConfig(space, config);
 
@@ -349,7 +343,7 @@ describe('src/space.spec', function() {
 
         it('should not reject this multiply case', function() {
           let config = config_create();
-          let space = space_createRoot(config);
+          let space = space_createRoot();
 
           config_addVarRange(config, 'A', 0, 10);
           config_addVarRange(config, 'B', 0, 10);
@@ -369,7 +363,7 @@ describe('src/space.spec', function() {
 
         it('step 0; two bools at start of search', function() {
           let config = config_create();
-          let space = space_createRoot(config);
+          let space = space_createRoot();
 
           config_addVarRange(config, 'A', 0, 1);
           config_addVarRange(config, 'B', 0, 1);
@@ -389,7 +383,7 @@ describe('src/space.spec', function() {
 
         it('step 1; first bool updated', function() {
           let config = config_create();
-          let space = space_createRoot(config);
+          let space = space_createRoot();
 
           config_addVarRange(config, 'A', 0, 0);
           config_addVarRange(config, 'B', 0, 1);
@@ -410,7 +404,7 @@ describe('src/space.spec', function() {
 
         it('step 1; second bool updated', function() {
           let config = config_create();
-          let space = space_createRoot(config);
+          let space = space_createRoot();
 
           config_addVarRange(config, 'A', 0, 1);
           config_addVarRange(config, 'B', 0, 0);
@@ -436,7 +430,7 @@ describe('src/space.spec', function() {
           // (base timeout callback test)
 
           let config = config_create();
-          let space = space_createRoot(config);
+          let space = space_createRoot();
 
           config_addVarRange(config, 'A', 0, 10);
           config_addVarRange(config, 'B', 0, 10);
@@ -449,7 +443,7 @@ describe('src/space.spec', function() {
 
         it('should not break early if callback doesnt return true', function() {
           let config = config_create();
-          let space = space_createRoot(config);
+          let space = space_createRoot();
 
           config_addVarRange(config, 'A', 0, 10);
           config_addVarRange(config, 'B', 0, 10);
@@ -464,7 +458,7 @@ describe('src/space.spec', function() {
 
         it('should break early if callback returns true', function() {
           let config = config_create();
-          let space = space_createRoot(config);
+          let space = space_createRoot();
 
           config_addVarRange(config, 'A', 0, 10);
           config_addVarRange(config, 'B', 0, 10);

--- a/tests/specs/space.spec.js
+++ b/tests/specs/space.spec.js
@@ -61,8 +61,9 @@ describe('src/space.spec', function() {
 
     describe('space_createClone()', function() {
 
-      let space = space_createRoot();
-      let clone = space_createClone(space, space.config);
+      let config = config_create();
+      let space = space_createRoot(config);
+      let clone = space_createClone(space, config);
 
       it('should return a new space', function() {
         expect(clone).to.not.equal(space);
@@ -73,9 +74,9 @@ describe('src/space.spec', function() {
       });
 
       it('should deep clone the vars', function() {
-        //for var_name in space.config.all_var_names
-        for (let i = 0; i < space.config.all_var_names.length; ++i) {
-          let varName = space.config.all_var_names[i];
+        //for var_name in config.all_var_names
+        for (let i = 0; i < config.all_var_names.length; ++i) {
+          let varName = config.all_var_names[i];
 
           if (typeof clone.vardoms[varName] !== 'number') expect(clone.vardoms[varName]).to.not.equal(space.vardoms[varName]);
           expect(clone.vardoms[varName]).to.eql(space.vardoms[varName]);
@@ -84,7 +85,7 @@ describe('src/space.spec', function() {
 
       // note: the deep clone check is already done above, no need to repeat it
       it('should clone certain props, copy others', function() {
-        expect(space.config).to.equal(clone.config);
+        expect(config).to.equal(clone.config);
       });
     });
 
@@ -143,147 +144,162 @@ describe('src/space.spec', function() {
     describe('space_isSolved()', function() {
 
       it('should return true if there are no vars', function() {
-        let space = space_createRoot();
-        space_initFromConfig(space, space.config);
-        expect(space_updateUnsolvedVarList(space, space.config)).to.equal(true);
+        let config = config_create();
+        let space = space_createRoot(config);
+        space_initFromConfig(space, config);
+        expect(space_updateUnsolvedVarList(space, config)).to.equal(true);
       });
 
       it('should return true if all 1 vars are solved', function() {
-        let space = space_createRoot();
-        config_addVarAnonConstant(space.config, 1);
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarAnonConstant(config, 1);
+        space_initFromConfig(space, config);
 
-        expect(space_updateUnsolvedVarList(space, space.config), 'only one solved var').to.equal(true);
+        expect(space_updateUnsolvedVarList(space, config), 'only one solved var').to.equal(true);
       });
 
       it('should return true if all 2 vars are solved', function() {
-        let space = space_createRoot();
-        config_addVarAnonConstant(space.config, 1);
-        config_addVarAnonConstant(space.config, 1);
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarAnonConstant(config, 1);
+        config_addVarAnonConstant(config, 1);
+        space_initFromConfig(space, config);
 
-        expect(space_updateUnsolvedVarList(space, space.config), 'two solved vars').to.equal(true);
+        expect(space_updateUnsolvedVarList(space, config), 'two solved vars').to.equal(true);
       });
 
       it('should return false if one var is not solved and is targeted', function() {
-        let space = space_createRoot();
-        config_addVarAnonRange(space.config, 0, 1);
-        space.config.targetedVars = space.config.all_var_names.slice(0);
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarAnonRange(config, 0, 1);
+        config.targetedVars = config.all_var_names.slice(0);
+        space_initFromConfig(space, config);
 
-        expect(space_updateUnsolvedVarList(space, space.config), 'only one unsolved var').to.equal(false);
+        expect(space_updateUnsolvedVarList(space, config), 'only one unsolved var').to.equal(false);
       });
 
       it('should have no unsolved var indexes if explicitly targeting no vars', function() {
-        let space = space_createRoot();
-        config_addVarAnonRange(space.config, 0, 1);
-        space.config.targetedVars = [];
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarAnonRange(config, 0, 1);
+        config.targetedVars = [];
+        space_initFromConfig(space, config);
 
-        expect(space_getUnsolvedVarCount(space, space.config), 'unsolved vars to solve').to.equal(0);
+        expect(space_getUnsolvedVarCount(space, config), 'unsolved vars to solve').to.equal(0);
       });
 
       it('should return false if at least one var of two is not solved and targeted', function() {
-        let space = space_createRoot();
-        config_addVarAnonRange(space.config, 0, 1);
-        config_addVarAnonRange(space.config, 0, 1);
-        space.config.targetedVars = space.config.all_var_names.slice(0);
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarAnonRange(config, 0, 1);
+        config_addVarAnonRange(config, 0, 1);
+        config.targetedVars = config.all_var_names.slice(0);
+        space_initFromConfig(space, config);
 
-        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars').to.equal(false);
+        expect(space_updateUnsolvedVarList(space, config), 'two unsolved vars').to.equal(false);
       });
 
       it('should return false if at least one var of two is not solved and not targeted', function() {
-        let space = space_createRoot();
-        config_addVarAnonRange(space.config, 0, 1);
-        config_addVarAnonRange(space.config, 0, 1);
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarAnonRange(config, 0, 1);
+        config_addVarAnonRange(config, 0, 1);
+        space_initFromConfig(space, config);
 
-        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars').to.equal(true);
+        expect(space_updateUnsolvedVarList(space, config), 'two unsolved vars').to.equal(true);
       });
 
       it('should return false if at least one var of three is not solved and all targeted', function() {
-        let space = space_createRoot();
-        config_addVarAnonRange(space.config, 0, 1);
-        config_addVarAnonRange(space.config, 0, 1);
-        config_addVarAnonConstant(space.config, 1);
-        space.config.targetedVars = space.config.all_var_names.slice(0);
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarAnonRange(config, 0, 1);
+        config_addVarAnonRange(config, 0, 1);
+        config_addVarAnonConstant(config, 1);
+        config.targetedVars = config.all_var_names.slice(0);
+        space_initFromConfig(space, config);
 
-        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars and a solved var').to.equal(false);
+        expect(space_updateUnsolvedVarList(space, config), 'two unsolved vars and a solved var').to.equal(false);
       });
 
       it('should return false if at least one var of three is not solved and not targeted', function() {
-        let space = space_createRoot();
-        config_addVarAnonRange(space.config, 0, 1);
-        config_addVarAnonRange(space.config, 0, 1);
-        config_addVarAnonConstant(space.config, 1);
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarAnonRange(config, 0, 1);
+        config_addVarAnonRange(config, 0, 1);
+        config_addVarAnonConstant(config, 1);
+        space_initFromConfig(space, config);
 
-        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars and a solved var').to.equal(true);
+        expect(space_updateUnsolvedVarList(space, config), 'two unsolved vars and a solved var').to.equal(true);
       });
 
       it('should return false if at least one var of three is not solved and only that one not is targeted', function() {
-        let space = space_createRoot();
-        config_addVarAnonRange(space.config, 0, 1);
-        config_addVarAnonRange(space.config, 0, 1);
-        let A = config_addVarAnonConstant(space.config, 1);
-        space.config.targetedVars = [space.config.all_var_names[A]];
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarAnonRange(config, 0, 1);
+        config_addVarAnonRange(config, 0, 1);
+        let A = config_addVarAnonConstant(config, 1);
+        config.targetedVars = [config.all_var_names[A]];
+        space_initFromConfig(space, config);
 
-        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars and a solved var').to.equal(true);
+        expect(space_updateUnsolvedVarList(space, config), 'two unsolved vars and a solved var').to.equal(true);
       });
 
       it('should return false if at least one var of three is not solved and that one is targeted', function() {
-        let space = space_createRoot();
-        let A = config_addVarAnonRange(space.config, 0, 1);
-        let B = config_addVarAnonRange(space.config, 0, 1);
-        config_addVarAnonConstant(space.config, 1);
-        space.config.targetedVars = [space.config.all_var_names[A], space.config.all_var_names[B]];
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        let A = config_addVarAnonRange(config, 0, 1);
+        let B = config_addVarAnonRange(config, 0, 1);
+        config_addVarAnonConstant(config, 1);
+        config.targetedVars = [config.all_var_names[A], config.all_var_names[B]];
+        space_initFromConfig(space, config);
 
-        expect(space_updateUnsolvedVarList(space, space.config), 'two unsolved vars and a solved var').to.equal(false);
+        expect(space_updateUnsolvedVarList(space, config), 'two unsolved vars and a solved var').to.equal(false);
       });
     });
 
     describe('space_solution()', function() {
 
       it('should return an object, not array', function() {
-        let space;
-        expect(space_solution(space = space_createRoot(), space.config)).to.be.an('object');
-        expect(space_solution(space = space_createRoot(), space.config)).not.to.be.an('array');
+        let config = config_create();
+        expect(space_solution(space_createRoot(config), config)).to.be.an('object');
+        expect(space_solution(space_createRoot(config), config)).not.to.be.an('array');
       });
 
       it('should return an empty object if there are no vars', function() {
-        let space = space_createRoot();
-        expect(space_solution(space, space.config)).to.eql({});
+        let config = config_create();
+        let space = space_createRoot(config);
+        expect(space_solution(space, config)).to.eql({});
       });
 
       it('should return false if a var covers no (more) elements', function() {
-        let space = space_createRoot();
-        config_addVarDomain(space.config, 'test', fixt_arrdom_nums(100));
-        space_initFromConfig(space, space.config);
-        space.vardoms[space.config.all_var_names.indexOf('test')] = fixt_numdom_empty();
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarDomain(config, 'test', fixt_arrdom_nums(100));
+        space_initFromConfig(space, config);
+        space.vardoms[config.all_var_names.indexOf('test')] = fixt_numdom_empty();
 
-        expect(space_solution(space, space.config)).to.eql({test: false});
+        expect(space_solution(space, config)).to.eql({test: false});
       });
 
       it('should return the value of a var is solved', function() {
-        let space = space_createRoot();
-        config_addVarDomain(space.config, 'test', fixt_arrdom_value(5, true));
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarDomain(config, 'test', fixt_arrdom_value(5, true));
+        space_initFromConfig(space, config);
 
-        expect(space_solution(space, space.config)).to.eql({test: 5});
+        expect(space_solution(space, config)).to.eql({test: 5});
       });
 
       it('should return the domain of a var if not yet determined', function() {
-        let space = space_createRoot();
-        config_addVarRange(space.config, 'single_range', 10, 120);
-        config_addVarDomain(space.config, 'multi_range', fixt_arrdom_ranges([10, 20], [30, 40]));
-        config_addVarDomain(space.config, 'multi_range_with_solved', fixt_arrdom_ranges([18, 20], [25, 25], [30, 40]));
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarRange(config, 'single_range', 10, 120);
+        config_addVarDomain(config, 'multi_range', fixt_arrdom_ranges([10, 20], [30, 40]));
+        config_addVarDomain(config, 'multi_range_with_solved', fixt_arrdom_ranges([18, 20], [25, 25], [30, 40]));
+        space_initFromConfig(space, config);
 
-        expect(space_solution(space, space.config)).to.eql({
+        expect(space_solution(space, config)).to.eql({
           single_range: fixt_arrdom_range(10, 120),
           multi_range: fixt_arrdom_ranges([10, 20], [30, 40]),
           multi_range_with_solved: fixt_arrdom_ranges([18, 20], [25, 25], [30, 40]),
@@ -291,36 +307,39 @@ describe('src/space.spec', function() {
       });
 
       it('should not add anonymous vars to the result', function() {
-        let space = space_createRoot();
-        config_addVarAnonConstant(space.config, 15);
-        config_addVarConstant(space.config, 'addme', 20);
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config);
+        config_addVarAnonConstant(config, 15);
+        config_addVarConstant(config, 'addme', 20);
+        space_initFromConfig(space, config);
 
-        expect(stripAnonVars(space_solution(space, space.config))).to.eql({addme: 20});
+        expect(stripAnonVars(space_solution(space, config))).to.eql({addme: 20});
       });
     });
 
     describe('space_toConfig', function() {
 
       it('should convert a space to its config', function() {
-        let space = space_createRoot(); // fresh space object
-        space_initFromConfig(space, space.config);
-        let config = config_create(); // fresh config object
+        let config = config_create();
+        let space = space_createRoot(config);
+        space_initFromConfig(space, config);
+        let config2 = config_create(); // fresh config object
 
         // if a space has no special things, it should produce a
         // fresh config... (but it's a fickle test at best)
-        expect(space_toConfig(space, space.config)).to.eql(config);
+        expect(space_toConfig(space, config)).to.eql(config2);
       });
 
       it('should convert a space with a var without domain', function() {
-        let space = space_createRoot(); // fresh space object
-        config_addVarNothing(space.config, 'A'); // becomes [SUB SUP]
-        space_initFromConfig(space, space.config);
+        let config = config_create();
+        let space = space_createRoot(config); // fresh space object
+        config_addVarNothing(config, 'A'); // becomes [SUB SUP]
+        space_initFromConfig(space, config);
 
-        let config = space_toConfig(space, space.config);
+        let config2 = space_toConfig(space, config);
 
-        expect(config.all_var_names).to.eql(['A']);
-        expect(config.initial_domains, 'empty property should exist').to.eql([fixt_strdom_range(SUB, SUP)]);
+        expect(config2.all_var_names).to.eql(['A']);
+        expect(config2.initial_domains, 'empty property should exist').to.eql([fixt_strdom_range(SUB, SUP)]);
       });
     });
 
@@ -329,81 +348,85 @@ describe('src/space.spec', function() {
       describe('simple cases', function() {
 
         it('should not reject this multiply case', function() {
-          let space = space_createRoot();
+          let config = config_create();
+          let space = space_createRoot(config);
 
-          config_addVarRange(space.config, 'A', 0, 10);
-          config_addVarRange(space.config, 'B', 0, 10);
-          config_addVarRange(space.config, 'MAX', 25, 25);
-          config_addVarRange(space.config, 'MUL', 0, 100);
+          config_addVarRange(config, 'A', 0, 10);
+          config_addVarRange(config, 'B', 0, 10);
+          config_addVarRange(config, 'MAX', 25, 25);
+          config_addVarRange(config, 'MUL', 0, 100);
 
-          config_addConstraint(space.config, 'ring-mul', ['A', 'B', 'MUL'], 'mul');
-          config_addConstraint(space.config, 'lt', ['MUL', 'MAX']);
+          config_addConstraint(config, 'ring-mul', ['A', 'B', 'MUL'], 'mul');
+          config_addConstraint(config, 'lt', ['MUL', 'MAX']);
 
-          space_initFromConfig(space, space.config);
+          space_initFromConfig(space, config);
 
-          expect(space_propagate(space, space.config)).to.eql(false);
+          expect(space_propagate(space, config)).to.eql(false);
         });
       });
 
       describe('vars tied to only one propagator', function() {
 
         it('step 0; two bools at start of search', function() {
-          let space = space_createRoot();
+          let config = config_create();
+          let space = space_createRoot(config);
 
-          config_addVarRange(space.config, 'A', 0, 1);
-          config_addVarRange(space.config, 'B', 0, 1);
+          config_addVarRange(config, 'A', 0, 1);
+          config_addVarRange(config, 'B', 0, 1);
 
-          config_addConstraint(space.config, 'neq', ['A', 'B']);
+          config_addConstraint(config, 'neq', ['A', 'B']);
 
-          space_initFromConfig(space, space.config);
+          space_initFromConfig(space, config);
 
           // A and B only connect to one propagator
           // at the start of a search nothing should change
           // so after propagate() the vars should remain the same
-          space_propagate(space, space.config);
+          space_propagate(space, config);
 
-          expect(space.vardoms[space.config.all_var_names.indexOf('B')]).to.eql(fixt_numdom_nums(0, 1));
-          expect(space.vardoms[space.config.all_var_names.indexOf('A')]).to.eql(fixt_numdom_nums(0, 1));
+          expect(space.vardoms[config.all_var_names.indexOf('B')]).to.eql(fixt_numdom_nums(0, 1));
+          expect(space.vardoms[config.all_var_names.indexOf('A')]).to.eql(fixt_numdom_nums(0, 1));
         });
 
         it('step 1; first bool updated', function() {
-          let space = space_createRoot();
+          let config = config_create();
+          let space = space_createRoot(config);
 
-          config_addVarRange(space.config, 'A', 0, 0);
-          config_addVarRange(space.config, 'B', 0, 1);
-          config_addConstraint(space.config, 'neq', ['A', 'B']);
+          config_addVarRange(config, 'A', 0, 0);
+          config_addVarRange(config, 'B', 0, 1);
+          config_addConstraint(config, 'neq', ['A', 'B']);
 
-          space_initFromConfig(space, space.config);
-          space.updatedVarIndex = space.config.all_var_names.indexOf('A'); // mark A as having been updated externally
+          space_initFromConfig(space, config);
+          space.updatedVarIndex = config.all_var_names.indexOf('A'); // mark A as having been updated externally
 
           // A "was updated" by a distributor
           // since it ties to neq it should step that propagator which should
           // affect B and solve the space. if it doesn't that probably means
           // the propagator is incorrectly skipped (or hey, some other bug)
-          space_propagate(space, space.config);
+          space_propagate(space, config);
 
-          expect(space.vardoms[space.config.all_var_names.indexOf('A')]).to.eql(fixt_numdom_nums(0)); // we set it
-          expect(space.vardoms[space.config.all_var_names.indexOf('B')]).to.eql(fixt_numdom_nums(1)); // by neq
+          expect(space.vardoms[config.all_var_names.indexOf('A')]).to.eql(fixt_numdom_nums(0)); // we set it
+          expect(space.vardoms[config.all_var_names.indexOf('B')]).to.eql(fixt_numdom_nums(1)); // by neq
         });
 
         it('step 1; second bool updated', function() {
-          let space = space_createRoot();
+          let config = config_create();
+          let space = space_createRoot(config);
 
-          config_addVarRange(space.config, 'A', 0, 1);
-          config_addVarRange(space.config, 'B', 0, 0);
-          config_addConstraint(space.config, 'neq', ['A', 'B']);
+          config_addVarRange(config, 'A', 0, 1);
+          config_addVarRange(config, 'B', 0, 0);
+          config_addConstraint(config, 'neq', ['A', 'B']);
 
-          space_initFromConfig(space, space.config);
-          space.updatedVarIndex = space.config.all_var_names.indexOf('B'); // mark A as having been updated externally
+          space_initFromConfig(space, config);
+          space.updatedVarIndex = config.all_var_names.indexOf('B'); // mark A as having been updated externally
 
           // B "was updated" by a distributor
           // since it ties to neq it should step that propagator which should
           // affect A and solve the space. if it doesn't that probably means
           // the propagator is incorrectly skipped (or hey, some other bug)
-          space_propagate(space, space.config);
+          space_propagate(space, config);
 
-          expect(space.vardoms[space.config.all_var_names.indexOf('A')]).to.eql(fixt_numdom_nums(1)); // by neq
-          expect(space.vardoms[space.config.all_var_names.indexOf('B')]).to.eql(fixt_numdom_nums(0)); // we set it
+          expect(space.vardoms[config.all_var_names.indexOf('A')]).to.eql(fixt_numdom_nums(1)); // by neq
+          expect(space.vardoms[config.all_var_names.indexOf('B')]).to.eql(fixt_numdom_nums(0)); // we set it
         });
       });
 
@@ -412,43 +435,46 @@ describe('src/space.spec', function() {
         it('should ignore timeout callback if not set at all', function() {
           // (base timeout callback test)
 
-          let space = space_createRoot();
+          let config = config_create();
+          let space = space_createRoot(config);
 
-          config_addVarRange(space.config, 'A', 0, 10);
-          config_addVarRange(space.config, 'B', 0, 10);
+          config_addVarRange(config, 'A', 0, 10);
+          config_addVarRange(config, 'B', 0, 10);
 
-          config_addConstraint(space.config, 'lt', ['A', 'B']);
+          config_addConstraint(config, 'lt', ['A', 'B']);
 
-          space_initFromConfig(space, space.config);
-          expect(space_propagate(space, space.config)).to.eql(false);
+          space_initFromConfig(space, config);
+          expect(space_propagate(space, config)).to.eql(false);
         });
 
         it('should not break early if callback doesnt return true', function() {
-          let space = space_createRoot();
+          let config = config_create();
+          let space = space_createRoot(config);
 
-          config_addVarRange(space.config, 'A', 0, 10);
-          config_addVarRange(space.config, 'B', 0, 10);
+          config_addVarRange(config, 'A', 0, 10);
+          config_addVarRange(config, 'B', 0, 10);
 
-          config_addConstraint(space.config, 'lt', ['A', 'B']);
+          config_addConstraint(config, 'lt', ['A', 'B']);
 
-          config_setOption(space.config, 'timeout_callback', _ => false);
-          space_initFromConfig(space, space.config);
+          config_setOption(config, 'timeout_callback', _ => false);
+          space_initFromConfig(space, config);
 
-          expect(space_propagate(space, space.config)).to.eql(false);
+          expect(space_propagate(space, config)).to.eql(false);
         });
 
         it('should break early if callback returns true', function() {
-          let space = space_createRoot();
+          let config = config_create();
+          let space = space_createRoot(config);
 
-          config_addVarRange(space.config, 'A', 0, 10);
-          config_addVarRange(space.config, 'B', 0, 10);
+          config_addVarRange(config, 'A', 0, 10);
+          config_addVarRange(config, 'B', 0, 10);
 
-          config_addConstraint(space.config, 'lt', ['A', 'B']);
+          config_addConstraint(config, 'lt', ['A', 'B']);
 
-          config_setOption(space.config, 'timeout_callback', _ => true);
-          space_initFromConfig(space, space.config);
+          config_setOption(config, 'timeout_callback', _ => true);
+          space_initFromConfig(space, config);
 
-          expect(space_propagate(space, space.config)).to.eql(true);
+          expect(space_propagate(space, config)).to.eql(true);
         });
       });
     });

--- a/tests/specs/space.spec.js
+++ b/tests/specs/space.spec.js
@@ -307,7 +307,7 @@ describe('src/space.spec', function() {
 
         // if a space has no special things, it should produce a
         // fresh config... (but it's a fickle test at best)
-        expect(space_toConfig(space)).to.eql(config);
+        expect(space_toConfig(space, space.config)).to.eql(config);
       });
 
       it('should convert a space with a var without domain', function() {
@@ -315,7 +315,7 @@ describe('src/space.spec', function() {
         config_addVarNothing(space.config, 'A'); // becomes [SUB SUP]
         space_initFromConfig(space);
 
-        let config = space_toConfig(space);
+        let config = space_toConfig(space, space.config);
 
         expect(config.all_var_names).to.eql(['A']);
         expect(config.initial_domains, 'empty property should exist').to.eql([fixt_strdom_range(SUB, SUP)]);

--- a/tests/specs/space.spec.js
+++ b/tests/specs/space.spec.js
@@ -339,7 +339,7 @@ describe('src/space.spec', function() {
 
           space_initFromConfig(space, space.config);
 
-          expect(space_propagate(space)).to.eql(false);
+          expect(space_propagate(space, space.config)).to.eql(false);
         });
       });
 
@@ -358,7 +358,7 @@ describe('src/space.spec', function() {
           // A and B only connect to one propagator
           // at the start of a search nothing should change
           // so after propagate() the vars should remain the same
-          space_propagate(space);
+          space_propagate(space, space.config);
 
           expect(space.vardoms[space.config.all_var_names.indexOf('B')]).to.eql(fixt_numdom_nums(0, 1));
           expect(space.vardoms[space.config.all_var_names.indexOf('A')]).to.eql(fixt_numdom_nums(0, 1));
@@ -378,7 +378,7 @@ describe('src/space.spec', function() {
           // since it ties to neq it should step that propagator which should
           // affect B and solve the space. if it doesn't that probably means
           // the propagator is incorrectly skipped (or hey, some other bug)
-          space_propagate(space);
+          space_propagate(space, space.config);
 
           expect(space.vardoms[space.config.all_var_names.indexOf('A')]).to.eql(fixt_numdom_nums(0)); // we set it
           expect(space.vardoms[space.config.all_var_names.indexOf('B')]).to.eql(fixt_numdom_nums(1)); // by neq
@@ -398,7 +398,7 @@ describe('src/space.spec', function() {
           // since it ties to neq it should step that propagator which should
           // affect A and solve the space. if it doesn't that probably means
           // the propagator is incorrectly skipped (or hey, some other bug)
-          space_propagate(space);
+          space_propagate(space, space.config);
 
           expect(space.vardoms[space.config.all_var_names.indexOf('A')]).to.eql(fixt_numdom_nums(1)); // by neq
           expect(space.vardoms[space.config.all_var_names.indexOf('B')]).to.eql(fixt_numdom_nums(0)); // we set it
@@ -418,7 +418,7 @@ describe('src/space.spec', function() {
           config_addConstraint(space.config, 'lt', ['A', 'B']);
 
           space_initFromConfig(space, space.config);
-          expect(space_propagate(space)).to.eql(false);
+          expect(space_propagate(space, space.config)).to.eql(false);
         });
 
         it('should not break early if callback doesnt return true', function() {
@@ -432,7 +432,7 @@ describe('src/space.spec', function() {
           config_setOption(space.config, 'timeout_callback', _ => false);
           space_initFromConfig(space, space.config);
 
-          expect(space_propagate(space)).to.eql(false);
+          expect(space_propagate(space, space.config)).to.eql(false);
         });
 
         it('should break early if callback returns true', function() {
@@ -446,7 +446,7 @@ describe('src/space.spec', function() {
           config_setOption(space.config, 'timeout_callback', _ => true);
           space_initFromConfig(space, space.config);
 
-          expect(space_propagate(space)).to.eql(true);
+          expect(space_propagate(space, space.config)).to.eql(true);
         });
       });
     });

--- a/tests/specs/space.spec.js
+++ b/tests/specs/space.spec.js
@@ -98,7 +98,7 @@ describe('src/space.spec', function() {
         config.targetedVars = 'all';
 
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         expect(space_getUnsolvedVarCount(space)).to.eql(0);
       });
@@ -110,7 +110,7 @@ describe('src/space.spec', function() {
         config.targetedVars = ['A', 'B'];
 
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         expect(_space_getUnsolvedVarNamesFresh(space).sort()).to.eql(['A', 'B']);
       });
@@ -123,7 +123,7 @@ describe('src/space.spec', function() {
         config.targetedVars = targets.slice(0);
 
         let space = space_createRoot(config);
-        space_initFromConfig(space);
+        space_initFromConfig(space, config);
 
         expect(_space_getUnsolvedVarNamesFresh(space).sort()).to.eql(targets.sort());
       });
@@ -136,7 +136,7 @@ describe('src/space.spec', function() {
         config.targetedVars = ['FAIL'];
 
         let space = space_createRoot(config);
-        expect(_ => space_initFromConfig(space)).to.throw('E_TARGETED_VARS_SHOULD_EXIST_NOW');
+        expect(_ => space_initFromConfig(space, config)).to.throw('E_TARGETED_VARS_SHOULD_EXIST_NOW');
       });
     });
 
@@ -144,14 +144,14 @@ describe('src/space.spec', function() {
 
       it('should return true if there are no vars', function() {
         let space = space_createRoot();
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
         expect(space_updateUnsolvedVarList(space)).to.equal(true);
       });
 
       it('should return true if all 1 vars are solved', function() {
         let space = space_createRoot();
         config_addVarAnonConstant(space.config, 1);
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_updateUnsolvedVarList(space), 'only one solved var').to.equal(true);
       });
@@ -160,7 +160,7 @@ describe('src/space.spec', function() {
         let space = space_createRoot();
         config_addVarAnonConstant(space.config, 1);
         config_addVarAnonConstant(space.config, 1);
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_updateUnsolvedVarList(space), 'two solved vars').to.equal(true);
       });
@@ -169,7 +169,7 @@ describe('src/space.spec', function() {
         let space = space_createRoot();
         config_addVarAnonRange(space.config, 0, 1);
         space.config.targetedVars = space.config.all_var_names.slice(0);
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_updateUnsolvedVarList(space), 'only one unsolved var').to.equal(false);
       });
@@ -178,7 +178,7 @@ describe('src/space.spec', function() {
         let space = space_createRoot();
         config_addVarAnonRange(space.config, 0, 1);
         space.config.targetedVars = [];
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_getUnsolvedVarCount(space), 'unsolved vars to solve').to.equal(0);
       });
@@ -188,7 +188,7 @@ describe('src/space.spec', function() {
         config_addVarAnonRange(space.config, 0, 1);
         config_addVarAnonRange(space.config, 0, 1);
         space.config.targetedVars = space.config.all_var_names.slice(0);
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_updateUnsolvedVarList(space), 'two unsolved vars').to.equal(false);
       });
@@ -197,7 +197,7 @@ describe('src/space.spec', function() {
         let space = space_createRoot();
         config_addVarAnonRange(space.config, 0, 1);
         config_addVarAnonRange(space.config, 0, 1);
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_updateUnsolvedVarList(space), 'two unsolved vars').to.equal(true);
       });
@@ -208,7 +208,7 @@ describe('src/space.spec', function() {
         config_addVarAnonRange(space.config, 0, 1);
         config_addVarAnonConstant(space.config, 1);
         space.config.targetedVars = space.config.all_var_names.slice(0);
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_updateUnsolvedVarList(space), 'two unsolved vars and a solved var').to.equal(false);
       });
@@ -218,7 +218,7 @@ describe('src/space.spec', function() {
         config_addVarAnonRange(space.config, 0, 1);
         config_addVarAnonRange(space.config, 0, 1);
         config_addVarAnonConstant(space.config, 1);
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_updateUnsolvedVarList(space), 'two unsolved vars and a solved var').to.equal(true);
       });
@@ -229,7 +229,7 @@ describe('src/space.spec', function() {
         config_addVarAnonRange(space.config, 0, 1);
         let A = config_addVarAnonConstant(space.config, 1);
         space.config.targetedVars = [space.config.all_var_names[A]];
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_updateUnsolvedVarList(space), 'two unsolved vars and a solved var').to.equal(true);
       });
@@ -240,7 +240,7 @@ describe('src/space.spec', function() {
         let B = config_addVarAnonRange(space.config, 0, 1);
         config_addVarAnonConstant(space.config, 1);
         space.config.targetedVars = [space.config.all_var_names[A], space.config.all_var_names[B]];
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_updateUnsolvedVarList(space), 'two unsolved vars and a solved var').to.equal(false);
       });
@@ -260,7 +260,7 @@ describe('src/space.spec', function() {
       it('should return false if a var covers no (more) elements', function() {
         let space = space_createRoot();
         config_addVarDomain(space.config, 'test', fixt_arrdom_nums(100));
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
         space.vardoms[space.config.all_var_names.indexOf('test')] = fixt_numdom_empty();
 
         expect(space_solution(space)).to.eql({test: false});
@@ -269,7 +269,7 @@ describe('src/space.spec', function() {
       it('should return the value of a var is solved', function() {
         let space = space_createRoot();
         config_addVarDomain(space.config, 'test', fixt_arrdom_value(5, true));
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_solution(space)).to.eql({test: 5});
       });
@@ -279,7 +279,7 @@ describe('src/space.spec', function() {
         config_addVarRange(space.config, 'single_range', 10, 120);
         config_addVarDomain(space.config, 'multi_range', fixt_arrdom_ranges([10, 20], [30, 40]));
         config_addVarDomain(space.config, 'multi_range_with_solved', fixt_arrdom_ranges([18, 20], [25, 25], [30, 40]));
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(space_solution(space)).to.eql({
           single_range: fixt_arrdom_range(10, 120),
@@ -292,7 +292,7 @@ describe('src/space.spec', function() {
         let space = space_createRoot();
         config_addVarAnonConstant(space.config, 15);
         config_addVarConstant(space.config, 'addme', 20);
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         expect(stripAnonVars(space_solution(space))).to.eql({addme: 20});
       });
@@ -302,7 +302,7 @@ describe('src/space.spec', function() {
 
       it('should convert a space to its config', function() {
         let space = space_createRoot(); // fresh space object
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
         let config = config_create(); // fresh config object
 
         // if a space has no special things, it should produce a
@@ -313,7 +313,7 @@ describe('src/space.spec', function() {
       it('should convert a space with a var without domain', function() {
         let space = space_createRoot(); // fresh space object
         config_addVarNothing(space.config, 'A'); // becomes [SUB SUP]
-        space_initFromConfig(space);
+        space_initFromConfig(space, space.config);
 
         let config = space_toConfig(space, space.config);
 
@@ -337,7 +337,7 @@ describe('src/space.spec', function() {
           config_addConstraint(space.config, 'ring-mul', ['A', 'B', 'MUL'], 'mul');
           config_addConstraint(space.config, 'lt', ['MUL', 'MAX']);
 
-          space_initFromConfig(space);
+          space_initFromConfig(space, space.config);
 
           expect(space_propagate(space)).to.eql(false);
         });
@@ -353,7 +353,7 @@ describe('src/space.spec', function() {
 
           config_addConstraint(space.config, 'neq', ['A', 'B']);
 
-          space_initFromConfig(space);
+          space_initFromConfig(space, space.config);
 
           // A and B only connect to one propagator
           // at the start of a search nothing should change
@@ -371,7 +371,7 @@ describe('src/space.spec', function() {
           config_addVarRange(space.config, 'B', 0, 1);
           config_addConstraint(space.config, 'neq', ['A', 'B']);
 
-          space_initFromConfig(space);
+          space_initFromConfig(space, space.config);
           space.updatedVarIndex = space.config.all_var_names.indexOf('A'); // mark A as having been updated externally
 
           // A "was updated" by a distributor
@@ -391,7 +391,7 @@ describe('src/space.spec', function() {
           config_addVarRange(space.config, 'B', 0, 0);
           config_addConstraint(space.config, 'neq', ['A', 'B']);
 
-          space_initFromConfig(space);
+          space_initFromConfig(space, space.config);
           space.updatedVarIndex = space.config.all_var_names.indexOf('B'); // mark A as having been updated externally
 
           // B "was updated" by a distributor
@@ -417,7 +417,7 @@ describe('src/space.spec', function() {
 
           config_addConstraint(space.config, 'lt', ['A', 'B']);
 
-          space_initFromConfig(space);
+          space_initFromConfig(space, space.config);
           expect(space_propagate(space)).to.eql(false);
         });
 
@@ -430,7 +430,7 @@ describe('src/space.spec', function() {
           config_addConstraint(space.config, 'lt', ['A', 'B']);
 
           config_setOption(space.config, 'timeout_callback', _ => false);
-          space_initFromConfig(space);
+          space_initFromConfig(space, space.config);
 
           expect(space_propagate(space)).to.eql(false);
         });
@@ -444,7 +444,7 @@ describe('src/space.spec', function() {
           config_addConstraint(space.config, 'lt', ['A', 'B']);
 
           config_setOption(space.config, 'timeout_callback', _ => true);
-          space_initFromConfig(space);
+          space_initFromConfig(space, space.config);
 
           expect(space_propagate(space)).to.eql(true);
         });

--- a/tests/specs/space.spec.js
+++ b/tests/specs/space.spec.js
@@ -249,12 +249,14 @@ describe('src/space.spec', function() {
     describe('space_solution()', function() {
 
       it('should return an object, not array', function() {
-        expect(space_solution(space_createRoot())).to.be.an('object');
-        expect(space_solution(space_createRoot())).not.to.be.an('array');
+        let space;
+        expect(space_solution(space = space_createRoot(), space.config)).to.be.an('object');
+        expect(space_solution(space = space_createRoot(), space.config)).not.to.be.an('array');
       });
 
       it('should return an empty object if there are no vars', function() {
-        expect(space_solution(space_createRoot())).to.eql({});
+        let space = space_createRoot();
+        expect(space_solution(space, space.config)).to.eql({});
       });
 
       it('should return false if a var covers no (more) elements', function() {
@@ -263,7 +265,7 @@ describe('src/space.spec', function() {
         space_initFromConfig(space, space.config);
         space.vardoms[space.config.all_var_names.indexOf('test')] = fixt_numdom_empty();
 
-        expect(space_solution(space)).to.eql({test: false});
+        expect(space_solution(space, space.config)).to.eql({test: false});
       });
 
       it('should return the value of a var is solved', function() {
@@ -271,7 +273,7 @@ describe('src/space.spec', function() {
         config_addVarDomain(space.config, 'test', fixt_arrdom_value(5, true));
         space_initFromConfig(space, space.config);
 
-        expect(space_solution(space)).to.eql({test: 5});
+        expect(space_solution(space, space.config)).to.eql({test: 5});
       });
 
       it('should return the domain of a var if not yet determined', function() {
@@ -281,7 +283,7 @@ describe('src/space.spec', function() {
         config_addVarDomain(space.config, 'multi_range_with_solved', fixt_arrdom_ranges([18, 20], [25, 25], [30, 40]));
         space_initFromConfig(space, space.config);
 
-        expect(space_solution(space)).to.eql({
+        expect(space_solution(space, space.config)).to.eql({
           single_range: fixt_arrdom_range(10, 120),
           multi_range: fixt_arrdom_ranges([10, 20], [30, 40]),
           multi_range_with_solved: fixt_arrdom_ranges([18, 20], [25, 25], [30, 40]),
@@ -294,7 +296,7 @@ describe('src/space.spec', function() {
         config_addVarConstant(space.config, 'addme', 20);
         space_initFromConfig(space, space.config);
 
-        expect(stripAnonVars(space_solution(space))).to.eql({addme: 20});
+        expect(stripAnonVars(space_solution(space, space.config))).to.eql({addme: 20});
       });
     });
 

--- a/tests/specs/space.spec.js
+++ b/tests/specs/space.spec.js
@@ -112,7 +112,7 @@ describe('src/space.spec', function() {
         let space = space_createRoot(config);
         space_initFromConfig(space, config);
 
-        expect(_space_getUnsolvedVarNamesFresh(space).sort()).to.eql(['A', 'B']);
+        expect(_space_getUnsolvedVarNamesFresh(space, config).sort()).to.eql(['A', 'B']);
       });
 
       it('should not care about the order of the var names', function() {
@@ -125,7 +125,7 @@ describe('src/space.spec', function() {
         let space = space_createRoot(config);
         space_initFromConfig(space, config);
 
-        expect(_space_getUnsolvedVarNamesFresh(space).sort()).to.eql(targets.sort());
+        expect(_space_getUnsolvedVarNamesFresh(space, config).sort()).to.eql(targets.sort());
       });
 
       it('should throw if var names dont exist', function() {

--- a/tests/specs/space.spec.js
+++ b/tests/specs/space.spec.js
@@ -100,7 +100,7 @@ describe('src/space.spec', function() {
         let space = space_createRoot(config);
         space_initFromConfig(space, config);
 
-        expect(space_getUnsolvedVarCount(space)).to.eql(0);
+        expect(space_getUnsolvedVarCount(space, config)).to.eql(0);
       });
 
       it('should use explicitly targeted vars regardless of being constrained', function() {
@@ -180,7 +180,7 @@ describe('src/space.spec', function() {
         space.config.targetedVars = [];
         space_initFromConfig(space, space.config);
 
-        expect(space_getUnsolvedVarCount(space), 'unsolved vars to solve').to.equal(0);
+        expect(space_getUnsolvedVarCount(space, space.config), 'unsolved vars to solve').to.equal(0);
       });
 
       it('should return false if at least one var of two is not solved and targeted', function() {

--- a/tests/specs/space.spec.js
+++ b/tests/specs/space.spec.js
@@ -62,7 +62,7 @@ describe('src/space.spec', function() {
     describe('space_createClone()', function() {
 
       let space = space_createRoot();
-      let clone = space_createClone(space);
+      let clone = space_createClone(space, space.config);
 
       it('should return a new space', function() {
         expect(clone).to.not.equal(space);


### PR DESCRIPTION
Removes the one thing from the space class that was not a primitive or array of primitives. Prepares to move everything to a buffer of some sort.
