### PR TITLE
Api cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Markov matrix row boolean-getter property has been changed from `boolean` to `boolVarName`. It must still be undefined, a string, or a function returning a string. The `boolean` property now throws when set to anything.
 - Markov matrix row boolean-getter method (`boolVarName` as a function, used to be `boolean` as a function) now receives no parameters when called. The renaming is partially to catch this change.
 - The internal `boolId` property for a markov matrix row is renamed to something more obviously internal. The old property now throws if set to anything.
+- Dropped "internal" exposed api's to support external subclass (`Solver#space_add_var_range`, `Solver#domain_max`, and `Solver#domain_toList`)
 
 ## v2.3.4:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - The internal `boolId` property for a markov matrix row is renamed to something more obviously internal. The old property now throws if set to anything.
 - Dropped "internal" exposed api's to support external subclass (`Solver#space_add_var_range`, `Solver#domain_max`, and `Solver#domain_toList`)
 - Removed support for distributor fallback shorthand `fallback_dist_name`. Just use `.fallback = {valtype: ...}` instead. the `fallback` property will be fleshed out a little better in the future.
+- The limitation that constraints must have at least one non-constant has been lifted. These cases are now immediately optimized away as much as possible.
 
 ## v2.3.4:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Markov matrix row boolean-getter method (`boolVarName` as a function, used to be `boolean` as a function) now receives no parameters when called. The renaming is partially to catch this change.
 - The internal `boolId` property for a markov matrix row is renamed to something more obviously internal. The old property now throws if set to anything.
 - Dropped "internal" exposed api's to support external subclass (`Solver#space_add_var_range`, `Solver#domain_max`, and `Solver#domain_toList`)
+- Removed support for distributor fallback shorthand `fallback_dist_name`. Just use `.fallback = {valtype: ...}` instead. the `fallback` property will be fleshed out a little better in the future.
 
 ## v2.3.4:
 

--- a/docs/config.docs.js
+++ b/docs/config.docs.js
@@ -2,6 +2,7 @@
  * @private Do not read any property from this object outside of `finitedomain`. Expose required data on Solver instead.
  * @typedef {Object} $config
  * @property {$var_strat_config} varStratConfig Defaults to a naive strategy
+ * @property {Object} var_dist_options
  * @property {string} valueStratName
  * @property {string[]|string} targetedVars='all' Search stops when these are solved.
  * @property {$var_strat_overrides} varStratOverrides Can apply a specific $var_strat_config per var

--- a/src/distribution/value.js
+++ b/src/distribution/value.js
@@ -135,8 +135,12 @@ function distribution_valueByList(space, config, varIndex, choiceIndex) {
   let varDistOptions = configVarDistOptions[varName];
   let listSource = varDistOptions.list;
 
-  let fallbackDistName = varDistOptions.fallback_dist_name;
-  ASSERT(fallbackDistName !== 'list', 'prevent recursion loops');
+  let fallbackName = '';
+  if (varDistOptions.fallback) {
+    fallbackName = varDistOptions.fallback.valtype;
+    ASSERT(fallbackName, 'should have a fallback type');
+    ASSERT(fallbackName !== 'list', 'prevent recursion loops');
+  }
 
   let list = listSource;
   if (typeof listSource === 'function') {
@@ -148,8 +152,8 @@ function distribution_valueByList(space, config, varIndex, choiceIndex) {
     case FIRST_CHOICE:
       let nextValue = domain_getFirstIntersectingValue(domain, list);
       if (nextValue === NO_SUCH_VALUE) {
-        if (fallbackDistName) {
-          return _distribute_getNextDomainForVar(fallbackDistName, space, config, varIndex, choiceIndex);
+        if (fallbackName) {
+          return _distribute_getNextDomainForVar(fallbackName, space, config, varIndex, choiceIndex);
         }
         return NO_CHOICE;
       } else {
@@ -161,8 +165,8 @@ function distribution_valueByList(space, config, varIndex, choiceIndex) {
       if (space._lastChosenValue >= 0) {
         return domain_removeValue(domain, space._lastChosenValue);
       }
-      if (fallbackDistName) {
-        return _distribute_getNextDomainForVar(fallbackDistName, space, config, varIndex, choiceIndex);
+      if (fallbackName) {
+        return _distribute_getNextDomainForVar(fallbackName, space, config, varIndex, choiceIndex);
       }
       return NO_CHOICE;
   }

--- a/src/solver.js
+++ b/src/solver.js
@@ -283,35 +283,35 @@ class Solver {
   }
 
   ['>='](e1, e2) {
-    return this.gte(e1, e2);
+    this.gte(e1, e2);
   }
   gte(e1, e2) {
     ASSERT(!(e1 instanceof Array), 'NOT_ACCEPTING_ARRAYS');
-    return config_addConstraint(this.config, 'gte', [GET_NAME(e1), GET_NAME(e2)]);
+    config_addConstraint(this.config, 'gte', [GET_NAME(e1), GET_NAME(e2)]);
   }
 
   ['<='](e1, e2) {
-    return this.lte(e1, e2);
+    this.lte(e1, e2);
   }
   lte(e1, e2) {
     ASSERT(!(e1 instanceof Array), 'NOT_ACCEPTING_ARRAYS');
-    return config_addConstraint(this.config, 'lte', [GET_NAME(e1), GET_NAME(e2)]);
+    config_addConstraint(this.config, 'lte', [GET_NAME(e1), GET_NAME(e2)]);
   }
 
   ['>'](e1, e2) {
-    return this.gt(e1, e2);
+    this.gt(e1, e2);
   }
   gt(e1, e2) {
     ASSERT(!(e1 instanceof Array), 'NOT_ACCEPTING_ARRAYS');
-    return config_addConstraint(this.config, 'gt', [GET_NAME(e1), GET_NAME(e2)]);
+    config_addConstraint(this.config, 'gt', [GET_NAME(e1), GET_NAME(e2)]);
   }
 
   ['<'](e1, e2) {
-    return this.lt(e1, e2);
+    this.lt(e1, e2);
   }
   lt(e1, e2) {
     ASSERT(!(e1 instanceof Array), 'NOT_ACCEPTING_ARRAYS');
-    return config_addConstraint(this.config, 'lt', [GET_NAME(e1), GET_NAME(e2)]);
+    config_addConstraint(this.config, 'lt', [GET_NAME(e1), GET_NAME(e2)]);
   }
 
 

--- a/src/solver.js
+++ b/src/solver.js
@@ -4,7 +4,6 @@ import {
   LOG_SOLVES,
   LOG_MAX,
   LOG_MIN,
-  NO_SUCH_VALUE,
 
   ASSERT,
   ASSERT_ARRDOM,
@@ -18,7 +17,6 @@ import {
   config_addConstraint,
   config_addVarAnonConstant,
   config_addVarDomain,
-  config_addVarRange,
   config_create,
   config_setDefaults,
   config_setOption,
@@ -30,10 +28,7 @@ import {
   domain_createEmpty,
   domain_fromListToArrdom,
   domain_isEmpty,
-  domain_max,
   domain_toArr,
-  domain_toList,
-  domain_arrToSmallest,
   domain_anyToSmallest,
 } from './domain';
 
@@ -496,22 +491,6 @@ class Solver {
   }
 
   /**
-   * Exposes internal method config_addVar for subclass
-   * (Used by PathSolver in a private project)
-   *
-   * @public
-   * @param {string} id
-   * @param {number} lo
-   * @param {number} hi
-   * @returns {string}
-   */
-  space_add_var_range(id, lo, hi) {
-    let varIndex = config_addVarRange(this.config, id, lo, hi);
-    ASSERT(this.config.all_var_names[varIndex] === id, 'SHOULD_USE_ID_AS_IS');
-    return id;
-  }
-
-  /**
    * Exposes internal method domain_fromList for subclass
    * (Used by PathSolver in a private project)
    * It will always create an array, never a "small domain"
@@ -523,31 +502,6 @@ class Solver {
    */
   domain_fromList(list) {
     return domain_fromListToArrdom(list);
-  }
-
-  /**
-   * Used by PathSolver in another (private) project
-   * Exposes domain_max
-   *
-   * @param {$arrdom} domain
-   * @returns {number} If negative, search failed. Note: external dep also depends on that being negative.
-   */
-  domain_max(domain) {
-    ASSERT_ARRDOM(domain);
-    if (domain.length === 0) return NO_SUCH_VALUE;
-    return domain_max(domain_arrToSmallest(domain));
-  }
-
-  /**
-   * Used by PathSolver in another (private) project
-   * Exposes domain_toList
-   * TODO: can we lock this down to an $arrdom ?
-   *
-   * @param {$domain} domain
-   * @returns {number[]}
-   */
-  domain_toList(domain) {
-    return domain_toList(domain);
   }
 
   /**

--- a/src/solver.js
+++ b/src/solver.js
@@ -249,7 +249,7 @@ class Solver {
   }
 
   ['=='](e1, e2) {
-    return this.eq(e1, e2);
+    this.eq(e1, e2);
   }
   eq(e1, e2) {
     if (e1 instanceof Array) {
@@ -266,7 +266,7 @@ class Solver {
   }
 
   ['!='](e1, e2) {
-    return this.neq(e1, e2);
+    this.neq(e1, e2);
   }
   neq(e1, e2) {
     if (e1 instanceof Array) {

--- a/tests/specs/solver.list.spec.js
+++ b/tests/specs/solver.list.spec.js
@@ -199,7 +199,9 @@ describe('src/solver.list.spec', function() {
       solver.declRange('V1', 0, 5, {
         valtype: 'list',
         list: [0, 15],
-        fallback_dist_name: 'max',
+        fallback: {
+          valtype: 'max',
+        },
       });
       solver['>']('V1', 0);
       let solutions = solver.solve();
@@ -235,7 +237,9 @@ describe('src/solver.list.spec', function() {
       solver.declRange('V1', 0, 5, {
         valtype: 'list',
         list: [3, 0, 1, 5],
-        fallback_dist_name: 'max',
+        fallback: {
+          valtype: 'max',
+        },
       });
       solver['>']('V1', 0);
 
@@ -255,7 +259,9 @@ describe('src/solver.list.spec', function() {
       solver.declRange('V1', 0, 5, {
         valtype: 'list',
         list: [3, 0, 1, 15, 5],
-        fallback_dist_name: 'max',
+        fallback: {
+          valtype: 'max',
+        },
       });
       solver['>']('V1', 6);
 

--- a/tests/specs/solver.spec.js
+++ b/tests/specs/solver.spec.js
@@ -784,19 +784,19 @@ describe('solver.spec', function() {
             let solver = new Solver();
             solver.decl('A', 100);
             solver.decl('B', 100);
-            expect(solver[method]('A', 'B')).to.equal('A');
+            expect(solver[method]('A', 'B')).to.equal(undefined);
           });
 
           it('should work with a number left', function() {
             let solver = new Solver();
             solver.decl('B', 100);
-            expect(solver[method](1, 'B')).to.equal('1'); // if we change anonymous var naming, this'll break
+            expect(solver[method](1, 'B')).to.equal(undefined); // if we change anonymous var naming, this'll break
           });
 
           it('should work with a number right', function() {
             let solver = new Solver();
             solver.decl('A', 100);
-            expect(solver[method]('A', 2)).to.equal('1'); // if we change anonymous var naming, this'll break
+            expect(solver[method]('A', 2)).to.equal(undefined); // if we change anonymous var naming, this'll break
           });
           it('should not work with an empty array', function() {
             let solver = new Solver();

--- a/tests/specs/solver.spec.js
+++ b/tests/specs/solver.spec.js
@@ -1,10 +1,8 @@
 import expect from '../fixtures/mocha_proxy.fixt';
 import {
-  fixt_arrdom_empty,
   fixt_arrdom_nums,
   fixt_arrdom_range,
   fixt_arrdom_ranges,
-  fixt_dom_nums,
   fixt_dom_ranges,
   stripAnonVarsFromArrays,
 } from '../fixtures/domain.fixt';
@@ -19,7 +17,6 @@ import {
   LOG_SOLVES,
   LOG_MAX,
   LOG_MIN,
-  NO_SUCH_VALUE,
   SUB,
   SUP,
 } from '../../src/helpers';
@@ -977,15 +974,6 @@ describe('solver.spec', function() {
       });
     });
 
-    describe('solver.space_add_var_range', function() {
-
-      it('should just map to config_addVarRange', function() {
-        let solver = new Solver();
-
-        expect(solver.space_add_var_range('foo', 1, 2)).to.equal('foo');
-      });
-    });
-
     describe('solver.domain_fromList', function() {
 
       it('should map to domain_fromList', function() {
@@ -998,30 +986,6 @@ describe('solver.spec', function() {
         let solver = new Solver();
 
         expect(solver.domain_fromList([1, 2, 4, 5, 7, 9, 10, 11, 12, 13, 15])).to.eql([1, 2, 4, 5, 7, 7, 9, 13, 15, 15]);
-      });
-    });
-
-    describe('solver.domain_max', function() {
-
-      it('should work on a domain', function() {
-        let solver = new Solver();
-
-        expect(solver.domain_max(fixt_arrdom_nums(0, 1, 4, 6))).to.eql(6);
-      });
-
-      it('should return NO_SUCH_VALUE if the domain is empty', function() {
-        let solver = new Solver();
-
-        expect(solver.domain_max(fixt_arrdom_empty())).to.eql(NO_SUCH_VALUE);
-      });
-    });
-
-    describe('solver.domain_toList', function() {
-
-      it('should return an array of values for given domain', function() {
-        let solver = new Solver();
-
-        expect(solver.domain_toList(fixt_dom_nums(0, 1, 2, 3, 8, 10))).to.eql([0, 1, 2, 3, 8, 10]);
       });
     });
   });

--- a/tests/specs/solver.spec.js
+++ b/tests/specs/solver.spec.js
@@ -239,7 +239,7 @@ describe('solver.spec', function() {
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
         });
 
-        it('should have at leat one string var name', function() {
+        it('should always return the result var name', function() {
           let solver3 = new Solver();
           solver3.decl('A', 100);
           solver3.decl('B', 100);
@@ -248,17 +248,17 @@ describe('solver.spec', function() {
           expect(solver3[method]('A', 'B')).to.be.a('string');
           expect(solver3[method](1, 'B')).to.be.a('string');
           expect(solver3[method]('A', 1)).to.be.a('string');
-          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](1, 2)).to.be.a('string');
 
-          expect(solver3[method]('A', 'B', 'C')).to.be.a('string');
-          expect(solver3[method](1, 'B', 'C')).to.be.a('string');
-          expect(solver3[method]('A', 2, 'C')).to.be.a('string');
-          expect(_ => solver3[method](1, 2, 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method]('A', 'B', 'C')).to.eql('C');
+          expect(solver3[method](1, 'B', 'C')).to.eql('C');
+          expect(solver3[method]('A', 2, 'C')).to.eql('C');
+          expect(solver3[method](1, 2, 'C')).to.eql('C');
 
           expect(solver3[method]('A', 'B', 3)).to.be.a('string');
           expect(solver3[method](1, 'B', 3)).to.be.a('string');
           expect(solver3[method]('A', 2, 3)).to.be.a('string');
-          expect(_ => solver3[method](1, 2, 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](1, 2, 3)).to.be.a('string');
         });
       }
 
@@ -308,7 +308,7 @@ describe('solver.spec', function() {
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
         });
 
-        it('should have at leat one string var name', function() {
+        it('should always return the result var name', function() {
           let solver3 = new Solver();
           solver3.decl('A', 100);
           solver3.decl('B', 100);
@@ -317,17 +317,17 @@ describe('solver.spec', function() {
           expect(solver3[method]('A', 'B')).to.be.a('string');
           expect(solver3[method](1, 'B')).to.be.a('string');
           expect(solver3[method]('A', 1)).to.be.a('string');
-          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](1, 2)).to.be.a('string');
 
-          expect(solver3[method]('A', 'B', 'C')).to.be.a('string');
-          expect(solver3[method](1, 'B', 'C')).to.be.a('string');
-          expect(solver3[method]('A', 2, 'C')).to.be.a('string');
-          expect(_ => solver3[method](1, 2, 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method]('A', 'B', 'C')).to.eql('C');
+          expect(solver3[method](1, 'B', 'C')).to.eql('C');
+          expect(solver3[method]('A', 2, 'C')).to.eql('C');
+          expect(solver3[method](1, 2, 'C')).to.eql('C');
 
           expect(solver3[method]('A', 'B', 3)).to.be.a('string');
           expect(solver3[method](1, 'B', 3)).to.be.a('string');
           expect(solver3[method]('A', 2, 3)).to.be.a('string');
-          expect(_ => solver3[method](1, 2, 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](1, 2, 3)).to.be.a('string');
         });
       }
 
@@ -378,7 +378,7 @@ describe('solver.spec', function() {
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
         });
 
-        it('should have at leat one string var name', function() {
+        it('should always return the result var name', function() {
           let solver3 = new Solver();
           solver3.decl('A', 100);
           solver3.decl('B', 100);
@@ -387,17 +387,17 @@ describe('solver.spec', function() {
           expect(solver3[method]('A', 'B')).to.be.a('string');
           expect(solver3[method](1, 'B')).to.be.a('string');
           expect(solver3[method]('A', 1)).to.be.a('string');
-          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](1, 2)).to.be.a('string');
 
-          expect(solver3[method]('A', 'B', 'C')).to.be.a('string');
-          expect(solver3[method](1, 'B', 'C')).to.be.a('string');
-          expect(solver3[method]('A', 2, 'C')).to.be.a('string');
-          expect(_ => solver3[method](1, 2, 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method]('A', 'B', 'C')).to.eql('C');
+          expect(solver3[method](1, 'B', 'C')).to.eql('C');
+          expect(solver3[method]('A', 2, 'C')).to.eql('C');
+          expect(solver3[method](1, 2, 'C')).to.eql('C');
 
           expect(solver3[method]('A', 'B', 3)).to.be.a('string');
           expect(solver3[method](1, 'B', 3)).to.be.a('string');
           expect(solver3[method]('A', 2, 3)).to.be.a('string');
-          expect(_ => solver3[method](1, 2, 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](1, 2, 3)).to.be.a('string');
         });
       }
 
@@ -448,7 +448,7 @@ describe('solver.spec', function() {
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
         });
 
-        it('should have at leat one string var name', function() {
+        it('should always return the result var name', function() {
           let solver3 = new Solver();
           solver3.decl('A', 100);
           solver3.decl('B', 100);
@@ -457,17 +457,17 @@ describe('solver.spec', function() {
           expect(solver3[method]('A', 'B')).to.be.a('string');
           expect(solver3[method](1, 'B')).to.be.a('string');
           expect(solver3[method]('A', 1)).to.be.a('string');
-          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](1, 2)).to.be.a('string');
 
-          expect(solver3[method]('A', 'B', 'C')).to.be.a('string');
-          expect(solver3[method](1, 'B', 'C')).to.be.a('string');
-          expect(solver3[method]('A', 2, 'C')).to.be.a('string');
-          expect(_ => solver3[method](1, 2, 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method]('A', 'B', 'C')).to.eql('C');
+          expect(solver3[method](1, 'B', 'C')).to.eql('C');
+          expect(solver3[method]('A', 2, 'C')).to.eql('C');
+          expect(solver3[method](1, 2, 'C')).to.eql('C');
 
           expect(solver3[method]('A', 'B', 3)).to.be.a('string');
           expect(solver3[method](1, 'B', 3)).to.be.a('string');
           expect(solver3[method]('A', 2, 3)).to.be.a('string');
-          expect(_ => solver3[method](1, 2, 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](1, 2, 3)).to.be.a('string');
         });
       }
 
@@ -517,26 +517,26 @@ describe('solver.spec', function() {
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('expecting result var name to be absent or a number or string:');
         });
 
-        it('should have at leat one string var name', function() {
+        it('should always return the result var name', function() {
           let solver3 = new Solver();
           solver3.decl('A', 100);
           solver3.decl('B', 100);
           solver3.decl('C', 100);
 
           expect(solver3[method]('A', 'B')).to.be.a('string');
-          expect(_ => solver3[method](1, 'B')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME'); // special case
+          expect(solver3[method](1, 'B')).to.be.a('string');
           expect(solver3[method]('A', 1)).to.be.a('string');
-          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](1, 2)).to.be.a('string');
 
-          expect(solver3[method](['A', 'B'], 'C')).to.be.a('string');
-          expect(solver3[method]([1, 'B'], 'C')).to.be.a('string');
-          expect(solver3[method](['A', 2], 'C')).to.be.a('string');
-          expect(_ => solver3[method]([1, 2], 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](['A', 'B'], 'C')).to.eql('C');
+          expect(solver3[method]([1, 'B'], 'C')).to.eql('C');
+          expect(solver3[method](['A', 2], 'C')).to.eql('C');
+          expect(solver3[method]([1, 2], 'C')).to.eql('C');
 
           expect(solver3[method](['A', 'B'], 3)).to.be.a('string');
           expect(solver3[method]([1, 'B'], 3)).to.be.a('string');
           expect(solver3[method](['A', 2], 3)).to.be.a('string');
-          expect(_ => solver3[method]([1, 2], 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method]([1, 2], 3)).to.be.a('string');
         });
       }
 
@@ -625,26 +625,26 @@ describe('solver.spec', function() {
           expect(_ => solver3[method](['A', 'B'], {})).to.throw('expecting result var name to be absent or a number or string:');
         });
 
-        it('should have at least one string var name', function() {
+        it('should always return the result var name, regardless', function() {
           let solver3 = new Solver();
           solver3.decl('A', 100);
           solver3.decl('B', 100);
           solver3.decl('C', 100);
 
           expect(solver3[method]('A', 'B')).to.be.a('string');
-          expect(_ => solver3[method](1, 'B')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](1, 'B')).to.be.a('string');
           expect(solver3[method]('A', 1)).to.be.a('string');
-          expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](1, 2)).to.be.a('string');
 
-          expect(solver3[method](['A', 'B'], 'C')).to.be.a('string');
-          expect(solver3[method]([1, 'B'], 'C')).to.be.a('string');
-          expect(solver3[method](['A', 2], 'C')).to.be.a('string');
-          expect(_ => solver3[method]([1, 2], 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method](['A', 'B'], 'C')).to.eql('C');
+          expect(solver3[method]([1, 'B'], 'C')).to.be.eql('C');
+          expect(solver3[method](['A', 2], 'C')).to.be.eql('C');
+          expect(solver3[method]([1, 2], 'C')).to.eql('C');
 
           expect(solver3[method](['A', 'B'], 3)).to.be.a('string');
           expect(solver3[method]([1, 'B'], 3)).to.be.a('string');
           expect(solver3[method](['A', 2], 3)).to.be.a('string');
-          expect(_ => solver3[method]([1, 2], 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(solver3[method]([1, 2], 3)).to.be.a('string');
         });
       }
 
@@ -667,7 +667,7 @@ describe('solver.spec', function() {
 
         it('accept zero vars', function() {
           let solver = new Solver();
-          expect(_ => solver[method]([])).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+          expect(_ => solver[method]([])).not.to.throw();
         });
 
         it('accept one var', function() {
@@ -878,7 +878,7 @@ describe('solver.spec', function() {
             expect(_ => solver3[method](['A', 'B'], {})).to.throw('STRING_KEY');
           });
 
-          it('should have at leat one string var name', function() {
+          it('should always return the result var name', function() {
             let solver3 = new Solver();
             solver3.decl('A', 100);
             solver3.decl('B', 100);
@@ -887,17 +887,17 @@ describe('solver.spec', function() {
             expect(solver3[method]('A', 'B')).to.be.a('string');
             expect(solver3[method](1, 'B')).to.be.a('string');
             expect(solver3[method]('A', 1)).to.be.a('string');
-            expect(_ => solver3[method](1, 2)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+            expect(solver3[method](1, 2)).to.be.a('string');
 
-            expect(solver3[method]('A', 'B', 'C')).to.be.a('string');
-            expect(solver3[method](1, 'B', 'C')).to.be.a('string');
-            expect(solver3[method]('A', 2, 'C')).to.be.a('string');
-            expect(_ => solver3[method](1, 2, 'C')).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+            expect(solver3[method]('A', 'B', 'C')).to.eql('C');
+            expect(solver3[method](1, 'B', 'C')).to.eql('C');
+            expect(solver3[method]('A', 2, 'C')).to.eql('C');
+            expect(solver3[method](1, 2, 'C')).to.eql('C');
 
             expect(solver3[method]('A', 'B', 3)).to.be.a('string');
             expect(solver3[method](1, 'B', 3)).to.be.a('string');
             expect(solver3[method]('A', 2, 3)).to.be.a('string');
-            expect(_ => solver3[method](1, 2, 3)).to.throw('E_MUST_GET_AT_LEAST_ONE_VAR_NAME');
+            expect(solver3[method](1, 2, 3)).to.be.a('string');
           });
         });
       }


### PR DESCRIPTION
Biggest change is removing certain api's that were exposed for a private project subclass that are no longer needed. And constraints no longer require at least one variable. That means you could do `solver.eq(1, 2)` and the solver would be fine. In such cases it may simply omit the constraint altogether.
